### PR TITLE
Make temporary paths and report paths configurable

### DIFF
--- a/src/SharpDetect.Cli/Handlers/RunCommandHandler.cs
+++ b/src/SharpDetect.Cli/Handlers/RunCommandHandler.cs
@@ -41,9 +41,15 @@ internal sealed class RunCommandHandler : IDisposable
         
         // Render and store report
         var report = GenerateReportSummary();
+        var reportsFolder = _arguments.Analysis.ReportsFolder ?? Directory.GetCurrentDirectory();
         var fileName = $"SharpDetect_Report_{TimeProvider.System.GetUtcNow().DateTime:O}.html";
-        await StoreReportSummary(report, fileName, cancellationToken);
-        await console.Output.WriteLineAsync($"Report stored to file: {Path.GetFullPath(fileName)}.");
+        var fullPath = Path.Combine(reportsFolder, fileName);
+        
+        // Ensure reports folder exists
+        Directory.CreateDirectory(reportsFolder);
+        
+        await StoreReportSummary(report, fullPath, cancellationToken);
+        await console.Output.WriteLineAsync($"Report stored to file: {Path.GetFullPath(fullPath)}.");
     }
 
     private Type LoadPluginInfo()

--- a/src/SharpDetect.Core/Configuration/PathsConfiguration.cs
+++ b/src/SharpDetect.Core/Configuration/PathsConfiguration.cs
@@ -1,0 +1,11 @@
+// Copyright 2025 Andrej Čižmárik and Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+namespace SharpDetect.Core.Configuration;
+
+public sealed class PathsConfiguration
+{
+    public string? TemporaryFilesFolder { get; init; }
+    public string? ReportsFolder { get; init; }
+}
+

