### PR TITLE
Improve data race reporting

### DIFF
--- a/src/Extensibility/SharpDetect.Plugins.DataRace.Common/DataRaceLogger.cs
+++ b/src/Extensibility/SharpDetect.Plugins.DataRace.Common/DataRaceLogger.cs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using Microsoft.Extensions.Logging;
-using SharpDetect.Core.Plugins;
+using SharpDetect.Core.Metadata;
 
 namespace SharpDetect.Plugins.DataRace.Common;
 
@@ -10,23 +10,30 @@ public static class DataRaceLogger
 {
     public static void LogDataRace(
         ILogger logger,
-        IReadOnlyDictionary<ProcessThreadId, string> threads,
-        ProcessThreadId reporterThreadId,
-        DataRaceInfo raceInfo)
+        DataRaceInfo raceInfo,
+        IMetadataContext metadataContext)
     {
         var fieldName = GetFieldDisplayName(raceInfo.FieldId);
-        var field = raceInfo.ObjectId != null
-            ? $"instance field {fieldName} (obj={raceInfo.ObjectId})"
+        var field = raceInfo.ObjectId is { } instance
+            ? $"instance field {fieldName} on object {instance.ObjectId.Value}"
             : $"static field {fieldName}";
-        var currentThread = threads[reporterThreadId];
-        var lastThread = raceInfo.LastAccess.ThreadName;
-
+        
         logger.LogWarning(
-            "[PID={ProcessId}] Data race on {Field}; previous thread: {LastThread}; current thread: {Thread}",
+            """
+            [PID={ProcessId}] Data race on {Field}
+                Current {CurrentAccessType} by thread {CurrentThread}:
+                    at {CurrentAccessLocation}
+                Previous {PreviousAccessType} by thread {PreviousThread}:
+                    at {PreviousAccessLocation}
+            """,
             raceInfo.ProcessId,
             field,
-            lastThread,
-            currentThread);
+            GetAccessTypeDisplayString(raceInfo.CurrentAccess),
+            raceInfo.CurrentAccess.ThreadName,
+            GetAccessDisplayString(raceInfo.CurrentAccess, metadataContext),
+            GetAccessTypeDisplayString(raceInfo.LastAccess),
+            raceInfo.LastAccess.ThreadName,
+            GetAccessDisplayString(raceInfo.LastAccess, metadataContext));
     }
     
     public static string GetFieldDisplayName(FieldId fieldId)
@@ -37,6 +44,26 @@ public static class DataRaceLogger
     public static string GetFieldTitle(FieldId fieldId)
     {
         return $"{fieldId.FieldDef.DeclaringType.Name}.{fieldId.FieldDef.Name}";
+    }
+    
+    private static string GetAccessTypeDisplayString(AccessInfo access)
+    {
+        return access.AccessType switch
+        {
+            AccessType.Read => "read",
+            AccessType.Write => "write",
+            _ => "<unresolved-access-type>"
+        };
+    }
+    
+    private static string GetAccessDisplayString(AccessInfo access, IMetadataContext metadataContext)
+    {
+        var pid = access.ProcessThreadId.ProcessId;
+        var resolver = metadataContext.GetResolver(pid);
+        var resolveResult = resolver.ResolveMethod(pid, access.ModuleId, access.MethodToken);
+        return resolveResult.IsSuccess
+            ? $"{resolveResult.Value.DeclaringType.FullName}.{resolveResult.Value.Name}:IL_{access.MethodOffset:X4}"
+            : $"<unresolved-method>:IL_{access.MethodOffset:X4}";
     }
 }
 

--- a/src/Extensibility/SharpDetect.Plugins.DataRace.Common/DataRaceReportingHelper.cs
+++ b/src/Extensibility/SharpDetect.Plugins.DataRace.Common/DataRaceReportingHelper.cs
@@ -49,35 +49,43 @@ public abstract class DataRaceReportingHelper
 
     public static IEnumerable<object> CreateReportDataContext(IEnumerable<Report> reports)
     {
-        return reports.Select(report => new
-        {
-            title = report.Title,
-            reportId = $"report-{report.Identifier}",
-            description = report.Description,
-            timestamp = report.DetectionTime,
-            target = report.Target,
-            threads = report.GetReportedThreads().Select(threadInfo =>
+        return reports
+            .GroupBy(report => report.Target ?? report.Title)
+            .Select(group => new
             {
-                report.TryGetReportReason(threadInfo, out var reason);
-                report.TryGetStackTrace(threadInfo, out var st);
-                return new
+                target = group.Key,
+                isGrouped = group.Any(r => r.Target != null),
+                childCount = group.Count(),
+                children = group.Select(report => new
                 {
-                    name = threadInfo.Name,
-                    reason = reason ?? "Unknown",
-                    stacktrace = st?.Frames.Select(frame => new
+                    title = report.Title,
+                    reportId = $"report-{report.Identifier}",
+                    description = report.Description,
+                    timestamp = report.DetectionTime,
+                    target = report.Target,
+                    threads = report.GetReportedThreads().Select(threadInfo =>
                     {
-                        metadataName = frame.MethodName,
-                        metadataToken = frame.MethodToken,
-                        methodOffset = $"IL_{frame.MethodOffset:X4}",
-                        instruction = frame.Instruction,
-                        sourceFile = frame.SourceMapping,
-                        sourceFileName = frame.SourceFileName,
-                        sourceLine = frame.SourceLine,
-                        sourceCode = frame.SourceCode,
-                    }).ToArray() ?? []
-                };
-            }).ToArray()
-        });
+                        report.TryGetReportReason(threadInfo, out var reason);
+                        report.TryGetStackTrace(threadInfo, out var st);
+                        return new
+                        {
+                            name = threadInfo.Name,
+                            reason = reason ?? "Unknown",
+                            stacktrace = st?.Frames.Select(frame => new
+                            {
+                                metadataName = frame.MethodName,
+                                metadataToken = frame.MethodToken,
+                                methodOffset = $"IL_{frame.MethodOffset:X4}",
+                                instruction = frame.Instruction,
+                                sourceFile = frame.SourceMapping,
+                                sourceFileName = frame.SourceFileName,
+                                sourceLine = frame.SourceLine,
+                                sourceCode = frame.SourceCode,
+                            }).ToArray() ?? []
+                        };
+                    }).ToArray()
+                }).ToArray()
+            });
     }
     
     private void PrepareNoViolationDiagnostics()
