### PR TITLE
Remove wrappers for .NET 10 monitor acquire/exit methods

### DIFF
--- a/src/Extensibility/SharpDetect.Plugins/Descriptors/MonitorMethodDescriptors.cs
+++ b/src/Extensibility/SharpDetect.Plugins/Descriptors/MonitorMethodDescriptors.cs
@@ -115,7 +115,7 @@ internal static class MonitorMethodDescriptors
             ArgumentTypeDescriptor.CreateSimple(CorElementType.ELEMENT_TYPE_OBJECT),
             ArgumentTypeDescriptor.CreateByRef(ArgumentTypeDescriptor.CreateSimple(CorElementType.ELEMENT_TYPE_BOOLEAN))),
         CreateRewritingDescriptor(
-            injectManagedWrapper: true,
+            injectManagedWrapper: false,
             arguments: [ObjectRefArg, BoolRefArg],
             returnValue: null,
             RecordedEventType.MonitorLockAcquire,


### PR DESCRIPTION
In .NET 10 implementation of monitor enter/exit was moved from native to managed world. These methods are no longer `extern` and as such do not need managed wrappers to be analyzed