--- a/src/SharpDetect.Core/Plugins/PluginConfiguration.cs
+++ b/src/SharpDetect.Core/Plugins/PluginConfiguration.cs
@@ -14,6 +14,7 @@ public record PluginConfiguration(
     string CommandQueueName,
     string? CommandQueueFile,
     uint CommandQueueSize,
+    string? TemporaryFilesFolder,
     object? AdditionalData)
 {
     public const string ConfigurationFileName = "SharpDetect_Configuration.json";
@@ -24,16 +25,19 @@ public record PluginConfiguration(
 
     public static PluginConfiguration Create(
         COR_PRF_MONITOR eventMask,
+        string? temporaryFilesFolder,
         object? additionalData)
     {
+        var tempFolder = temporaryFilesFolder ?? Path.GetTempPath();
         return new PluginConfiguration(
             EventMask: (uint)eventMask,
             SharedMemoryName: "SharpDetect_NotificationsQueue",
-            SharedMemoryFile: "SharpDetect_NotificationsQueue.data",
+            SharedMemoryFile: Path.Combine(tempFolder, "SharpDetect_NotificationsQueue.data"),
             SharedMemorySize: 20_971_520 /* 20 MB */,
             CommandQueueName: "SharpDetect_CommandQueue",
-            CommandQueueFile: "SharpDetect_CommandQueue.data",
+            CommandQueueFile: Path.Combine(tempFolder, "SharpDetect_CommandQueue.data"),
             CommandQueueSize: 1_048_576 /* 1 MB */,
+            temporaryFilesFolder,
             additionalData);
     }
 

--- a/src/SharpDetect.Worker/Commands/Run/AnalysisPluginConfigurationArgs.cs
+++ b/src/SharpDetect.Worker/Commands/Run/AnalysisPluginConfigurationArgs.cs
@@ -10,4 +10,6 @@ public record AnalysisPluginConfigurationArgs(
     string FullTypeName,
     string Configuration,
     bool RenderReport = false,
-    LogLevel LogLevel = LogLevel.Warning);
+    LogLevel LogLevel = LogLevel.Warning,
+    string? TemporaryFilesFolder = null,
+    string? ReportsFolder = null);

--- a/src/SharpDetect.Worker/Commands/Run/RunCommandArgs.cs
+++ b/src/SharpDetect.Worker/Commands/Run/RunCommandArgs.cs
@@ -1,9 +1,6 @@
 // Copyright 2025 Andrej Čižmárik and Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-using Microsoft.Extensions.Logging;
-using System.Runtime.InteropServices;
-
 namespace SharpDetect.Worker.Commands.Run;
 
 public record RunCommandArgs(

--- a/src/SharpDetect.Worker/Configuration/AnalysisServiceProviderBuilder.cs
+++ b/src/SharpDetect.Worker/Configuration/AnalysisServiceProviderBuilder.cs
@@ -4,6 +4,7 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using SharpDetect.Communication;
+using SharpDetect.Core.Configuration;
 using SharpDetect.Core.Plugins;
 using SharpDetect.Loader;
 using SharpDetect.Metadata;
@@ -46,6 +47,11 @@ public sealed class AnalysisServiceProviderBuilder(RunCommandArgs arguments)
     public IServiceProvider Build()
     {
         _services.AddSingleton(arguments);
+        _services.AddSingleton(new PathsConfiguration
+        {
+            TemporaryFilesFolder = arguments.Analysis.TemporaryFilesFolder,
+            ReportsFolder = arguments.Analysis.ReportsFolder
+        });
         _services.AddLogging(builder => _configureLogger?.Invoke(builder));
         _services.AddSharpDetectLoaderServices();
         _services.AddSharpDetectMetadataServices();

--- a/src/SharpDetect.Worker/Services/AnalysisWorker.cs
+++ b/src/SharpDetect.Worker/Services/AnalysisWorker.cs
@@ -186,9 +186,10 @@ public sealed class AnalysisWorker : IAnalysisWorker
             throw new PlatformNotSupportedException($"OS: {RuntimeInformation.OSDescription}.");
     }
     
-    private static string GetFullConfigurationPath()
+    private string GetFullConfigurationPath()
     {
-        return Path.Combine(Path.GetTempPath(), PluginConfiguration.ConfigurationFileName);
+        var tempFolder = _plugin.Configuration.TemporaryFilesFolder ?? Path.GetTempPath();
+        return Path.Combine(tempFolder, PluginConfiguration.ConfigurationFileName);
     }
 
     private void CleanupConfigurationFile(string configurationPath)

--- a/src/Tests/SharpDetect.E2ETests/Utils/TestDeadlockPlugin.cs
+++ b/src/Tests/SharpDetect.E2ETests/Utils/TestDeadlockPlugin.cs
@@ -1,6 +1,7 @@
 // Copyright 2025 Andrej Čižmárik and Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+using SharpDetect.Core.Configuration;
 using SharpDetect.Core.Events;
 using SharpDetect.Core.Plugins;
 using SharpDetect.Plugins.Deadlock;
@@ -11,8 +12,8 @@ public sealed class TestDeadlockPlugin : DeadlockPlugin
 {
     public event Action<(RecordedEventMetadata Metadata, StackTraceSnapshotsRecordedEvent Args)>? StackTraceSnapshotsCreated;
     
-    public TestDeadlockPlugin(ICallstackResolver callstackResolver, TimeProvider timeProvider, IServiceProvider serviceProvider)
-        : base(callstackResolver, timeProvider, serviceProvider)
+    public TestDeadlockPlugin(ICallstackResolver callstackResolver, TimeProvider timeProvider, PathsConfiguration pathsConfiguration, IServiceProvider serviceProvider)
+        : base(callstackResolver, timeProvider, pathsConfiguration, serviceProvider)
     {
         
     }

--- a/src/Tests/SharpDetect.E2ETests/Utils/TestHappensBeforePlugin.cs
+++ b/src/Tests/SharpDetect.E2ETests/Utils/TestHappensBeforePlugin.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Immutable;
 using dnlib.DotNet;
+using SharpDetect.Core.Configuration;
 using SharpDetect.Core.Events;
 using SharpDetect.Core.Events.Profiler;
 using SharpDetect.Core.Metadata;
@@ -17,24 +18,7 @@ public sealed class TestHappensBeforePlugin : HappensBeforeOrderingPluginBase, I
 {
     public string ReportCategory => "Test";
     public RecordedEventActionVisitorBase EventsVisitor => this;
-    public override PluginConfiguration Configuration { get; } = PluginConfiguration.Create(
-        eventMask: COR_PRF_MONITOR.COR_PRF_MONITOR_ASSEMBLY_LOADS |
-                   COR_PRF_MONITOR.COR_PRF_MONITOR_MODULE_LOADS |
-                   COR_PRF_MONITOR.COR_PRF_MONITOR_JIT_COMPILATION |
-                   COR_PRF_MONITOR.COR_PRF_MONITOR_THREADS |
-                   COR_PRF_MONITOR.COR_PRF_MONITOR_ENTERLEAVE |
-                   COR_PRF_MONITOR.COR_PRF_MONITOR_GC |
-                   COR_PRF_MONITOR.COR_PRF_ENABLE_FUNCTION_ARGS |
-                   COR_PRF_MONITOR.COR_PRF_ENABLE_FUNCTION_RETVAL |
-                   COR_PRF_MONITOR.COR_PRF_ENABLE_FRAME_INFO |
-                   COR_PRF_MONITOR.COR_PRF_DISABLE_INLINING |
-                   COR_PRF_MONITOR.COR_PRF_DISABLE_OPTIMIZATIONS |
-                   COR_PRF_MONITOR.COR_PRF_DISABLE_TRANSPARENCY_CHECKS_UNDER_FULL_TRUST |
-                   COR_PRF_MONITOR.COR_PRF_DISABLE_ALL_NGEN_IMAGES,
-        additionalData: MonitorMethodDescriptors.GetAllMethods()
-            .Concat(ThreadMethodDescriptors.GetAllMethods())
-            .Concat(TestMethodDescriptors.GetAllTestMethods())
-            .ToImmutableArray());
+    public override PluginConfiguration Configuration { get; }
     public DirectoryInfo ReportTemplates => throw new NotSupportedException();
     public Summary CreateDiagnostics() => throw new NotSupportedException();
     public IEnumerable<object> CreateReportDataContext(IEnumerable<Report> reports) => throw new NotSupportedException();
@@ -69,10 +53,30 @@ public sealed class TestHappensBeforePlugin : HappensBeforeOrderingPluginBase, I
 
     public TestHappensBeforePlugin(
         IMetadataContext metadataContext,
+        PathsConfiguration pathsConfiguration,
         IServiceProvider serviceProvider)
         : base(serviceProvider)
     {
         _metadataContext = metadataContext;
+        Configuration = PluginConfiguration.Create(
+            eventMask: COR_PRF_MONITOR.COR_PRF_MONITOR_ASSEMBLY_LOADS |
+                       COR_PRF_MONITOR.COR_PRF_MONITOR_MODULE_LOADS |
+                       COR_PRF_MONITOR.COR_PRF_MONITOR_JIT_COMPILATION |
+                       COR_PRF_MONITOR.COR_PRF_MONITOR_THREADS |
+                       COR_PRF_MONITOR.COR_PRF_MONITOR_ENTERLEAVE |
+                       COR_PRF_MONITOR.COR_PRF_MONITOR_GC |
+                       COR_PRF_MONITOR.COR_PRF_ENABLE_FUNCTION_ARGS |
+                       COR_PRF_MONITOR.COR_PRF_ENABLE_FUNCTION_RETVAL |
+                       COR_PRF_MONITOR.COR_PRF_ENABLE_FRAME_INFO |
+                       COR_PRF_MONITOR.COR_PRF_DISABLE_INLINING |
+                       COR_PRF_MONITOR.COR_PRF_DISABLE_OPTIMIZATIONS |
+                       COR_PRF_MONITOR.COR_PRF_DISABLE_TRANSPARENCY_CHECKS_UNDER_FULL_TRUST |
+                       COR_PRF_MONITOR.COR_PRF_DISABLE_ALL_NGEN_IMAGES,
+            additionalData: MonitorMethodDescriptors.GetAllMethods()
+                .Concat(ThreadMethodDescriptors.GetAllMethods())
+                .Concat(TestMethodDescriptors.GetAllTestMethods())
+                .ToImmutableArray(),
+            temporaryFilesFolder: pathsConfiguration.TemporaryFilesFolder);
     }
 
     public MethodDef Resolve(RecordedEventMetadata metadata, ModuleId moduleId, MdMethodDef methodToken)


### PR DESCRIPTION
The defaults are problematic on some systems. For example `/tmp` might not have correct rights or reports should be exported to a different (common) folder independent of analysis configuration.