### PR TITLE
Fix help command suggestions

### DIFF
--- a/src/SharpDetect.Cli/Program.cs
+++ b/src/SharpDetect.Cli/Program.cs
@@ -1,20 +1,37 @@
 // Copyright 2026 Andrej Čižmárik and Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+using System.Diagnostics;
 using CliFx;
 
 namespace SharpDetect.Cli;
 
 public static class Program
 {
+    private const string ProgramTitle = "SharpDetect";
+    private const string ProgramDescription = "Dynamic analysis framework for .NET programs";
+    private const string ExecutableName = "sharpdetect";
+    private const string InstallationRootEnvVariable = "SHARPDETECT_ROOT";
+    
     public static async Task<int> Main()
     {
         var root = Path.GetDirectoryName(typeof(Program).Assembly.Location);
-        Environment.SetEnvironmentVariable("SHARPDETECT_ROOT", root);
+        Environment.SetEnvironmentVariable(InstallationRootEnvVariable, root);
 
-        return await new CliApplicationBuilder()
+        var builder = new CliApplicationBuilder()
             .AddCommandsFromThisAssembly()
-            .Build()
-            .RunAsync();
+            .SetTitle(ProgramTitle)
+            .SetDescription(ProgramDescription)
+            .SetExecutableName(ExecutableName);
+        DisableDebugModeInRelease(builder);
+        
+        return await builder.Build().RunAsync();
+    }
+
+    [Conditional("RELEASE")]
+    private static void DisableDebugModeInRelease(CliApplicationBuilder builder)
+    {
+        builder.AllowDebugMode(isAllowed: false);
+        builder.AllowPreviewMode(isAllowed: false);
     }
 }


### PR DESCRIPTION
Default behavior of CliFx is to use assembly name instead of the tool name. This caused help to show commands that are not usable when installed as .NET tool.

**Old output**
```text
SharpDetect.Cli v2.0.0

USAGE
  dotnet SharpDetect.Cli.dll [options]
  dotnet SharpDetect.Cli.dll [command] [...]

OPTIONS
  -h|--help         Shows help text. 
  --version         Shows version information. 

COMMANDS
  init              Creates a configuration file for analysis 
  run               Executes analysis based on provided configuration file 

You can run `dotnet SharpDetect.Cli.dll [command] --help` to show help on a specific command.
```

**New output**
```text
SharpDetect v2.0.0
  Dynamic analysis framework for .NET programs

USAGE
  sharpdetect [options]
  sharpdetect [command] [...]

OPTIONS
  -h|--help         Shows help text. 
  --version         Shows version information. 

COMMANDS
  init              Creates a configuration file for analysis 
  run               Executes analysis based on provided configuration file 

You can run `sharpdetect [command] --help` to show help on a specific command.
```