### PR TITLE
Add missing `WorkingDirectory` to `TargetConfigurationArgs`

### DIFF
--- a/src/SharpDetect.Cli/Handlers/InitCommandHandler.cs
+++ b/src/SharpDetect.Cli/Handlers/InitCommandHandler.cs
@@ -62,6 +62,7 @@ internal sealed class InitCommandHandler(string outputFile, string pluginType, s
             Path: targetAssemblyPath,
             Architecture: RuntimeInformation.ProcessArchitecture,
             Args: null,
+            WorkingDirectory: null,
             AdditionalEnvironmentVariables: null,
             RedirectInputOutput: new RedirectInputOutputConfigurationArgs(
                 SingleConsoleMode: true,

--- a/src/SharpDetect.Worker/Commands/Run/TargetConfigurationArgs.cs
+++ b/src/SharpDetect.Worker/Commands/Run/TargetConfigurationArgs.cs
@@ -9,5 +9,6 @@ public record TargetConfigurationArgs(
     string Path,
     Architecture Architecture, 
     string? Args, 
+    string? WorkingDirectory, 
     KeyValuePair<string, string>[]? AdditionalEnvironmentVariables,
     RedirectInputOutputConfigurationArgs? RedirectInputOutput);


### PR DESCRIPTION
Setting `WorkingDirectory` is important when running some applications