### PR TITLE
Add missing support for `Monitor.ExitIfLockTaken` in .NET 10

### DIFF
--- a/src/Extensibility/SharpDetect.Plugins/Descriptors/MonitorMethodDescriptors.cs
+++ b/src/Extensibility/SharpDetect.Plugins/Descriptors/MonitorMethodDescriptors.cs
@@ -38,6 +38,7 @@ internal static class MonitorMethodDescriptors
     // Exit methods
     private static readonly MethodDescriptor MonitorExitV8;
     private static readonly MethodDescriptor MonitorExitV10;
+    private static readonly MethodDescriptor MonitorExitIfLockTakenV10;
     
     // Signal methods
     private static readonly MethodDescriptor MonitorPulseOne;
@@ -64,6 +65,7 @@ internal static class MonitorMethodDescriptors
         // Initialize Exit methods
         MonitorExitV8 = CreateExitDescriptor_v8();
         MonitorExitV10 = CreateExitDescriptor_v10();
+        MonitorExitIfLockTakenV10 = CreateExitIfLockTaken_V10();
         
         // Initialize Signal methods
         MonitorPulseOne = CreatePulseDescriptor();
@@ -239,6 +241,21 @@ internal static class MonitorMethodDescriptors
             returnValue: null,
             RecordedEventType.MonitorLockRelease,
             RecordedEventType.MonitorLockReleaseResult));
+    
+    private static MethodDescriptor CreateExitIfLockTaken_V10() => new(
+        "ExitIfLockTaken",
+        MonitorTypeName,
+        MethodVersionDescriptor.Create(Version10, Version10Max),
+        CreateSignature(
+            CorElementType.ELEMENT_TYPE_VOID,
+            ArgumentTypeDescriptor.CreateSimple(CorElementType.ELEMENT_TYPE_OBJECT),
+            ArgumentTypeDescriptor.CreateByRef(ArgumentTypeDescriptor.CreateSimple(CorElementType.ELEMENT_TYPE_BOOLEAN))),
+        CreateRewritingDescriptor(
+            injectManagedWrapper: false,
+            arguments: [ObjectRefArg, BoolRefArg],
+            returnValue: null,
+            RecordedEventType.MonitorLockRelease,
+            RecordedEventType.MonitorLockReleaseResult));
 
     // Signal method descriptors
     private static MethodDescriptor CreatePulseDescriptor() => new(
@@ -337,6 +354,7 @@ internal static class MonitorMethodDescriptors
         yield return MonitorTryReliableEnterObjectV10;
         yield return MonitorTryReliableEnterObjectTimeoutV10;
         yield return MonitorExitV10;
+        yield return MonitorExitIfLockTakenV10;
     }
 
     private static IEnumerable<MethodDescriptor> GetAllMethodsSdkAgnostic()

--- a/src/Tests/SharpDetect.E2ETests.Subject/Entrypoint.cs
+++ b/src/Tests/SharpDetect.E2ETests.Subject/Entrypoint.cs
@@ -25,6 +25,11 @@ namespace SharpDetect.E2ETests.Subject
                 case nameof(Test_ShadowCallstack_MonitorPulseAll):
                     Test_ShadowCallstack_MonitorPulseAll();
                     break;
+#if NET10_0_OR_GREATER
+                case nameof(Test_ShadowCallstack_MonitorExitIfLockTaken):
+                    Test_ShadowCallstack_MonitorExitIfLockTaken();
+                    break;
+#endif
             }
             
             // Method interpretation events
@@ -54,6 +59,11 @@ namespace SharpDetect.E2ETests.Subject
                 case nameof(Test_MonitorMethods_Wait3_Reentrancy):
                     Test_MonitorMethods_Wait3_Reentrancy();
                     break;
+#if NET10_0_OR_GREATER
+                case nameof(Test_MonitorMethods_ExitIfLockTaken):
+                    Test_MonitorMethods_ExitIfLockTaken();
+                    break;
+#endif
                 case nameof(Test_ThreadMethods_Join1):
                     Test_ThreadMethods_Join1();
                     break;

--- a/src/Tests/SharpDetect.E2ETests/MethodInterpretationTestConfigurations/MethodInterpretation_Monitor_ExitIfLockTaken.json
+++ b/src/Tests/SharpDetect.E2ETests/MethodInterpretationTestConfigurations/MethodInterpretation_Monitor_ExitIfLockTaken.json
@@ -1,0 +1,27 @@
+{
+  "Target": {
+    "Path": "../../../../SharpDetect.E2ETests.Subject/bin/%BUILD_CONFIGURATION%/%SDK%/SharpDetect.E2ETests.Subject.dll",
+    "Args": "Test_MonitorMethods_ExitIfLockTaken",
+    "Architecture": "X64",
+    "RedirectInputOutput": {
+      "SingleConsoleMode": true
+    }
+  },
+  "Runtime": {
+    "Profiler": {
+      "Clsid": "{b2c60596-b36d-460b-902a-3d91f5878529}",
+      "Path": {
+        "WindowsX64": "../../../../../artifacts/Profilers/win-x64/SharpDetect.Concurrency.Profiler.dll",
+        "LinuxX64": "../../../../../artifacts/Profilers/linux-x64/SharpDetect.Concurrency.Profiler.so"
+      },
+      "LogLevel": "Information"
+    }
+  },
+  "Analysis": {
+    "Path": "SharpDetect.E2ETests.dll",
+    "FullTypeName": "SharpDetect.E2ETests.Utils.TestHappensBeforePlugin",
+    "RenderReport": false,
+    "LogLevel": "Information"
+  }
+}
+

