### PR TITLE
Abort profiler attach for unsupported SDK

### DIFF
--- a/src/SharpDetect.Core/Events/IRecordedEventArgs.cs
+++ b/src/SharpDetect.Core/Events/IRecordedEventArgs.cs
@@ -8,6 +8,7 @@ namespace SharpDetect.Core.Events;
 [Union((int)RecordedEventType.ProfilerInitialize, typeof(ProfilerInitializeRecordedEvent))]
 [Union((int)RecordedEventType.ProfilerLoad, typeof(ProfilerLoadRecordedEvent))]
 [Union((int)RecordedEventType.ProfilerDestroy, typeof(ProfilerDestroyRecordedEvent))]
+[Union((int)RecordedEventType.ProfilerAbortInitialize, typeof(ProfilerAbortInitializeEvent))]
 [Union((int)RecordedEventType.AssemblyLoad, typeof(AssemblyLoadRecordedEvent))]
 [Union((int)RecordedEventType.ModuleLoad, typeof(ModuleLoadRecordedEvent))]
 [Union((int)RecordedEventType.TypeLoad, typeof(TypeLoadRecordedEvent))]

--- a/src/SharpDetect.Core/Events/RecordedEventActionVisitorBase.cs
+++ b/src/SharpDetect.Core/Events/RecordedEventActionVisitorBase.cs
@@ -12,6 +12,7 @@ public abstract class RecordedEventActionVisitorBase
             case ProfilerLoadRecordedEvent profilerLoadArgs: Visit(metadata, profilerLoadArgs); break;
             case ProfilerInitializeRecordedEvent profilerInitializeArgs: Visit(metadata, profilerInitializeArgs); break;
             case ProfilerDestroyRecordedEvent profilerDestroyArgs: Visit(metadata, profilerDestroyArgs); break;
+            case ProfilerAbortInitializeEvent profilerAbortInitializeEvent: Visit(metadata, profilerAbortInitializeEvent); break;
             case AssemblyLoadRecordedEvent assemblyLoadArgs: Visit(metadata, assemblyLoadArgs); break;
             case ModuleLoadRecordedEvent moduleLoadArgs: Visit(metadata, moduleLoadArgs); break;
             case TypeLoadRecordedEvent typeLoadArgs: Visit(metadata, typeLoadArgs); break;
@@ -48,6 +49,9 @@ public abstract class RecordedEventActionVisitorBase
         => DefaultVisit(metadata, args);
 
     protected virtual void Visit(RecordedEventMetadata metadata, ProfilerDestroyRecordedEvent args)
+        => DefaultVisit(metadata, args);
+
+    protected virtual void Visit(RecordedEventMetadata metadata, ProfilerAbortInitializeEvent args)
         => DefaultVisit(metadata, args);
 
     protected virtual void Visit(RecordedEventMetadata metadata, AssemblyLoadRecordedEvent args)

--- a/src/SharpDetect.Core/Events/RecordedEventType.cs
+++ b/src/SharpDetect.Core/Events/RecordedEventType.cs
@@ -43,14 +43,12 @@ public enum RecordedEventType : ushort
     MethodReferenceInjection = 29,
     MethodBodyRewrite = 30,
 
-    /* Objects tracking */
-    ObjectTracking = 31,
-    ObjectRemoved = 32,
-
     /* Profiler lifecycle */
-    ProfilerLoad = 33,
-    ProfilerInitialize = 34,
-    ProfilerDestroy = 35,
+    ProfilerLoad = 31,
+    ProfilerInitialize = 32,
+    ProfilerDestroy = 33,
+    ProfilerAbortInitialize = 34,
+    //Reserved = 35,
 
     /* Stack trace snapshots */
     StackTraceSnapshot = 36,

--- a/src/SharpDetect.Core/Events/RecordedEvents.cs
+++ b/src/SharpDetect.Core/Events/RecordedEvents.cs
@@ -21,6 +21,10 @@ public sealed record ProfilerInitializeRecordedEvent() : IRecordedEventArgs;
 public sealed record ProfilerDestroyRecordedEvent() : IRecordedEventArgs;
 
 [MessagePackObject]
+public sealed record ProfilerAbortInitializeEvent(
+    [property: Key(0)] string Reason) : IRecordedEventArgs;
+
+[MessagePackObject]
 public sealed record AssemblyLoadRecordedEvent(
     [property: Key(0)] AssemblyId AssemblyId,
     [property: Key(1)] string Name) : IRecordedEventArgs;

--- a/src/SharpDetect.Core/Plugins/PluginBase.cs
+++ b/src/SharpDetect.Core/Plugins/PluginBase.cs
@@ -48,6 +48,18 @@ public abstract class PluginBase : RecordedEventActionVisitorBase, IDisposable
         InitializeCommandsChannel(metadata.Pid);
     }
 