@@ -113,15 +121,25 @@ public abstract class DataRaceReportingHelper
         var fieldName = DataRaceLogger.GetFieldDisplayName(group.Key.FieldId);
 
         var reportBuilder = new ReportBuilder(index, _reportCategory, firstRace.Timestamp);
-        reportBuilder.SetTitle(fieldTitle);
-        reportBuilder.SetTarget(fieldName);
+        if (group.Key.ObjectId is not null)
+        {
+            reportBuilder.SetTitle(fieldTitle);
+            reportBuilder.SetTarget(fieldName);
+        }
+        else
+        {
+            reportBuilder.SetTitle(fieldName);
+        }
 
         var accessCollector = CollectThreadAccesses(group);
 
         // Count distinct access locations (after field-level deduplication)
         var distinctAccessCount = accessCollector.GetThreads()
             .Sum(t => accessCollector.GetDistinctAccesses(t).Count());
-        reportBuilder.SetDescription($"data race ({distinctAccessCount} distinct access locations)");
+        
+        reportBuilder.SetDescription(group.Key.ObjectId is { } objectId
+            ? $"Object {objectId.ObjectId.Value} ({distinctAccessCount} distinct access locations)"
+            : $"{distinctAccessCount} distinct access locations");
 
         AddThreadsToReport(reportBuilder, accessCollector);
 

--- a/src/Extensibility/SharpDetect.Plugins.DataRace.Common/DataRaceReportingHelper.cs
+++ b/src/Extensibility/SharpDetect.Plugins.DataRace.Common/DataRaceReportingHelper.cs
@@ -1,7 +1,6 @@
 // Copyright 2026 Andrej Čižmárik and Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-using System.Collections.Immutable;
 using SharpDetect.Core.Metadata;
 using SharpDetect.Core.Plugins;
 using SharpDetect.Core.Reporting.Model;
@@ -47,26 +46,104 @@ public abstract class DataRaceReportingHelper
         return _reporter.Build();
     }
 
+    private const int MaxObjectLabels = 5;
+
     public static IEnumerable<object> CreateReportDataContext(IEnumerable<Report> reports)
     {
         return reports
             .GroupBy(report => report.Target ?? report.Title)
-            .Select(group => new
+            .Select(group =>
             {
-                target = group.Key,
-                isGrouped = group.Any(r => r.Target != null),
-                childCount = group.Count(),
-                children = group.Select(report => new
+                var isGrouped = group.Any(r => r.Target != null);
+                var children = BuildMergedChildren(group).ToArray();
+                return new
                 {
-                    title = report.Title,
-                    reportId = $"report-{report.Identifier}",
-                    description = report.Description,
-                    timestamp = report.DetectionTime,
-                    target = report.Target,
-                    threads = report.GetReportedThreads().Select(threadInfo =>
+                    target = group.Key,
+                    shortTarget = ComputeShortTarget(group.Key),
+                    isGrouped,
+                    instanceCount = group.Count(),
+                    children
+                };
+            });
+    }
+
+    private static string ComputeShortTarget(string fullTarget)
+    {
+        var lastDot = fullTarget.LastIndexOf('.');
+        if (lastDot <= 0)
+            return fullTarget;
+
+        var withoutField = fullTarget[..lastDot];
+        var lastSlash = withoutField.LastIndexOf('/');
+        if (lastSlash >= 0)
+        {
+            var nestedType = withoutField[(lastSlash + 1)..];
+            var fieldName = fullTarget[(lastDot + 1)..];
+            return $"{nestedType}.{fieldName}";
+        }
+
+        var secondLastDot = withoutField.LastIndexOf('.');
+        return secondLastDot >= 0
+            ? fullTarget[(secondLastDot + 1)..]
+            : fullTarget;
+    }
+
+    private static string ComputeChildFingerprint(Report report)
+    {
+        var parts = report.GetReportedThreads()
+            .SelectMany(t =>
+            {
+                report.TryGetStackTrace(t, out var st);
+                return st?.Frames.Select(f => $"{f.MethodToken}@{f.MethodOffset}")
+                       ?? [];
+            })
+            .OrderBy(s => s)
+            .Distinct();
+        return string.Join("|", parts);
+    }
+
+    private static IEnumerable<object> BuildMergedChildren(IEnumerable<Report> reports)
+    {
+        return reports
+            .GroupBy(ComputeChildFingerprint)
+            .Select(fg =>
+            {
+                var representative = fg.First();
+                var objectCount = fg.Count();
+
+                var allLabels = fg
+                    .Where(r => r.Target is not null)
+                    .Select(r =>
                     {
-                        report.TryGetReportReason(threadInfo, out var reason);
-                        report.TryGetStackTrace(threadInfo, out var st);
+                        var desc = r.Description;
+                        var parenIdx = desc.IndexOf('(');
+                        return parenIdx > 0 ? desc[..parenIdx].TrimEnd() : desc;
+                    })
+                    .ToArray();
+
+                var displayLabels = allLabels.Take(MaxObjectLabels).ToArray();
+                var extraObjectCount = allLabels.Length - displayLabels.Length;
+
+                var accessCount = representative.GetReportedThreads().Count();
+                var summaryText = objectCount > 1
+                    ? $"{objectCount} objects · {accessCount} distinct access locations"
+                    : representative.Description;
+
+                return (object)new
+                {
+                    reportId = $"report-{representative.Identifier}",
+                    description = representative.Description,
+                    summaryText,
+                    objectCount,
+                    hasObjectLabels = displayLabels.Length > 0,
+                    objectLabels = displayLabels,
+                    hasExtraObjects = extraObjectCount > 0,
+                    extraObjectCount,
+                    timestamp = representative.DetectionTime,
+                    threads = representative.GetReportedThreads().Select(threadInfo =>
+                    {
+                        representative.TryGetReportReason(threadInfo, out var reason);
+                        representative.TryGetStackTrace(threadInfo, out var st);
                         return new
                         {
                             name = threadInfo.Name,
@@ -84,7 +161,7 @@ public abstract class DataRaceReportingHelper
                             }).ToArray() ?? []
                         };
                     }).ToArray()
-                }).ToArray()
+                };
             });
     }
     