--- a/src/Tests/SharpDetect.E2ETests/MethodInterpretationTests.cs
+++ b/src/Tests/SharpDetect.E2ETests/MethodInterpretationTests.cs
@@ -35,6 +35,7 @@ public class MethodInterpretationTests(ITestOutputHelper testOutput)
     [InlineData($"{ConfigurationFolder}/MethodInterpretation_Monitor_TryEnterExit3.json", "net8.0")]
     [InlineData($"{ConfigurationFolder}/MethodInterpretation_Monitor_TryEnterExit3.json", "net9.0")]
     [InlineData($"{ConfigurationFolder}/MethodInterpretation_Monitor_TryEnterExit3.json", "net10.0")]
+    [InlineData($"{ConfigurationFolder}/MethodInterpretation_Monitor_ExitIfLockTaken.json", "net10.0")]
     public async Task MethodInterpretation_Monitor_EnterExit(string configuration, string sdk)
     {
         // Arrange
@@ -88,7 +89,7 @@ public class MethodInterpretationTests(ITestOutputHelper testOutput)
         // Assert
         Assert.True(AssertStatus.Satisfied == assert.Evaluate(events), assert.GetDiagnosticInfo());
     }
-    
+
     [Theory]
     [InlineData($"{ConfigurationFolder}/MethodInterpretation_Thread_Join1.json", "net8.0")]
     [InlineData($"{ConfigurationFolder}/MethodInterpretation_Thread_Join1.json", "net9.0")]

--- a/src/Tests/SharpDetect.E2ETests/ShadowCallstackTestConfigurations/ShadowCallstack_Monitor_ExitIfLockTaken.json
+++ b/src/Tests/SharpDetect.E2ETests/ShadowCallstackTestConfigurations/ShadowCallstack_Monitor_ExitIfLockTaken.json
@@ -1,0 +1,27 @@
+{
+  "Target": {
+    "Path": "../../../../SharpDetect.E2ETests.Subject/bin/%BUILD_CONFIGURATION%/%SDK%/SharpDetect.E2ETests.Subject.dll",
+    "Args": "Test_ShadowCallstack_MonitorExitIfLockTaken",
+    "Architecture": "X64",
+    "RedirectInputOutput": {
+      "SingleConsoleMode": true
+    }
+  },
+  "Runtime": {
+    "Profiler": {
+      "Clsid": "{b2c60596-b36d-460b-902a-3d91f5878529}",
+      "Path": {
+        "WindowsX64": "../../../../../artifacts/Profilers/win-x64/SharpDetect.Concurrency.Profiler.dll",
+        "LinuxX64": "../../../../../artifacts/Profilers/linux-x64/SharpDetect.Concurrency.Profiler.so"
+      },
+      "LogLevel": "Information"
+    }
+  },
+  "Analysis": {
+    "Path": "SharpDetect.E2ETests.dll",
+    "FullTypeName": "SharpDetect.E2ETests.Utils.TestHappensBeforePlugin",
+    "RenderReport": false,
+    "LogLevel": "Information"
+  }
+}
+

--- a/src/Tests/SharpDetect.E2ETests/ShadowCallstackTests.cs
+++ b/src/Tests/SharpDetect.E2ETests/ShadowCallstackTests.cs
@@ -29,6 +29,7 @@ public class ShadowCallstackTests(ITestOutputHelper testOutput)
     [InlineData($"{ConfigurationFolder}/ShadowCallstack_Monitor_PulseAll.json", "net8.0")]
     [InlineData($"{ConfigurationFolder}/ShadowCallstack_Monitor_PulseAll.json", "net9.0")]
     [InlineData($"{ConfigurationFolder}/ShadowCallstack_Monitor_PulseAll.json", "net10.0")]
+    [InlineData($"{ConfigurationFolder}/ShadowCallstack_Monitor_ExitIfLockTaken.json", "net10.0")]
     public async Task ShadowCallstack_IntegrityTest(string configuration, string sdk)
     {
         // Arrange

--- a/src/Tests/SharpDetect.E2ETests/SharpDetect.E2ETests.csproj
+++ b/src/Tests/SharpDetect.E2ETests/SharpDetect.E2ETests.csproj
@@ -117,6 +117,12 @@
     <None Update="DeadlockPluginTestConfigurations\DeadlockPlugin_CanDetectLockDeadlock.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="MethodInterpretationTestConfigurations\MethodInterpretation_Monitor_ExitIfLockTaken.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="ShadowCallstackTestConfigurations\ShadowCallstack_Monitor_ExitIfLockTaken.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
 </Project>

--- a/src/Tests/SharpDetect.E2ETests/Utils/TestMethodDescriptors.cs
+++ b/src/Tests/SharpDetect.E2ETests/Utils/TestMethodDescriptors.cs
@@ -32,6 +32,7 @@ internal static class TestMethodDescriptors
             "Test_MonitorMethods_TryEnterExit1",
             "Test_MonitorMethods_TryEnterExit2",
             "Test_MonitorMethods_TryEnterExit3",
+            "Test_MonitorMethods_ExitIfLockTaken",
             "Test_ThreadMethods_Join1",
             "Test_ThreadMethods_Join2",
             "Test_ThreadMethods_Join3",


### PR DESCRIPTION
This PR adds support for `Monitor.ExitIfLockTaken`. Its missing support was causing analysis to crash in some scenarios on .NET 10 due to shadow runtime inconsistent state.