### PR TITLE
Fix failure when program terminates too early after violation

### DIFF
--- a/src/Tests/SharpDetect.E2ETests/DeadlockPluginTests.cs
+++ b/src/Tests/SharpDetect.E2ETests/DeadlockPluginTests.cs
@@ -52,19 +52,13 @@ public class DeadlockPluginTests(ITestOutputHelper testOutput)
         using var mutex = new Mutex(initiallyOwned: true, SynchronizationMutexName);
         var plugin = services.GetRequiredService<TestDeadlockPlugin>();
         var analysisWorker = services.GetRequiredService<IAnalysisWorker>();
-        var snapshotCreated = false;
-        plugin.StackTraceSnapshotsCreated += _ =>
-        {
-            snapshotCreated = true;
-            mutex.ReleaseMutex();
-        };
+        plugin.StackTraceSnapshotsCreated += _ => mutex.ReleaseMutex();
 
         // Execute
         await analysisWorker.ExecuteAsync(CancellationToken.None);
         var report = plugin.CreateDiagnostics().GetAllReports().FirstOrDefault();
 
         // Assert
-        Assert.True(snapshotCreated);
         Assert.NotNull(report);
         Assert.Equal(plugin.ReportCategory, report.Category);
     }
@@ -82,19 +76,13 @@ public class DeadlockPluginTests(ITestOutputHelper testOutput)
         using var mutex = new Mutex(initiallyOwned: true, SynchronizationMutexName);
         var plugin = services.GetRequiredService<TestDeadlockPlugin>();
         var analysisWorker = services.GetRequiredService<IAnalysisWorker>();
-        var snapshotCreated = false;
-        plugin.StackTraceSnapshotsCreated += _ =>
-        {
-            snapshotCreated = true;
-            mutex.ReleaseMutex();
-        };
+        plugin.StackTraceSnapshotsCreated += _ => mutex.ReleaseMutex();
 
         // Execute
         await analysisWorker.ExecuteAsync(CancellationToken.None);
         var report = plugin.CreateDiagnostics().GetAllReports().FirstOrDefault();
 
         // Assert
-        Assert.True(snapshotCreated);
         Assert.NotNull(report);
         Assert.Equal(plugin.ReportCategory, report.Category);
     }
@@ -112,19 +100,13 @@ public class DeadlockPluginTests(ITestOutputHelper testOutput)
         using var mutex = new Mutex(initiallyOwned: true, SynchronizationMutexName);
         var plugin = services.GetRequiredService<TestDeadlockPlugin>();
         var analysisWorker = services.GetRequiredService<IAnalysisWorker>();
-        var snapshotCreated = false;
-        plugin.StackTraceSnapshotsCreated += _ =>
-        {
-            snapshotCreated = true;
-            mutex.ReleaseMutex();
-        };
+        plugin.StackTraceSnapshotsCreated += _ => mutex.ReleaseMutex();
 
         // Execute
         await analysisWorker.ExecuteAsync(CancellationToken.None);
         var report = plugin.CreateDiagnostics().GetAllReports().FirstOrDefault();
 
         // Assert
-        Assert.True(snapshotCreated);
         Assert.NotNull(report);
         Assert.Equal(plugin.ReportCategory, report.Category);
     }


### PR DESCRIPTION
E2E tests can fail when program terminates too early after violation occurs.

1. Violation occurs
2. Analyzer process sends request to capture stack traces for affected threads
3. Target process captures stack traces and sends response
4. Target process terminates

There is a race between last two points. This PR should make tests more stable. We now assert that deadlock was detected not that also whole report is ready.