--- a/src/Extensibility/SharpDetect.Plugins.DataRace.Common/Templates/Partials/violations.html
+++ b/src/Extensibility/SharpDetect.Plugins.DataRace.Common/Templates/Partials/violations.html
@@ -11,18 +11,24 @@
 {{#if isGrouped}}
 <details class="violation-group" data-searchable>
     <summary>
-        <span class="card-title">{{target}}</span>
-        <span class="card-desc">{{childCount}} occurrence(s)</span>
+        <span class="card-title">{{shortTarget}}</span>
+        <span class="card-desc">{{instanceCount}} instance(s)</span>
     </summary>
     <div class="violation-group-body">
         <span class="metadata-fullname">{{target}}</span>
         {{#children}}
         <details class="violation-card">
             <summary>
-                <span class="card-title">{{description}}</span>
+                <span class="card-title">{{summaryText}}</span>
                 <span class="card-timestamp">{{timestamp}}</span>
             </summary>
             <div class="violation-card-body">
+                {{#if hasObjectLabels}}
+                <div class="affected-objects">
+                    {{#objectLabels}}<span class="object-label">{{this}}</span>{{/objectLabels}}
+                    {{#if hasExtraObjects}}<span class="object-label object-label-more">+{{extraObjectCount}} more</span>{{/if}}
+                </div>
+                {{/if}}
                 <div class="thread-grid">
                     {{#threads}}
                     <div class="thread-panel">
@@ -68,7 +74,7 @@
 {{#children}}
 <details class="violation-card" data-searchable>
     <summary>
-        <span class="card-title">{{../target}}</span>
+        <span class="card-title">{{../shortTarget}}</span>
         <span class="card-desc">{{description}}</span>
     </summary>
     <div class="violation-card-body">

--- a/src/Extensibility/SharpDetect.Plugins.DataRace.Common/Templates/Partials/violations.html
+++ b/src/Extensibility/SharpDetect.Plugins.DataRace.Common/Templates/Partials/violations.html
@@ -2,6 +2,7 @@
 <div class="violations-toolbar">
     <input type="text" id="violationsFilter" placeholder="Search violations by field, thread, description..." oninput="filterViolations()">
     <button class="btn btn-toggle" id="btnHideSystem" onclick="toggleSystemViolations()">Hide System.*</button>
+    <button class="btn btn-toggle" id="btnHideMicrosoft" onclick="toggleMicrosoftViolations()">Hide Microsoft.*</button>
     <button class="btn" onclick="toggleAllViolations(true)">Expand All</button>
     <button class="btn" onclick="toggleAllViolations(false)">Collapse All</button>
 </div>

--- a/src/Extensibility/SharpDetect.Plugins.DataRace.Common/Templates/Partials/violations.html
+++ b/src/Extensibility/SharpDetect.Plugins.DataRace.Common/Templates/Partials/violations.html
@@ -8,16 +8,71 @@
 
 <div id="violationsContainer">
 {{#reports}}
+{{#if isGrouped}}
+<details class="violation-group" data-searchable>
+    <summary>
+        <span class="card-title">{{target}}</span>
+        <span class="card-desc">{{childCount}} occurrence(s)</span>
+    </summary>
+    <div class="violation-group-body">
+        <span class="metadata-fullname">{{target}}</span>
+        {{#children}}
+        <details class="violation-card">
+            <summary>
+                <span class="card-title">{{description}}</span>
+                <span class="card-timestamp">{{timestamp}}</span>
+            </summary>
+            <div class="violation-card-body">
+                <div class="thread-grid">
+                    {{#threads}}
+                    <div class="thread-panel">
+                        <div class="thread-panel-header">
+                            <span class="thread-name">{{name}}</span>
+                        </div>
+                        <div class="thread-panel-reason">{{reason}}</div>
+                        {{#if stacktrace}}
+                        <div class="stacktrace-block">
+                            {{#stacktrace}}
+                            <div class="stacktrace-line">
+                                <span class="frame-method">{{metadataName}}</span>
+                                {{#if sourceCode}}
+                                <div class="frame-source">
+                                    <span class="frame-source-line">{{sourceLine}}</span>
+                                    <code class="frame-source-code">{{sourceCode}}</code>
+                                </div>
+                                {{else}}
+                                <div class="frame-source">
+                                    <span class="frame-source-line">{{methodOffset}}</span>
+                                    <code class="frame-source-code">{{instruction}}</code>
+                                </div>
+                                {{/if}}
+                                <div class="frame-details">
+                                    {{#if sourceFileName}}
+                                    <span class="frame-detail"><span class="frame-detail-label">File</span> {{sourceFileName}}:{{sourceLine}}</span>
+                                    {{/if}}
+                                    <span class="frame-detail"><span class="frame-detail-label">Assembly</span> {{sourceFile}} ({{metadataToken}})</span>
+                                </div>
+                            </div>
+                            {{/stacktrace}}
+                        </div>
+                        {{/if}}
+                    </div>
+                    {{/threads}}
+                </div>
+            </div>
+        </details>
+        {{/children}}
+    </div>
+</details>
+{{else}}
+{{#children}}
 <details class="violation-card" data-searchable>
     <summary>
-        <span class="card-title">{{title}}</span>
+        <span class="card-title">{{../target}}</span>
         <span class="card-desc">{{description}}</span>
-        <span class="card-timestamp">{{timestamp}}</span>
     </summary>
     <div class="violation-card-body">
-        {{#if target}}
-        <span class="metadata-fullname">{{target}}</span>
-        {{/if}}
+        <span class="metadata-fullname">{{../target}}</span>
         <div class="thread-grid">
             {{#threads}}
             <div class="thread-panel">
@@ -56,6 +111,8 @@
         </div>
     </div>
 </details>
+{{/children}}
+{{/if}}
 {{/reports}}
 </div>
 

--- a/src/Extensibility/SharpDetect.Plugins.DataRace.Eraser/EraserPlugin.cs
+++ b/src/Extensibility/SharpDetect.Plugins.DataRace.Eraser/EraserPlugin.cs
@@ -26,6 +26,7 @@ public partial class EraserPlugin : PerThreadOrderingPluginBase, IPlugin
     public DirectoryInfo ReportTemplates { get; }
 
     private readonly EraserDetector _detector;
+    private readonly HashSet<FieldId> _reportedRacyFields = [];
     private readonly List<DataRaceInfo> _detectedRaces = [];
     private readonly HashSet<ProcessThreadId> _trackedThreads = [];
 
@@ -138,7 +139,7 @@ public partial class EraserPlugin : PerThreadOrderingPluginBase, IPlugin
                 args.FieldToken,
                 objectId: null) is { } raceInfo)
         {
-            RecordDataRace(args.ProcessThreadId, raceInfo);
+            RecordDataRace(raceInfo);
         }
     }
     
@@ -155,7 +156,7 @@ public partial class EraserPlugin : PerThreadOrderingPluginBase, IPlugin
                 args.FieldToken,
                 args.ObjectId) is { } raceInfo)
         {
-            RecordDataRace(args.ProcessThreadId, raceInfo);
+            RecordDataRace(raceInfo);
         }
     }
 
@@ -172,7 +173,7 @@ public partial class EraserPlugin : PerThreadOrderingPluginBase, IPlugin
                 args.FieldToken,
                 objectId: null) is { } raceInfo)
         {
-            RecordDataRace(args.ProcessThreadId, raceInfo);
+            RecordDataRace(raceInfo);
         }
     }
     
@@ -189,7 +190,7 @@ public partial class EraserPlugin : PerThreadOrderingPluginBase, IPlugin
                 args.FieldToken,
                 args.ObjectId) is { } raceInfo)
         {
-            RecordDataRace(args.ProcessThreadId, raceInfo);
+            RecordDataRace(raceInfo);
         }
     }
 
@@ -226,14 +227,10 @@ public partial class EraserPlugin : PerThreadOrderingPluginBase, IPlugin
         base.Visit(metadata, args);
     }
     
-    private void RecordDataRace(ProcessThreadId reporterThreadId, DataRaceInfo raceInfo)
+    private void RecordDataRace(DataRaceInfo raceInfo)
     {
         _detectedRaces.Add(raceInfo);
-        DataRaceLogger.LogDataRace(Logger, Threads, reporterThreadId, raceInfo);
-    }
-    
-    private static string GetFieldDisplayName(FieldId fieldId)
-    {
-        return DataRaceLogger.GetFieldDisplayName(fieldId);
+        if (_reportedRacyFields.Add(raceInfo.FieldId))
+            DataRaceLogger.LogDataRace(Logger, raceInfo, MetadataContext);
     }
 }

--- a/src/Extensibility/SharpDetect.Plugins.DataRace.FastTrack/FastTrackPlugin.cs
+++ b/src/Extensibility/SharpDetect.Plugins.DataRace.FastTrack/FastTrackPlugin.cs
@@ -26,6 +26,7 @@ public partial class FastTrackPlugin : PerThreadOrderingPluginBase, IPlugin
     public DirectoryInfo ReportTemplates { get; }
 
     private readonly FastTrackDetector _detector;
+    private readonly HashSet<FieldId> _reportedRacyFields = [];
     private readonly List<DataRaceInfo> _detectedRaces = [];
     private readonly HashSet<ProcessThreadId> _trackedThreads = [];
     private readonly Dictionary<ProcessTrackedObjectId, ProcessThreadId> _startingThreads = [];
@@ -161,7 +162,7 @@ public partial class FastTrackPlugin : PerThreadOrderingPluginBase, IPlugin
                     args.FieldToken,
                     objectId: null) is { } raceInfo)
             {
-                RecordDataRace(args.ProcessThreadId, raceInfo);
+                RecordDataRace(raceInfo);
             }
         }
     }
@@ -186,7 +187,7 @@ public partial class FastTrackPlugin : PerThreadOrderingPluginBase, IPlugin
                     args.FieldToken,
                     args.ObjectId) is { } raceInfo)
             {
-                RecordDataRace(args.ProcessThreadId, raceInfo);
+                RecordDataRace(raceInfo);
             }
         }
     }
@@ -211,7 +212,7 @@ public partial class FastTrackPlugin : PerThreadOrderingPluginBase, IPlugin
                     args.FieldToken,
                     objectId: null) is { } raceInfo)
             {
-                RecordDataRace(args.ProcessThreadId, raceInfo);
+                RecordDataRace(raceInfo);
             }
         }
     }
@@ -236,7 +237,7 @@ public partial class FastTrackPlugin : PerThreadOrderingPluginBase, IPlugin
                     args.FieldToken,
                     args.ObjectId) is { } raceInfo)
             {
-                RecordDataRace(args.ProcessThreadId, raceInfo);
+                RecordDataRace(raceInfo);
             }
         }
     }
@@ -302,15 +303,11 @@ public partial class FastTrackPlugin : PerThreadOrderingPluginBase, IPlugin
         base.Visit(metadata, args);
     }
 
-    private void RecordDataRace(ProcessThreadId reporterThreadId, DataRaceInfo raceInfo)
+    private void RecordDataRace(DataRaceInfo raceInfo)
     {
         _detectedRaces.Add(raceInfo);
-        DataRaceLogger.LogDataRace(Logger, Threads, reporterThreadId, raceInfo);
-    }
-
-    private static string GetFieldDisplayName(FieldId fieldId)
-    {
-        return DataRaceLogger.GetFieldDisplayName(fieldId);
+        if (_reportedRacyFields.Add(raceInfo.FieldId))
+            DataRaceLogger.LogDataRace(Logger, raceInfo, MetadataContext);
     }
 }
 

--- a/src/SharpDetect.Cli/Handlers/RunCommandHandler.cs
+++ b/src/SharpDetect.Cli/Handlers/RunCommandHandler.cs
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Reflection;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using CliFx.Infrastructure;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -59,8 +61,27 @@ internal sealed class RunCommandHandler : IDisposable
         var reportFileName = _arguments.Analysis.ReportFileName;
         var writer = _serviceProvider.GetRequiredService<IReportSummaryWriter>();
         var renderer = _serviceProvider.GetRequiredService<IReportSummaryRenderer>();
-        var context = new SummaryRenderingContext(reportSummary, plugin, plugin.ReportTemplates);
+        var configurationJson = SerializeConfigurationJson(_arguments);
+        var context = new SummaryRenderingContext(reportSummary, plugin, plugin.ReportTemplates, configurationJson);
         return writer.Write(reportFileName, reportDirectory, context, renderer, cancellationToken);
+    }
+
+    private static string SerializeConfigurationJson(object configuration)
+    {
+        try
+        {
+            var options = new JsonSerializerOptions
+            {
+                WriteIndented = true,
+                DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+                Converters = { new JsonStringEnumConverter() }
+            };
+            return JsonSerializer.Serialize(configuration, options);
+        }
+        catch
+        {
+            return "<unable-to-serialize-configuration>";
+        }
     }
 
     private Type LoadPluginInfo()

--- a/src/SharpDetect.Core/Reporting/SummaryRenderingContext.cs
+++ b/src/SharpDetect.Core/Reporting/SummaryRenderingContext.cs
@@ -9,4 +9,5 @@ namespace SharpDetect.Core.Reporting;
 public record SummaryRenderingContext(
     Summary Summary,
     IPlugin Plugin,
-    DirectoryInfo AdditionalPartials);
+    DirectoryInfo AdditionalPartials,
+    string ConfigurationJson);

--- a/src/SharpDetect.Reporting/Services/HtmlReportRenderer.cs
+++ b/src/SharpDetect.Reporting/Services/HtmlReportRenderer.cs
@@ -71,12 +71,13 @@ internal sealed partial class HtmlReportRenderer : IReportSummaryRenderer
             COR_PRF_RUNTIME_TYPE.COR_PRF_CORE_CLR => "CoreCLR",
             _ => "unknown runtime"
         };
-        var allReports = plugin.CreateReportDataContext(summary.GetAllReports()).ToArray();
+        var rawReports = summary.GetAllReports().ToArray();
+        var allReports = plugin.CreateReportDataContext(rawReports).ToArray();
         return new
         {
             title = summary.Title,
             description = summary.Description,
-            reportCount = allReports.Length,
+            reportCount = rawReports.Length,
             environmentInfo = new
             {
                 sharpDetectVersion,

--- a/src/SharpDetect.Reporting/Services/HtmlReportRenderer.cs
+++ b/src/SharpDetect.Reporting/Services/HtmlReportRenderer.cs
@@ -27,7 +27,7 @@ internal sealed partial class HtmlReportRenderer : IReportSummaryRenderer
     public string Render(SummaryRenderingContext context)
     {
         var environment = CreateEnvironment(context.AdditionalPartials);
-        var dataContent = BuildDataContext(context.Plugin, context.Summary);
+        var dataContent = BuildDataContext(context.Plugin, context.Summary, context.ConfigurationJson);
         var compiledTemplate = environment.Compile(_template);
         return compiledTemplate(dataContent);
     }
@@ -57,7 +57,7 @@ internal sealed partial class HtmlReportRenderer : IReportSummaryRenderer
         return environment;
     }
 
-    private static object BuildDataContext(IPlugin plugin, Summary summary)
+    private static object BuildDataContext(IPlugin plugin, Summary summary, string configurationJson)
     {
         var sharpDetectVersion = typeof(HtmlReportRenderer).Assembly
             .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?
@@ -120,7 +120,8 @@ internal sealed partial class HtmlReportRenderer : IReportSummaryRenderer
                 publicKey = moduleInfo.PublicKey,
                 culture = moduleInfo.Culture
             }),
-            reports = allReports
+            reports = allReports,
+            configurationJson
         };
     }
 

