### PR TITLE
Stop tracking GCed objects

### DIFF
--- a/src/Extensibility/SharpDetect.Plugins.DataRace.Eraser/AccessTracker.cs
+++ b/src/Extensibility/SharpDetect.Plugins.DataRace.Eraser/AccessTracker.cs
@@ -1,6 +1,7 @@
 // Copyright 2026 Andrej Čižmárik and Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+using SharpDetect.Core.Events.Profiler;
 using SharpDetect.Core.Plugins;
 
 namespace SharpDetect.Plugins.DataRace.Eraser;
@@ -11,6 +12,7 @@ internal sealed class AccessTracker(TimeProvider timeProvider, Func<ProcessThrea
     private readonly Dictionary<FieldId, AccessInfo> _staticLastWriteAccessInfo = [];
     private readonly Dictionary<(FieldId, ProcessTrackedObjectId), AccessInfo> _instanceLastAccessInfo = [];
     private readonly Dictionary<(FieldId, ProcessTrackedObjectId), AccessInfo> _instanceLastWriteAccessInfo = [];
+    private readonly Dictionary<ProcessTrackedObjectId, HashSet<FieldId>> _objectFieldIndex = [];
     
     public AccessInfo? GetLastAccess(FieldId fieldId, ProcessTrackedObjectId? objectId)
     {
@@ -34,6 +36,7 @@ internal sealed class AccessTracker(TimeProvider timeProvider, Func<ProcessThrea
             _instanceLastAccessInfo[key] = accessInfo;
             if (accessInfo.AccessType == AccessType.Write)
                 _instanceLastWriteAccessInfo[key] = accessInfo;
+            TrackObjectField(objectId.Value, fieldId);
         }
         else
         {
@@ -56,5 +59,32 @@ internal sealed class AccessTracker(TimeProvider timeProvider, Func<ProcessThrea
             methodToken,
             accessType,
             timeProvider.GetUtcNow().DateTime);
+    }
+    
+    public void RemoveTrackedObjects(uint processId, ReadOnlySpan<TrackedObjectId> removedObjectIds)
+    {
+        foreach (var objectId in removedObjectIds)
+        {
+            var processObjectId = new ProcessTrackedObjectId(processId, objectId);
+            if (!_objectFieldIndex.Remove(processObjectId, out var fieldIds))
+                continue;
+            
+            foreach (var fieldId in fieldIds)
+            {
+                _instanceLastAccessInfo.Remove((fieldId, processObjectId));
+                _instanceLastWriteAccessInfo.Remove((fieldId, processObjectId));
+            }
+        }
+    }
+    
+    private void TrackObjectField(ProcessTrackedObjectId objectId, FieldId fieldId)
+    {
+        if (!_objectFieldIndex.TryGetValue(objectId, out var fieldIds))
+        {
+            fieldIds = [];
+            _objectFieldIndex[objectId] = fieldIds;
+        }
+
+        fieldIds.Add(fieldId);
     }
 }

--- a/src/Extensibility/SharpDetect.Plugins.DataRace.Eraser/EraserDetector.cs
+++ b/src/Extensibility/SharpDetect.Plugins.DataRace.Eraser/EraserDetector.cs
@@ -48,6 +48,12 @@ internal sealed class EraserDetector
         _threadLockSetTracker.UnregisterThread(threadId);
     }
 
+    public void RecordGarbageCollectedObjects(uint processId, ReadOnlySpan<TrackedObjectId> removedObjectIds)
+    {
+        _shadowMemory.RemoveTrackedObjects(processId, removedObjectIds);
+        _accessTracker.RemoveTrackedObjects(processId, removedObjectIds);
+    }
+
     public void RecordLockAcquired(ProcessThreadId threadId, ProcessTrackedObjectId lockId)
     {
         _threadLockSetTracker.AcquireLock(threadId, lockId);

--- a/src/Extensibility/SharpDetect.Plugins.DataRace.Eraser/EraserPlugin.cs
+++ b/src/Extensibility/SharpDetect.Plugins.DataRace.Eraser/EraserPlugin.cs
@@ -238,6 +238,12 @@ public partial class EraserPlugin : PerThreadOrderingPluginBase, IPlugin
 
         base.Visit(metadata, args);
     }
+
+    protected override void Visit(RecordedEventMetadata metadata, GarbageCollectedTrackedObjectsRecordedEvent args)
+    {
+        _detector.RecordGarbageCollectedObjects(metadata.Pid, args.RemovedTrackedObjectIds);
+        base.Visit(metadata, args);
+    }
     
     private static string GetFieldDisplayName(FieldId fieldId)
     {

--- a/src/Extensibility/SharpDetect.Plugins.DataRace.Eraser/ShadowMemory.cs
+++ b/src/Extensibility/SharpDetect.Plugins.DataRace.Eraser/ShadowMemory.cs
@@ -1,6 +1,7 @@
 // Copyright 2026 Andrej Čižmárik and Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+using SharpDetect.Core.Events.Profiler;
 using SharpDetect.Core.Plugins;
 
 namespace SharpDetect.Plugins.DataRace.Eraser;
@@ -9,6 +10,7 @@ internal sealed class ShadowMemory
 {
     private readonly Dictionary<FieldId, ShadowVariable> _staticShadowWords = [];
     private readonly Dictionary<(FieldId, ProcessTrackedObjectId), ShadowVariable> _instanceShadowWords = [];
+    private readonly Dictionary<ProcessTrackedObjectId, HashSet<FieldId>> _objectFieldIndex = [];
     
     public ShadowVariable GetOrCreateVirgin(FieldId fieldId, ProcessTrackedObjectId? objectId)
     {
@@ -35,6 +37,7 @@ internal sealed class ShadowMemory
 
         shadow = ShadowVariable.CreateVirgin();
         _instanceShadowWords[key] = shadow;
+        TrackObjectField(objectId, fieldId);
         return shadow;
     }
     
@@ -43,6 +46,7 @@ internal sealed class ShadowMemory
         if (objectId != null)
         {
             _instanceShadowWords[(fieldId, objectId.Value)] = shadow;
+            TrackObjectField(objectId.Value, fieldId);
         }
         else
         {
@@ -50,5 +54,29 @@ internal sealed class ShadowMemory
         }
     }
     
+    public void RemoveTrackedObjects(uint processId, ReadOnlySpan<TrackedObjectId> removedObjectIds)
+    {
+        foreach (var objectId in removedObjectIds)
+        {
+            var processObjectId = new ProcessTrackedObjectId(processId, objectId);
+            if (!_objectFieldIndex.Remove(processObjectId, out var fieldIds))
+                continue;
+            
+            foreach (var fieldId in fieldIds)
+                _instanceShadowWords.Remove((fieldId, processObjectId));
+        }
+    }
+
     public int Count => _staticShadowWords.Count + _instanceShadowWords.Count;
+    
+    private void TrackObjectField(ProcessTrackedObjectId objectId, FieldId fieldId)
+    {
+        if (!_objectFieldIndex.TryGetValue(objectId, out var fieldIds))
+        {
+            fieldIds = [];
+            _objectFieldIndex[objectId] = fieldIds;
+        }
+
+        fieldIds.Add(fieldId);
+    }
 }


### PR DESCRIPTION
This PR fixes an issue where data race detectors keep tracking instances that were already removed by GC