+    protected override void Visit(RecordedEventMetadata metadata, ProfilerInitializeRecordedEvent args)
+    {
+        Reporter.AddRuntimeProperty("Profiler", "Attached");
+        base.Visit(metadata, args);
+    }
+
+    protected override void Visit(RecordedEventMetadata metadata, ProfilerAbortInitializeEvent args)
+    {
+        Reporter.AddRuntimeProperty("Profiler", $"Aborted. Reason: \"{args.Reason}\"");
+        base.Visit(metadata, args);
+    }
+
     protected override void Visit(RecordedEventMetadata metadata, ModuleLoadRecordedEvent args)
     {
         var result = ModuleBindContext.TryGetModule(metadata.Pid, args.ModuleId);

--- a/src/SharpDetect.Profiler/LibIPC/Messages.cpp
+++ b/src/SharpDetect.Profiler/LibIPC/Messages.cpp
@@ -34,6 +34,12 @@ ProfilerDestroyMsg Helpers::CreateProfilerDestroyMsg(LibIPC::MetadataMsg&& metad
     return { std::move(metadataMsg), ProfilerDestroyMsgArgsInstance(discriminator, ProfilerDestroyMsgArgs()) };
 }
 
+ProfilerAbortInitializeMsg Helpers::CreateProfilerAbortInitializeMsg(LibIPC::MetadataMsg&& metadataMsg, const std::string& reason)
+{
+    constexpr auto discriminator = static_cast<INT32>(RecordedEventType::ProfilerAbortInitialize);
+    return { std::move(metadataMsg), ProfilerAbortInitializeMsgArgsInstance(discriminator, ProfilerAbortInitializeMsgArgs(reason)) };
+}
+
 AssemblyLoadMsg Helpers::CreateAssemblyLoadMsg(MetadataMsg&& metadataMsg, UINT64 assemblyId, const std::string& name)
 {
     constexpr auto discriminator = static_cast<INT32>(RecordedEventType::AssemblyLoad);

--- a/src/SharpDetect.Profiler/LibIPC/Messages.h
+++ b/src/SharpDetect.Profiler/LibIPC/Messages.h
@@ -58,14 +58,12 @@ namespace LibIPC
 		MethodReferenceInjection = 29,
 		MethodBodyRewrite = 30,
 
-		/* Objects tracking */
-		ObjectTracking = 31,
-		ObjectRemoved = 32,
-
 		/* Profiler lifecycle */
-		ProfilerLoad = 33,
-		ProfilerInitialize = 34,
-		ProfilerDestroy = 35,
+		ProfilerLoad = 31,
+		ProfilerInitialize = 32,
+		ProfilerDestroy = 33,
+		ProfilerAbortInitialize = 34,
+		//Reserved = 35,
 
 		/* Stack trace snapshots */
 		StackTraceSnapshot = 36,
@@ -104,6 +102,10 @@ namespace LibIPC
 	using ProfilerDestroyMsgArgs = msgpack::type::tuple<>;
 	using ProfilerDestroyMsgArgsInstance = msgpack::type::tuple<INT32, ProfilerDestroyMsgArgs>;
 	using ProfilerDestroyMsg = msgpack::type::tuple<MetadataMsg, ProfilerDestroyMsgArgsInstance>;
+
+	using ProfilerAbortInitializeMsgArgs = msgpack::type::tuple<std::string>;
+	using ProfilerAbortInitializeMsgArgsInstance = msgpack::type::tuple<INT32, ProfilerAbortInitializeMsgArgs>;
+	using ProfilerAbortInitializeMsg = msgpack::type::tuple<MetadataMsg, ProfilerAbortInitializeMsgArgsInstance>;
 
 	using AssemblyLoadMsgArgs = msgpack::type::tuple<UINT64, std::string>;
 	using AssemblyLoadMsgArgsInstance = msgpack::type::tuple<INT32, AssemblyLoadMsgArgs>;
@@ -212,6 +214,7 @@ namespace LibIPC
 		ProfilerInitializeMsg CreateProfilerInitiazeMsg(MetadataMsg&& metadataMsg);
 		ProfilerLoadMsg CreateProfilerLoadMsg(MetadataMsg&& metadataMsg, UINT32 runtime, UINT32 major, UINT32 minor, UINT32 build, UINT32 qfe);
 		ProfilerDestroyMsg CreateProfilerDestroyMsg(MetadataMsg&& metadataMsg);
+		ProfilerAbortInitializeMsg CreateProfilerAbortInitializeMsg(MetadataMsg&& metadataMsg, const std::string& reason);
 		AssemblyLoadMsg CreateAssemblyLoadMsg(MetadataMsg&& metadataMsg, UINT64 assemblyId, const std::string& name);
 		ModuleLoadMsg CreateModuleLoadMsg(MetadataMsg&& metadataMsg, UINT64 moduleId, UINT64 assemblyId, const std::string& name);
 		TypeLoadMsg CreateTypeLoadMsg(MetadataMsg&& metadataMsg, UINT64 moduleId, UINT32 mdTypeDef);

--- a/src/SharpDetect.Profiler/SharpDetect.Concurrency.Profiler/CorProfiler.h
+++ b/src/SharpDetect.Profiler/SharpDetect.Concurrency.Profiler/CorProfiler.h
@@ -50,6 +50,7 @@ namespace Profiler
 		[[nodiscard]] std::shared_ptr<MethodDescriptor> FindMethodDescriptor(FunctionID functionId);
 
 	private:
+		HRESULT AbortAttach(const std::string& reason);
 		[[nodiscard]] LibIPC::MetadataMsg CreateMetadataMsg() const;
 		[[nodiscard]] LibIPC::MetadataMsg CreateMetadataMsg(UINT64 commandId) const;
 		HRESULT CaptureStackTrace(UINT64 commandId, ThreadID threadId);

--- a/src/SharpDetect.Profiler/cmake/json.cmake
+++ b/src/SharpDetect.Profiler/cmake/json.cmake
@@ -1,2 +1,1 @@
 add_subdirectory("${PROFILER_LIB_DIR}/json")
-


### PR DESCRIPTION
This ensures graceful termination when user tries to analyze unsupported program.