--- a/src/SharpDetect.Reporting/SharpDetect.Reporting.csproj
+++ b/src/SharpDetect.Reporting/SharpDetect.Reporting.csproj
@@ -18,6 +18,9 @@
     <None Update="Templates\Partials\content.html">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Templates\Partials\configuration.html">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="Templates\Partials\foot.html">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/src/SharpDetect.Reporting/Templates/Partials/configuration.html
+++ b/src/SharpDetect.Reporting/Templates/Partials/configuration.html
@@ -1,0 +1,6 @@
+{{#if configurationJson}}
+<pre class="config-json">{{configurationJson}}</pre>
+{{else}}
+<p class="config-json-empty">No configuration was provided for this analysis.</p>
+{{/if}}
+

--- a/src/SharpDetect.Reporting/Templates/Partials/content.html
+++ b/src/SharpDetect.Reporting/Templates/Partials/content.html
@@ -53,6 +53,17 @@
     </div>
 </details>
 
+<!-- Configuration Section -->
+<details class="section">
+    <summary>
+        <span class="section-icon">⚙️</span>
+        Analysis Configuration
+    </summary>
+    <div class="section-body">
+        {{> configuration}}
+    </div>
+</details>
+    
 <!-- Assemblies Section -->
 <details class="section">
     <summary>

--- a/src/SharpDetect.Reporting/Templates/Partials/foot.html
+++ b/src/SharpDetect.Reporting/Templates/Partials/foot.html
@@ -10,8 +10,8 @@
 
     let _hideSystemViolations = false;
 
-    function isSystemViolation(card) {
-        const target = card.querySelector('.metadata-fullname');
+    function isSystemViolation(el) {
+        const target = el.querySelector('.metadata-fullname');
         if (!target)
             return false;
         return target.textContent.trim().startsWith('System.');
@@ -21,7 +21,13 @@
         const filter = document.getElementById('violationsFilter');
         if (!filter) return;
         const query = filter.value.toLowerCase();
-        const cards = document.querySelectorAll('#violationsContainer .violation-card');
+        const groups = document.querySelectorAll('#violationsContainer > .violation-group');
+        const cards = document.querySelectorAll('#violationsContainer > .violation-card');
+        groups.forEach(function(group) {
+            const hiddenBySystem = _hideSystemViolations && isSystemViolation(group);
+            const hiddenBySearch = query && !group.textContent.toLowerCase().includes(query);
+            group.style.display = (hiddenBySystem || hiddenBySearch) ? 'none' : '';
+        });
         cards.forEach(function(card) {
             const hiddenBySystem = _hideSystemViolations && isSystemViolation(card);
             const hiddenBySearch = query && !card.textContent.toLowerCase().includes(query);
@@ -40,9 +46,9 @@
     }
 
     function toggleAllViolations(expand) {
-        const cards = document.querySelectorAll('#violationsContainer .violation-card');
-        cards.forEach(function(card) {
-            card.open = expand;
+        const items = document.querySelectorAll('#violationsContainer .violation-group, #violationsContainer .violation-card');
+        items.forEach(function(item) {
+            item.open = expand;
         });
     }
 
@@ -50,9 +56,8 @@
         const btn = document.getElementById('btnHideSystem');
         if (!btn)
             return;
-        const hasSystemViolation = Array.from(
-            document.querySelectorAll('#violationsContainer .violation-card')
-        ).some(isSystemViolation);
+        const items = document.querySelectorAll('#violationsContainer > .violation-group, #violationsContainer > .violation-card');
+        const hasSystemViolation = Array.from(items).some(isSystemViolation);
         btn.style.display = hasSystemViolation ? '' : 'none';
     });
 

--- a/src/SharpDetect.Reporting/Templates/Partials/foot.html
+++ b/src/SharpDetect.Reporting/Templates/Partials/foot.html
@@ -9,12 +9,20 @@
     }
 
     let _hideSystemViolations = false;
+    let _hideMicrosoftViolations = false;
 
     function isSystemViolation(el) {
         const target = el.querySelector('.metadata-fullname');
         if (!target)
             return false;
         return target.textContent.trim().startsWith('System.');
+    }
+
+    function isMicrosoftViolation(el) {
+        const target = el.querySelector('.metadata-fullname');
+        if (!target)
+            return false;
+        return target.textContent.trim().startsWith('Microsoft.');
     }
 
     function filterViolations() {
@@ -25,13 +33,15 @@
         const cards = document.querySelectorAll('#violationsContainer > .violation-card');
         groups.forEach(function(group) {
             const hiddenBySystem = _hideSystemViolations && isSystemViolation(group);
+            const hiddenByMicrosoft = _hideMicrosoftViolations && isMicrosoftViolation(group);
             const hiddenBySearch = query && !group.textContent.toLowerCase().includes(query);
-            group.style.display = (hiddenBySystem || hiddenBySearch) ? 'none' : '';
+            group.style.display = (hiddenBySystem || hiddenByMicrosoft || hiddenBySearch) ? 'none' : '';
         });
         cards.forEach(function(card) {
             const hiddenBySystem = _hideSystemViolations && isSystemViolation(card);
+            const hiddenByMicrosoft = _hideMicrosoftViolations && isMicrosoftViolation(card);
             const hiddenBySearch = query && !card.textContent.toLowerCase().includes(query);
-            card.style.display = (hiddenBySystem || hiddenBySearch) ? 'none' : '';
+            card.style.display = (hiddenBySystem || hiddenByMicrosoft || hiddenBySearch) ? 'none' : '';
         });
     }
 
@@ -45,6 +55,16 @@
         filterViolations();
     }
 
+    function toggleMicrosoftViolations() {
+        _hideMicrosoftViolations = !_hideMicrosoftViolations;
+        const btn = document.getElementById('btnHideMicrosoft');
+        if (btn) {
+            btn.classList.toggle('btn-active', _hideMicrosoftViolations);
+            btn.textContent = _hideMicrosoftViolations ? 'Show Microsoft.*' : 'Hide Microsoft.*';
+        }
+        filterViolations();
+    }
+
     function toggleAllViolations(expand) {
         const items = document.querySelectorAll('#violationsContainer .violation-group, #violationsContainer .violation-card');
         items.forEach(function(item) {
@@ -53,12 +73,19 @@
     }
 
     document.addEventListener('DOMContentLoaded', function() {
-        const btn = document.getElementById('btnHideSystem');
-        if (!btn)
-            return;
         const items = document.querySelectorAll('#violationsContainer > .violation-group, #violationsContainer > .violation-card');
-        const hasSystemViolation = Array.from(items).some(isSystemViolation);
-        btn.style.display = hasSystemViolation ? '' : 'none';
+
+        const btnSystem = document.getElementById('btnHideSystem');
+        if (btnSystem) {
+            const hasSystemViolation = Array.from(items).some(isSystemViolation);
+            btnSystem.style.display = hasSystemViolation ? '' : 'none';
+        }
+
+        const btnMicrosoft = document.getElementById('btnHideMicrosoft');
+        if (btnMicrosoft) {
+            const hasMicrosoftViolation = Array.from(items).some(isMicrosoftViolation);
+            btnMicrosoft.style.display = hasMicrosoftViolation ? '' : 'none';
+        }
     });
 
     (function() {

--- a/src/SharpDetect.Reporting/Templates/Partials/styles.css
+++ b/src/SharpDetect.Reporting/Templates/Partials/styles.css
@@ -255,6 +255,28 @@ body {
     border-top: 1px solid var(--color-border);
     padding: 1.25rem;
 }
+.affected-objects {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.375rem;
+    margin-bottom: 1rem;
+}
+.object-label {
+    display: inline-flex;
+    align-items: center;
+    padding: 0.125rem 0.5rem;
+    border-radius: 999px;
+    font-family: var(--font-mono);
+    font-size: 0.75rem;
+    font-weight: 500;
+    background: var(--color-primary-subtle);
+    color: var(--color-primary);
+}
+.object-label-more {
+    background: var(--color-bg);
+    color: var(--color-text-muted);
+    border: 1px solid var(--color-border);
+}
 
 .info-grid {
     display: grid;

--- a/src/SharpDetect.Reporting/Templates/Partials/styles.css
+++ b/src/SharpDetect.Reporting/Templates/Partials/styles.css
@@ -118,6 +118,7 @@ body {
 }
 
 .section,
+.violation-group,
 .violation-card {
     background: var(--color-surface);
     border: 1px solid var(--color-border);
@@ -128,16 +129,29 @@ body {
     box-shadow: var(--shadow-sm);
     margin-bottom: 1rem;
 }
+.violation-group {
+    border-radius: var(--radius-lg);
+    margin-bottom: 0.75rem;
+    box-shadow: var(--shadow-sm);
+    transition: box-shadow 0.15s ease;
+}
+.violation-group:hover {
+    box-shadow: var(--shadow-md);
+}
 .violation-card {
     border-radius: var(--radius);
     margin-bottom: 0.75rem;
     transition: box-shadow 0.15s ease;
+}
+.violation-card:last-child {
+    margin-bottom: 0;
 }
 .violation-card:hover {
     box-shadow: var(--shadow-md);
 }
 
 .section > summary,
+.violation-group > summary,
 .violation-card > summary {
     display: flex;
     align-items: center;
@@ -148,14 +162,17 @@ body {
     transition: background 0.1s ease;
 }
 .section > summary:hover,
+.violation-group > summary:hover,
 .violation-card > summary:hover {
     background: var(--color-bg);
 }
 .section > summary::-webkit-details-marker,
+.violation-group > summary::-webkit-details-marker,
 .violation-card > summary::-webkit-details-marker {
     display: none;
 }
 .section > summary::before,
+.violation-group > summary::before,
 .violation-card > summary::before {
     content: "";
     display: inline-block;
@@ -168,6 +185,7 @@ body {
     flex-shrink: 0;
 }
 .section[open] > summary::before,
+.violation-group[open] > summary::before,
 .violation-card[open] > summary::before {
     transform: rotate(45deg);
 }
@@ -186,6 +204,32 @@ body {
 }
 .section-body {
     padding: 1.5rem;
+}
+
+.violation-group > summary {
+    flex-wrap: wrap;
+    padding: 1rem 1.25rem;
+    border-bottom: 1px solid transparent;
+}
+.violation-group[open] > summary {
+    border-bottom-color: var(--color-border);
+}
+.violation-group > summary .card-title {
+    font-weight: 600;
+    font-size: 0.9375rem;
+}
+.violation-group > summary .card-desc {
+    flex: 1;
+    font-size: 0.8125rem;
+    color: var(--color-text-secondary);
+    min-width: 200px;
+}
+.violation-group-body {
+    padding: 1.25rem;
+}
+.violation-group-body > .metadata-fullname {
+    display: block;
+    margin-bottom: 1rem;
 }
 
 .violation-card > summary {

--- a/src/SharpDetect.Reporting/Templates/Partials/styles.css
+++ b/src/SharpDetect.Reporting/Templates/Partials/styles.css
@@ -622,6 +622,25 @@ body {
     font-family: var(--font-mono);
 }
 
+.config-json {
+    background: var(--color-code-bg);
+    color: var(--color-code-text);
+    font-family: var(--font-mono);
+    font-size: 0.8125rem;
+    line-height: 1.6;
+    padding: 1rem 1.25rem;
+    border-radius: var(--radius);
+    border: 1px solid var(--color-border);
+    overflow-x: auto;
+    white-space: pre;
+    tab-size: 2;
+}
+
+.config-json-empty {
+    color: var(--color-text-secondary);
+    font-style: italic;
+}
+
 .text-sm {
     font-size: 0.8125rem;
 }

--- a/src/Tests/SharpDetect.E2ETests/DataRacePluginTests.cs
+++ b/src/Tests/SharpDetect.E2ETests/DataRacePluginTests.cs
@@ -329,7 +329,7 @@ public class DataRacePluginTests(ITestOutputHelper testOutput)
         // Execute
         await analysisWorker.ExecuteAsync(CancellationToken.None);
         var summary = plugin.CreateDiagnostics();
-        var context = new SummaryRenderingContext(summary, plugin, plugin.ReportTemplates);
+        var context = new SummaryRenderingContext(summary, plugin, plugin.ReportTemplates, ConfigurationJson: string.Empty);
         var exception = await Record.ExceptionAsync(() => reportWriter.Write(context, reportRenderer, CancellationToken.None));
 
         // Assert

--- a/src/Tests/SharpDetect.E2ETests/DeadlockPluginTests.cs
+++ b/src/Tests/SharpDetect.E2ETests/DeadlockPluginTests.cs
@@ -90,7 +90,7 @@ public class DeadlockPluginTests(ITestOutputHelper testOutput)
         // Execute
         await analysisWorker.ExecuteAsync(CancellationToken.None);
         var summary = plugin.CreateDiagnostics();
-        var context = new SummaryRenderingContext(summary, plugin, plugin.ReportTemplates);
+        var context = new SummaryRenderingContext(summary, plugin, plugin.ReportTemplates, ConfigurationJson: string.Empty);
         var exception = await Record.ExceptionAsync(() => reportWriter.Write(context, reportRenderer, CancellationToken.None));
 
         // Assert


### PR DESCRIPTION
- Console reports are improved. Races are reported like this:
```text
      [PID=28389] Data race on static field Test.StaticField
          Current write by thread T2:
              at Program.Method1:IL_0018
          Previous write by thread T3:
              at Program.Method2:IL_0018
```
- Console reports do not show different races on the same field. For full report see HTML reports.
- HTML reports now deduplicate reports for instance fields that differ just in the instance.
- HTML reports now also contain configuration section (displays used JSON).
