### PR TITLE
Add support for SemaphoreSlim in data race analysis

### DIFF
--- a/src/Extensibility/SharpDetect.Plugins.DataRace.FastTrack/FastTrackDetector.cs
+++ b/src/Extensibility/SharpDetect.Plugins.DataRace.FastTrack/FastTrackDetector.cs
@@ -18,8 +18,8 @@ internal sealed class FastTrackDetector
     private readonly TimeProvider _timeProvider;
     private readonly Dictionary<ProcessThreadId, VectorClock> _threadClocks = [];
     private readonly Dictionary<ProcessTrackedObjectId, VectorClock> _lockClocks = [];
+    private readonly Dictionary<ProcessTrackedObjectId, VectorClock> _semaphoreClocks = [];
     private readonly Dictionary<ProcessTrackedObjectId, VectorClock> _taskClocks = [];
-    private readonly Dictionary<ProcessTrackedObjectId, VectorClock> _awaiterClocks = [];
     private readonly Dictionary<(FieldId, ProcessTrackedObjectId?), VectorClock> _volatileClocks = [];
     private readonly Dictionary<ProcessTrackedObjectId, HashSet<FieldId>> _volatileClocksObjectIndex = [];
 
@@ -63,6 +63,7 @@ internal sealed class FastTrackDetector
         {
             var processObjectId = new ProcessTrackedObjectId(processId, objectId);
             _lockClocks.Remove(processObjectId);
+            _semaphoreClocks.Remove(processObjectId);
             _taskClocks.Remove(processObjectId);
         }
 
@@ -138,7 +139,22 @@ internal sealed class FastTrackDetector
         _lockClocks[lockId] = threadVc.Clone();
         threadVc.Increment(threadId);
     }
-    
+
+    public void RecordSemaphoreAcquired(ProcessThreadId threadId, ProcessTrackedObjectId semaphoreId)
+    {
+        var threadVc = GetOrCreateThreadClock(threadId);
+        var semaphoreVc = GetOrCreateSemaphoreClock(semaphoreId);
+        threadVc.Join(semaphoreVc);
+    }
+
+    public void RecordSemaphoreReleased(ProcessThreadId threadId, ProcessTrackedObjectId semaphoreId)
+    {
+        var threadVc = GetOrCreateThreadClock(threadId);
+        var semaphoreVc = GetOrCreateSemaphoreClock(semaphoreId);
+        semaphoreVc.Join(threadVc);
+        threadVc.Increment(threadId);
+    }
+
     public void RecordObjectWaitCalled(ProcessThreadId threadId, ProcessTrackedObjectId lockId)
     {
         RecordLockReleased(threadId, lockId);
@@ -355,6 +371,17 @@ internal sealed class FastTrackDetector
         {
             vc = new VectorClock();
             _lockClocks[lockId] = vc;
+        }
+
+        return vc;
+    }
+
+    private VectorClock GetOrCreateSemaphoreClock(ProcessTrackedObjectId semaphoreId)
+    {
+        if (!_semaphoreClocks.TryGetValue(semaphoreId, out var vc))
+        {
+            vc = new VectorClock();
+            _semaphoreClocks[semaphoreId] = vc;
         }
 
         return vc;

--- a/src/Extensibility/SharpDetect.Plugins.DataRace.FastTrack/FastTrackPlugin.cs
+++ b/src/Extensibility/SharpDetect.Plugins.DataRace.FastTrack/FastTrackPlugin.cs
@@ -75,6 +75,7 @@ public partial class FastTrackPlugin : PerThreadOrderingPluginBase, IPlugin
                     LockMethodDescriptors.GetAllMethods()).Concat(
                     ThreadMethodDescriptors.GetAllMethods()).Concat(
                     TaskMethodDescriptors.GetAllMethods()).Concat(
+                    SemaphoreSlimMethodDescriptors.GetAllMethods()).Concat(
                     FieldAccessDescriptors.GetAllMethods())
                     .ToImmutableArray(),
                 TypeInjectionDescriptors = SharpDetectHelperTypeDescriptors.GetAllTypes(),
@@ -98,6 +99,8 @@ public partial class FastTrackPlugin : PerThreadOrderingPluginBase, IPlugin
         TaskStarted += OnTaskStarted;
         TaskCompleted += OnTaskCompleted;
         TaskJoinFinished += OnTaskJoinFinished;
+        SemaphoreAcquireReturned += OnSemaphoreAcquireReturned;
+        SemaphoreReleased += OnSemaphoreReleased;
 
         ReportTemplates = new DirectoryInfo(
             Path.Combine(
@@ -278,6 +281,17 @@ public partial class FastTrackPlugin : PerThreadOrderingPluginBase, IPlugin
     {
         if (args.IsSuccess)
             _detector.RecordTaskJoinFinished(args.ProcessThreadId, args.TaskObjectId);
+    }
+
+    private void OnSemaphoreAcquireReturned(SemaphoreAcquireResultArgs args)
+    {
+        if (args.IsSuccess)
+            _detector.RecordSemaphoreAcquired(args.ProcessThreadId, args.SemaphoreId);
+    }
+
+    private void OnSemaphoreReleased(SemaphoreReleaseArgs args)
+    {
+        _detector.RecordSemaphoreReleased(args.ProcessThreadId, args.SemaphoreId);
     }
 
     protected override void Visit(RecordedEventMetadata metadata, ThreadRenameRecordedEvent args)

--- a/src/Extensibility/SharpDetect.Plugins.Descriptors/Methods/SemaphoreSlimMethodDescriptors.cs
+++ b/src/Extensibility/SharpDetect.Plugins.Descriptors/Methods/SemaphoreSlimMethodDescriptors.cs
@@ -1,0 +1,116 @@
+// Copyright 2026 Andrej Čižmárik and Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+using SharpDetect.Core.Events;
+using SharpDetect.Core.Events.Profiler;
+
+namespace SharpDetect.Plugins.Descriptors.Methods;
+
+public static class SemaphoreSlimMethodDescriptors
+{
+    private const string SemaphoreSlimTypeName = "System.Threading.SemaphoreSlim";
+    private const string CancellationTokenTypeName = "System.Threading.CancellationToken";
+
+    private static readonly Version Version8 = new(8, 0, 0);
+    private static readonly Version Version10 = new(10, 0, 0);
+    private static readonly Version Version10Max = new(10, int.MaxValue, int.MaxValue);
+    
+    private static readonly CapturedArgumentDescriptor ObjectRefArg =
+        new(0, new((byte)nint.Size, CapturedValue.CaptureAsReference));
+    
+    private static readonly MethodDescriptor WaitV8;
+    private static readonly MethodDescriptor WaitCoreV10;
+    private static readonly MethodDescriptor ReleaseNoArgs;
+    private static readonly MethodDescriptor ReleaseWithCount;
+
+    static SemaphoreSlimMethodDescriptors()
+    {
+        WaitV8 = new MethodDescriptor(
+            MethodName: "Wait",
+            DeclaringTypeFullName: SemaphoreSlimTypeName,
+            VersionDescriptor: MethodVersionDescriptor.Create(Version8, Version10),
+            SignatureDescriptor: new MethodSignatureDescriptor(
+                CallingConvention: CorCallingConvention.IMAGE_CEE_CS_CALLCONV_HASTHIS,
+                ParametersCount: 2,
+                ReturnType: ArgumentTypeDescriptor.CreateSimple(CorElementType.ELEMENT_TYPE_BOOLEAN),
+                ArgumentTypeElements:
+                [
+                    ArgumentTypeDescriptor.CreateSimple(CorElementType.ELEMENT_TYPE_I4),
+                    ArgumentTypeDescriptor.CreateValueType(CancellationTokenTypeName)
+                ]),
+            RewritingDescriptor: new MethodRewritingDescriptor(
+                InjectHooks: true,
+                InjectManagedWrapper: false,
+                Arguments: [ObjectRefArg],
+                ReturnValue: new CapturedValueDescriptor(sizeof(bool), CapturedValue.CaptureAsValue),
+                MethodEnterInterpretation: (ushort)RecordedEventType.SemaphoreTryAcquire,
+                MethodExitInterpretation: (ushort)RecordedEventType.SemaphoreAcquireResult));
+        
+        WaitCoreV10 = new MethodDescriptor(
+            MethodName: "WaitCore",
+            DeclaringTypeFullName: SemaphoreSlimTypeName,
+            VersionDescriptor: MethodVersionDescriptor.Create(Version10, Version10Max),
+            SignatureDescriptor: new MethodSignatureDescriptor(
+                CallingConvention: CorCallingConvention.IMAGE_CEE_CS_CALLCONV_HASTHIS,
+                ParametersCount: 2,
+                ReturnType: ArgumentTypeDescriptor.CreateSimple(CorElementType.ELEMENT_TYPE_BOOLEAN),
+                ArgumentTypeElements:
+                [
+                    ArgumentTypeDescriptor.CreateSimple(CorElementType.ELEMENT_TYPE_I8),
+                    ArgumentTypeDescriptor.CreateValueType(CancellationTokenTypeName)
+                ]),
+            RewritingDescriptor: new MethodRewritingDescriptor(
+                InjectHooks: true,
+                InjectManagedWrapper: false,
+                Arguments: [ObjectRefArg],
+                ReturnValue: new CapturedValueDescriptor(sizeof(bool), CapturedValue.CaptureAsValue),
+                MethodEnterInterpretation: (ushort)RecordedEventType.SemaphoreTryAcquire,
+                MethodExitInterpretation: (ushort)RecordedEventType.SemaphoreAcquireResult));
+
+        ReleaseNoArgs = new MethodDescriptor(
+            MethodName: "Release",
+            DeclaringTypeFullName: SemaphoreSlimTypeName,
+            VersionDescriptor: null,
+            SignatureDescriptor: new MethodSignatureDescriptor(
+                CallingConvention: CorCallingConvention.IMAGE_CEE_CS_CALLCONV_HASTHIS,
+                ParametersCount: 0,
+                ReturnType: ArgumentTypeDescriptor.CreateSimple(CorElementType.ELEMENT_TYPE_I4),
+                ArgumentTypeElements: []),
+            RewritingDescriptor: new MethodRewritingDescriptor(
+                InjectHooks: true,
+                InjectManagedWrapper: false,
+                Arguments: [ObjectRefArg],
+                ReturnValue: null,
+                MethodEnterInterpretation: (ushort)RecordedEventType.SemaphoreRelease,
+                MethodExitInterpretation: (ushort)RecordedEventType.SemaphoreReleaseResult));
+
+        ReleaseWithCount = new MethodDescriptor(
+            MethodName: "Release",
+            DeclaringTypeFullName: SemaphoreSlimTypeName,
+            VersionDescriptor: null,
+            SignatureDescriptor: new MethodSignatureDescriptor(
+                CallingConvention: CorCallingConvention.IMAGE_CEE_CS_CALLCONV_HASTHIS,
+                ParametersCount: 1,
+                ReturnType: ArgumentTypeDescriptor.CreateSimple(CorElementType.ELEMENT_TYPE_I4),
+                ArgumentTypeElements: [ArgumentTypeDescriptor.CreateSimple(CorElementType.ELEMENT_TYPE_I4)]),
+            RewritingDescriptor: new MethodRewritingDescriptor(
+                InjectHooks: true,
+                InjectManagedWrapper: false,
+                Arguments: [ObjectRefArg],
+                ReturnValue: null,
+                MethodEnterInterpretation: (ushort)RecordedEventType.SemaphoreRelease,
+                MethodExitInterpretation: (ushort)RecordedEventType.SemaphoreReleaseResult));
+    }
+
+    public static IEnumerable<MethodDescriptor> GetAllMethods()
+    {
+        // Internal API
+        yield return WaitV8;
+        yield return WaitCoreV10;
+        
+        // Public API
+        yield return ReleaseNoArgs;
+        yield return ReleaseWithCount;
+    }
+}
+

--- a/src/Extensibility/SharpDetect.Plugins.PerThreadOrdering/PerThreadOrderingPluginBase.cs
+++ b/src/Extensibility/SharpDetect.Plugins.PerThreadOrdering/PerThreadOrderingPluginBase.cs
@@ -39,6 +39,9 @@ public abstract class PerThreadOrderingPluginBase : PluginBase
     public event Action<StaticFieldWriteArgs>? StaticFieldWritten;
     public event Action<InstanceFieldReadArgs>? InstanceFieldRead;
     public event Action<InstanceFieldWriteArgs>? InstanceFieldWritten;
+    public event Action<SemaphoreAcquireAttemptArgs>? SemaphoreAcquireAttempted;
+    public event Action<SemaphoreAcquireResultArgs>? SemaphoreAcquireReturned;
+    public event Action<SemaphoreReleaseArgs>? SemaphoreReleased;
 
     protected PerThreadOrderingPluginBase(
         IModuleBindContext moduleBindContext,
@@ -72,6 +75,9 @@ public abstract class PerThreadOrderingPluginBase : PluginBase
     protected void RaiseStaticFieldWritten(StaticFieldWriteArgs args) => StaticFieldWritten?.Invoke(args);
     protected void RaiseInstanceFieldRead(InstanceFieldReadArgs args) => InstanceFieldRead?.Invoke(args);
     protected void RaiseInstanceFieldWritten(InstanceFieldWriteArgs args) => InstanceFieldWritten?.Invoke(args);
+    protected void RaiseSemaphoreAcquireAttempted(SemaphoreAcquireAttemptArgs args) => SemaphoreAcquireAttempted?.Invoke(args);
+    protected void RaiseSemaphoreAcquireReturned(SemaphoreAcquireResultArgs args) => SemaphoreAcquireReturned?.Invoke(args);
+    protected void RaiseSemaphoreReleased(SemaphoreReleaseArgs args) => SemaphoreReleased?.Invoke(args);
 
     [RecordedEventBind((ushort)RecordedEventType.LockAcquire)]
     [RecordedEventBind((ushort)RecordedEventType.LockTryAcquire)]
@@ -79,7 +85,7 @@ public abstract class PerThreadOrderingPluginBase : PluginBase
     [RecordedEventBind((ushort)RecordedEventType.MonitorLockTryAcquire)]
     public void OnLockAcquireEnter(RecordedEventMetadata metadata, MethodEnterWithArgumentsRecordedEvent args)
     {
-        var (id, arguments, lockId) = ExtractLockContext(metadata, args);
+        var (id, arguments, lockId) = ExtractSynchronizationContext(metadata, args);
         _callStackTracker.Push(id, new StackFrame(args.ModuleId, args.MethodToken, arguments));
         LockAcquireAttempted?.Invoke(new(id, args.ModuleId, args.MethodToken, lockId));
     }
@@ -144,7 +150,7 @@ public abstract class PerThreadOrderingPluginBase : PluginBase
     [RecordedEventBind((ushort)RecordedEventType.MonitorWaitAttempt)]
     public void OnMonitorWaitAttempt(RecordedEventMetadata metadata, MethodEnterWithArgumentsRecordedEvent args)
     {
-        var (id, arguments, lockId) = ExtractLockContext(metadata, args);
+        var (id, arguments, lockId) = ExtractSynchronizationContext(metadata, args);
         OnBeforeWaitAttempt(id, lockId);
         _callStackTracker.Push(id, new StackFrame(args.ModuleId, args.MethodToken, arguments));
         ProcessWaitAttempt(id, args.ModuleId, args.MethodToken, lockId);
@@ -156,11 +162,41 @@ public abstract class PerThreadOrderingPluginBase : PluginBase
         var id = new ProcessThreadId(metadata.Pid, metadata.Tid);
         var frame = _callStackTracker.Peek(id);
         EnsureCallStackIntegrity(frame, args.ModuleId, args.MethodToken);
-        var lockId = ExtractLockIdFromFrame(id, frame);
+        var lockId = ExtractSynchronizationObjectIdFromFrame(id, frame);
         var success = MemoryMarshal.Read<bool>(args.ReturnValue);
         ProcessWaitReturn(id, args.ModuleId, args.MethodToken, lockId, success);
     }
 
+    [RecordedEventBind((ushort)RecordedEventType.SemaphoreAcquire)]
+    [RecordedEventBind((ushort)RecordedEventType.SemaphoreTryAcquire)]
+    public void OnSemaphoreAcquireEnter(RecordedEventMetadata metadata, MethodEnterWithArgumentsRecordedEvent args)
+    {
+        var (id, arguments, semaphoreId) = ExtractSynchronizationContext(metadata, args);
+        _callStackTracker.Push(id, new StackFrame(args.ModuleId, args.MethodToken, arguments));
+        SemaphoreAcquireAttempted?.Invoke(new(id, args.ModuleId, args.MethodToken, semaphoreId));
+    }
+
+    [RecordedEventBind((ushort)RecordedEventType.SemaphoreAcquireResult)]
+    public void OnSemaphoreAcquireExit(RecordedEventMetadata metadata, MethodExitRecordedEvent args)
+        => HandleSemaphoreAcquireExit(metadata, args.ModuleId, args.MethodToken, isSuccess: true);
+
+    [RecordedEventBind((ushort)RecordedEventType.SemaphoreAcquireResult)]
+    public void OnSemaphoreAcquireExit(RecordedEventMetadata metadata, MethodExitWithArgumentsRecordedEvent args)
+    {
+        var isSuccess = MemoryMarshal.Read<bool>(args.ReturnValue);
+        HandleSemaphoreAcquireExit(metadata, args.ModuleId, args.MethodToken, isSuccess);
+    }
+
+    [RecordedEventBind((ushort)RecordedEventType.SemaphoreRelease)]
+    public void OnSemaphoreReleaseEnter(RecordedEventMetadata metadata, MethodEnterWithArgumentsRecordedEvent args)
+        => PushArgumentsOnCallStack(metadata, args);
+
+    [RecordedEventBind((ushort)RecordedEventType.SemaphoreReleaseResult)]
+    public void OnSemaphoreReleaseExit(RecordedEventMetadata metadata, MethodExitRecordedEvent args)
+    {
+        var (id, semaphoreId) = PopLockContext(metadata, args);
+        SemaphoreReleased?.Invoke(new(id, args.ModuleId, args.MethodToken, semaphoreId));
+    }
     
     [RecordedEventBind((ushort)RecordedEventType.ThreadStartCore)]
     public void OnThreadStartCore(RecordedEventMetadata metadata, MethodEnterWithArgumentsRecordedEvent args)
@@ -330,7 +366,7 @@ public abstract class PerThreadOrderingPluginBase : PluginBase
         var id = new ProcessThreadId(metadata.Pid, metadata.Tid);
         var frame = _callStackTracker.Peek(id);
         EnsureCallStackIntegrity(frame, moduleId, functionToken);
-        var lockId = ExtractLockIdFromFrame(id, frame);
+        var lockId = ExtractSynchronizationObjectIdFromFrame(id, frame);
 
         if (!lockTaken)
         {
@@ -473,14 +509,14 @@ public abstract class PerThreadOrderingPluginBase : PluginBase
     protected IReadOnlySet<ProcessThreadId> GetTrackedThreadIds()
         => _callStackTracker.GetThreadIds();
 
-    private (ProcessThreadId Id, RuntimeArgumentList Arguments, ProcessTrackedObjectId LockId) ExtractLockContext(
+    private (ProcessThreadId Id, RuntimeArgumentList Arguments, ProcessTrackedObjectId SynchronizationObjectId) ExtractSynchronizationContext(
         RecordedEventMetadata metadata,
         MethodEnterWithArgumentsRecordedEvent args)
     {
         var id = new ProcessThreadId(metadata.Pid, metadata.Tid);
         var arguments = ParseArguments(metadata, args);
-        var lockId = new ProcessTrackedObjectId(id.ProcessId, arguments[0].Value.AsT1);
-        return (id, arguments, lockId);
+        var synchronizationObjectId = new ProcessTrackedObjectId(id.ProcessId, arguments[0].Value.AsT1);
+        return (id, arguments, synchronizationObjectId);
     }
 
     private (ProcessThreadId Id, ProcessTrackedObjectId LockId) PopLockContext(
@@ -490,7 +526,7 @@ public abstract class PerThreadOrderingPluginBase : PluginBase
         var id = new ProcessThreadId(metadata.Pid, metadata.Tid);
         var frame = _callStackTracker.Pop(id);
         EnsureCallStackIntegrity(frame, args.ModuleId, args.MethodToken);
-        return (id, ExtractLockIdFromFrame(id, frame));
+        return (id, ExtractSynchronizationObjectIdFromFrame(id, frame));
     }
 
     private (ProcessThreadId Id, ProcessTrackedObjectId LockId, bool LockTaken) PopLockContextWithFlag(
@@ -519,8 +555,22 @@ public abstract class PerThreadOrderingPluginBase : PluginBase
         return true;
     }
 
-    private static ProcessTrackedObjectId ExtractLockIdFromFrame(ProcessThreadId id, StackFrame frame)
+    private static ProcessTrackedObjectId ExtractSynchronizationObjectIdFromFrame(ProcessThreadId id, StackFrame frame)
         => new(id.ProcessId, frame.Arguments!.Value[0].Value.AsT1);
+
+    private void HandleSemaphoreAcquireExit(
+        RecordedEventMetadata metadata,
+        ModuleId moduleId,
+        MdMethodDef functionToken,
+        bool isSuccess)
+    {
+        var id = new ProcessThreadId(metadata.Pid, metadata.Tid);
+        var frame = _callStackTracker.Peek(id);
+        EnsureCallStackIntegrity(frame, moduleId, functionToken);
+        var semaphoreId = ExtractSynchronizationObjectIdFromFrame(id, frame);
+        _callStackTracker.Pop(id);
+        SemaphoreAcquireReturned?.Invoke(new(id, moduleId, functionToken, semaphoreId, isSuccess));
+    }
 
     private void PushArgumentsOnCallStack(RecordedEventMetadata metadata, MethodEnterWithArgumentsRecordedEvent args)
     {

--- a/src/SharpDetect.Core/Events/RecordedEventType.cs
+++ b/src/SharpDetect.Core/Events/RecordedEventType.cs
@@ -82,11 +82,16 @@ public enum RecordedEventType : ushort
     LockAcquireResult = 115,
     LockRelease = 116,
     LockReleaseResult = 117,
+    SemaphoreAcquire = 118,
+    SemaphoreTryAcquire = 119,
+    SemaphoreAcquireResult = 120,
+    SemaphoreRelease = 121,
+    SemaphoreReleaseResult = 122,
 
     /* Task synchronization */
-    TaskSchedule = 120,
-    TaskStart = 121,
-    TaskComplete = 122,
-    TaskJoinStart = 123,
-    TaskJoinFinish = 124,
+    TaskSchedule = 200,
+    TaskStart = 201,
+    TaskComplete = 202,
+    TaskJoinStart = 203,
+    TaskJoinFinish = 204,
 }

--- a/src/SharpDetect.Core/Plugins/PluginEventArgs.cs
+++ b/src/SharpDetect.Core/Plugins/PluginEventArgs.cs
@@ -25,3 +25,6 @@ public readonly record struct TaskScheduleArgs(ProcessThreadId ProcessThreadId, 
 public readonly record struct TaskStartArgs(ProcessThreadId ProcessThreadId, ProcessTrackedObjectId TaskObjectId);
 public readonly record struct TaskCompleteArgs(ProcessThreadId ProcessThreadId, ProcessTrackedObjectId TaskObjectId);
 public readonly record struct TaskJoinFinishArgs(ProcessThreadId ProcessThreadId, ProcessTrackedObjectId TaskObjectId, bool IsSuccess);
+public readonly record struct SemaphoreAcquireAttemptArgs(ProcessThreadId ProcessThreadId, ModuleId ModuleId, MdMethodDef MethodToken, ProcessTrackedObjectId SemaphoreId);
+public readonly record struct SemaphoreAcquireResultArgs(ProcessThreadId ProcessThreadId, ModuleId ModuleId, MdMethodDef MethodToken, ProcessTrackedObjectId SemaphoreId, bool IsSuccess);
+public readonly record struct SemaphoreReleaseArgs(ProcessThreadId ProcessThreadId, ModuleId ModuleId, MdMethodDef MethodToken, ProcessTrackedObjectId SemaphoreId);

--- a/src/Tests/SharpDetect.E2ETests.Subject/Entrypoint.cs
+++ b/src/Tests/SharpDetect.E2ETests.Subject/Entrypoint.cs
@@ -126,6 +126,27 @@ namespace SharpDetect.E2ETests.Subject
                     Test_LockMethods_TryEnterExit2();
                     break;
 #endif
+                case nameof(Test_SemaphoreSlimMethods_WaitRelease1):
+                    Test_SemaphoreSlimMethods_WaitRelease1();
+                    break;
+                case nameof(Test_SemaphoreSlimMethods_WaitRelease2):
+                    Test_SemaphoreSlimMethods_WaitRelease2();
+                    break;
+                case nameof(Test_SemaphoreSlimMethods_WaitRelease3):
+                    Test_SemaphoreSlimMethods_WaitRelease3();
+                    break;
+                case nameof(Test_SemaphoreSlimMethods_TryWaitRelease1):
+                    Test_SemaphoreSlimMethods_TryWaitRelease1();
+                    break;
+                case nameof(Test_SemaphoreSlimMethods_TryWaitRelease2):
+                    Test_SemaphoreSlimMethods_TryWaitRelease2();
+                    break;
+                case nameof(Test_SemaphoreSlimMethods_TryWaitRelease3):
+                    Test_SemaphoreSlimMethods_TryWaitRelease3();
+                    break;
+                case nameof(Test_SemaphoreSlimMethods_TryWaitRelease4):
+                    Test_SemaphoreSlimMethods_TryWaitRelease4();
+                    break;
             }
 
             // Field events
@@ -427,6 +448,9 @@ namespace SharpDetect.E2ETests.Subject
                     break;
                 case nameof(Test_NoDataRace_Task_SequentialTasks_WriteRead):
                     Test_NoDataRace_Task_SequentialTasks_WriteRead();
+                    break;
+                case nameof(Test_NoDataRace_SemaphoreSlim_ProtectedWriteRead):
+                    Test_NoDataRace_SemaphoreSlim_ProtectedWriteRead();
                     break;
             }
 

--- a/src/Tests/SharpDetect.E2ETests.Subject/SimpleTests.cs
+++ b/src/Tests/SharpDetect.E2ETests.Subject/SimpleTests.cs
@@ -1135,6 +1135,73 @@ namespace SharpDetect.E2ETests.Subject
             Task.Run(() => { _ = DataRace.Test_DataRace_ValueType_Static; }).Wait();
         }
 
+        public static void Test_SemaphoreSlimMethods_WaitRelease1()
+        {
+            var sem = new SemaphoreSlim(1, 1);
+            sem.Wait();
+            sem.Release();
+        }
+
+        public static void Test_SemaphoreSlimMethods_WaitRelease2()
+        {
+            var sem = new SemaphoreSlim(1, 1);
+            sem.Wait(CancellationToken.None);
+            sem.Release();
+        }
+
+        public static void Test_SemaphoreSlimMethods_WaitRelease3()
+        {
+            var sem = new SemaphoreSlim(1, 1);
+            sem.Wait();
+            sem.Release(releaseCount: 1);
+        }
+
+        public static void Test_SemaphoreSlimMethods_TryWaitRelease1()
+        {
+            var sem = new SemaphoreSlim(1, 1);
+            if (sem.Wait(millisecondsTimeout: Timeout.Infinite))
+                sem.Release();
+        }
+
+        public static void Test_SemaphoreSlimMethods_TryWaitRelease2()
+        {
+            var sem = new SemaphoreSlim(1, 1);
+            if (sem.Wait(timeout: TimeSpan.FromMilliseconds(Timeout.Infinite)))
+                sem.Release();
+        }
+
+        public static void Test_SemaphoreSlimMethods_TryWaitRelease3()
+        {
+            var sem = new SemaphoreSlim(1, 1);
+            if (sem.Wait(millisecondsTimeout: Timeout.Infinite, cancellationToken: CancellationToken.None))
+                sem.Release();
+        }
+
+        public static void Test_SemaphoreSlimMethods_TryWaitRelease4()
+        {
+            var sem = new SemaphoreSlim(1, 1);
+            if (sem.Wait(timeout: TimeSpan.FromMilliseconds(Timeout.Infinite), cancellationToken: CancellationToken.None))
+                sem.Release();
+        }
+
+        public static void Test_NoDataRace_SemaphoreSlim_ProtectedWriteRead()
+        {
+            var sem = new SemaphoreSlim(1, 1);
+            var task1 = Task.Run(() =>
+            {
+                sem.Wait();
+                DataRace.Test_DataRace_ValueType_Static = 42;
+                sem.Release();
+            });
+            var task2 = Task.Run(() =>
+            {
+                sem.Wait();
+                _ = DataRace.Test_DataRace_ValueType_Static;
+                sem.Release();
+            });
+            Task.WaitAll(task1, task2);
+        }
+
         public static void Test_SingleGarbageCollection_ObjectTracking_Simple()
         {
             // Generate garbage

--- a/src/Tests/SharpDetect.E2ETests/DataRacePluginTestConfigurations/NoDataRace_SemaphoreSlim_ProtectedWriteRead.json
+++ b/src/Tests/SharpDetect.E2ETests/DataRacePluginTestConfigurations/NoDataRace_SemaphoreSlim_ProtectedWriteRead.json
@@ -1,0 +1,29 @@
+{
+  "Target": {
+    "Path": "../../../../SharpDetect.E2ETests.Subject/bin/%BUILD_CONFIGURATION%/%SDK%/SharpDetect.E2ETests.Subject.dll",
+    "Args": "Test_NoDataRace_SemaphoreSlim_ProtectedWriteRead",
+    "RedirectInputOutput": {
+      "SingleConsoleMode": true
+    }
+  },
+  "Runtime": {
+    "Profiler": {
+      "LogLevel": "Information"
+    }
+  },
+  "Analysis": {
+    "Path": "SharpDetect.E2ETests.dll",
+    "PluginFullTypeName": "SharpDetect.E2ETests.Utils.TestFastTrackPlugin",
+    "RenderReport": false,
+    "LogLevel": "Information",
+    "Configuration":
+    {
+      "SkipInstrumentationForAssemblies":
+      [
+        "System.",
+        "Microsoft."
+      ]
+    }
+  }
+}
+

--- a/src/Tests/SharpDetect.E2ETests/DataRacePluginTests.cs
+++ b/src/Tests/SharpDetect.E2ETests/DataRacePluginTests.cs
@@ -288,6 +288,15 @@ public class DataRacePluginTests(ITestOutputHelper testOutput)
     }
 
     [Theory]
+    [InlineData($"{ConfigurationFolder}/{nameof(NoDataRace_SemaphoreSlim_ProtectedWriteRead)}.json", "net8.0", FastTrackPluginFullTypeName)]
+    [InlineData($"{ConfigurationFolder}/{nameof(NoDataRace_SemaphoreSlim_ProtectedWriteRead)}.json", "net9.0", FastTrackPluginFullTypeName)]
+    [InlineData($"{ConfigurationFolder}/{nameof(NoDataRace_SemaphoreSlim_ProtectedWriteRead)}.json", "net10.0", FastTrackPluginFullTypeName)]
+    public Task NoDataRace_SemaphoreSlim_ProtectedWriteRead(string configuration, string sdk, string plugin)
+    {
+        return AssertDoesNotDetectDataRace(configuration, sdk, plugin);
+    }
+
+    [Theory]
     [InlineData($"{ConfigurationFolder}/{nameof(CanRenderReport)}.json", "net10.0", FastTrackPluginFullTypeName)]
     [InlineData($"{ConfigurationFolder}/{nameof(CanRenderReport)}.json", "net10.0", EraserPluginFullTypeName)]
     public async Task CanRenderReport(string configuration, string sdk, string pluginFullTypeName)

--- a/src/Tests/SharpDetect.E2ETests/MethodInterpretationTestConfigurations/MethodInterpretation_SemaphoreSlim_TryWaitRelease1.json
+++ b/src/Tests/SharpDetect.E2ETests/MethodInterpretationTestConfigurations/MethodInterpretation_SemaphoreSlim_TryWaitRelease1.json
@@ -1,0 +1,21 @@
+{
+  "Target": {
+    "Path": "../../../../SharpDetect.E2ETests.Subject/bin/%BUILD_CONFIGURATION%/%SDK%/SharpDetect.E2ETests.Subject.dll",
+    "Args": "Test_SemaphoreSlimMethods_TryWaitRelease1",
+    "RedirectInputOutput": {
+      "SingleConsoleMode": true
+    }
+  },
+  "Runtime": {
+    "Profiler": {
+      "LogLevel": "Information"
+    }
+  },
+  "Analysis": {
+    "Path": "SharpDetect.E2ETests.dll",
+    "PluginFullTypeName": "SharpDetect.E2ETests.Utils.TestExecutionOrderingPlugin",
+    "RenderReport": false,
+    "LogLevel": "Information"
+  }
+}
+

--- a/src/Tests/SharpDetect.E2ETests/MethodInterpretationTestConfigurations/MethodInterpretation_SemaphoreSlim_TryWaitRelease2.json
+++ b/src/Tests/SharpDetect.E2ETests/MethodInterpretationTestConfigurations/MethodInterpretation_SemaphoreSlim_TryWaitRelease2.json
@@ -1,0 +1,21 @@
+{
+  "Target": {
+    "Path": "../../../../SharpDetect.E2ETests.Subject/bin/%BUILD_CONFIGURATION%/%SDK%/SharpDetect.E2ETests.Subject.dll",
+    "Args": "Test_SemaphoreSlimMethods_TryWaitRelease2",
+    "RedirectInputOutput": {
+      "SingleConsoleMode": true
+    }
+  },
+  "Runtime": {
+    "Profiler": {
+      "LogLevel": "Information"
+    }
+  },
+  "Analysis": {
+    "Path": "SharpDetect.E2ETests.dll",
+    "PluginFullTypeName": "SharpDetect.E2ETests.Utils.TestExecutionOrderingPlugin",
+    "RenderReport": false,
+    "LogLevel": "Information"
+  }
+}
+

--- a/src/Tests/SharpDetect.E2ETests/MethodInterpretationTestConfigurations/MethodInterpretation_SemaphoreSlim_TryWaitRelease3.json
+++ b/src/Tests/SharpDetect.E2ETests/MethodInterpretationTestConfigurations/MethodInterpretation_SemaphoreSlim_TryWaitRelease3.json
@@ -1,0 +1,21 @@
+{
+  "Target": {
+    "Path": "../../../../SharpDetect.E2ETests.Subject/bin/%BUILD_CONFIGURATION%/%SDK%/SharpDetect.E2ETests.Subject.dll",
+    "Args": "Test_SemaphoreSlimMethods_TryWaitRelease3",
+    "RedirectInputOutput": {
+      "SingleConsoleMode": true
+    }
+  },
+  "Runtime": {
+    "Profiler": {
+      "LogLevel": "Information"
+    }
+  },
+  "Analysis": {
+    "Path": "SharpDetect.E2ETests.dll",
+    "PluginFullTypeName": "SharpDetect.E2ETests.Utils.TestExecutionOrderingPlugin",
+    "RenderReport": false,
+    "LogLevel": "Information"
+  }
+}
+

--- a/src/Tests/SharpDetect.E2ETests/MethodInterpretationTestConfigurations/MethodInterpretation_SemaphoreSlim_TryWaitRelease4.json
+++ b/src/Tests/SharpDetect.E2ETests/MethodInterpretationTestConfigurations/MethodInterpretation_SemaphoreSlim_TryWaitRelease4.json
@@ -1,0 +1,21 @@
+{
+  "Target": {
+    "Path": "../../../../SharpDetect.E2ETests.Subject/bin/%BUILD_CONFIGURATION%/%SDK%/SharpDetect.E2ETests.Subject.dll",
+    "Args": "Test_SemaphoreSlimMethods_TryWaitRelease4",
+    "RedirectInputOutput": {
+      "SingleConsoleMode": true
+    }
+  },
+  "Runtime": {
+    "Profiler": {
+      "LogLevel": "Information"
+    }
+  },
+  "Analysis": {
+    "Path": "SharpDetect.E2ETests.dll",
+    "PluginFullTypeName": "SharpDetect.E2ETests.Utils.TestExecutionOrderingPlugin",
+    "RenderReport": false,
+    "LogLevel": "Information"
+  }
+}
+

--- a/src/Tests/SharpDetect.E2ETests/MethodInterpretationTestConfigurations/MethodInterpretation_SemaphoreSlim_WaitRelease1.json
+++ b/src/Tests/SharpDetect.E2ETests/MethodInterpretationTestConfigurations/MethodInterpretation_SemaphoreSlim_WaitRelease1.json
@@ -1,0 +1,21 @@
+{
+  "Target": {
+    "Path": "../../../../SharpDetect.E2ETests.Subject/bin/%BUILD_CONFIGURATION%/%SDK%/SharpDetect.E2ETests.Subject.dll",
+    "Args": "Test_SemaphoreSlimMethods_WaitRelease1",
+    "RedirectInputOutput": {
+      "SingleConsoleMode": true
+    }
+  },
+  "Runtime": {
+    "Profiler": {
+      "LogLevel": "Information"
+    }
+  },
+  "Analysis": {
+    "Path": "SharpDetect.E2ETests.dll",
+    "PluginFullTypeName": "SharpDetect.E2ETests.Utils.TestExecutionOrderingPlugin",
+    "RenderReport": false,
+    "LogLevel": "Information"
+  }
+}
+

--- a/src/Tests/SharpDetect.E2ETests/MethodInterpretationTestConfigurations/MethodInterpretation_SemaphoreSlim_WaitRelease2.json
+++ b/src/Tests/SharpDetect.E2ETests/MethodInterpretationTestConfigurations/MethodInterpretation_SemaphoreSlim_WaitRelease2.json
@@ -1,0 +1,21 @@
+{
+  "Target": {
+    "Path": "../../../../SharpDetect.E2ETests.Subject/bin/%BUILD_CONFIGURATION%/%SDK%/SharpDetect.E2ETests.Subject.dll",
+    "Args": "Test_SemaphoreSlimMethods_WaitRelease2",
+    "RedirectInputOutput": {
+      "SingleConsoleMode": true
+    }
+  },
+  "Runtime": {
+    "Profiler": {
+      "LogLevel": "Information"
+    }
+  },
+  "Analysis": {
+    "Path": "SharpDetect.E2ETests.dll",
+    "PluginFullTypeName": "SharpDetect.E2ETests.Utils.TestExecutionOrderingPlugin",
+    "RenderReport": false,
+    "LogLevel": "Information"
+  }
+}
+

--- a/src/Tests/SharpDetect.E2ETests/MethodInterpretationTestConfigurations/MethodInterpretation_SemaphoreSlim_WaitRelease3.json
+++ b/src/Tests/SharpDetect.E2ETests/MethodInterpretationTestConfigurations/MethodInterpretation_SemaphoreSlim_WaitRelease3.json
@@ -1,0 +1,21 @@
+{
+  "Target": {
+    "Path": "../../../../SharpDetect.E2ETests.Subject/bin/%BUILD_CONFIGURATION%/%SDK%/SharpDetect.E2ETests.Subject.dll",
+    "Args": "Test_SemaphoreSlimMethods_WaitRelease3",
+    "RedirectInputOutput": {
+      "SingleConsoleMode": true
+    }
+  },
+  "Runtime": {
+    "Profiler": {
+      "LogLevel": "Information"
+    }
+  },
+  "Analysis": {
+    "Path": "SharpDetect.E2ETests.dll",
+    "PluginFullTypeName": "SharpDetect.E2ETests.Utils.TestExecutionOrderingPlugin",
+    "RenderReport": false,
+    "LogLevel": "Information"
+  }
+}
+

--- a/src/Tests/SharpDetect.E2ETests/MethodInterpretationTests.cs
+++ b/src/Tests/SharpDetect.E2ETests/MethodInterpretationTests.cs
@@ -305,6 +305,75 @@ public class MethodInterpretationTests(ITestOutputHelper testOutput)
     }
 
     [Theory]
+    [InlineData($"{ConfigurationFolder}/MethodInterpretation_SemaphoreSlim_WaitRelease1.json", "net8.0")]
+    [InlineData($"{ConfigurationFolder}/MethodInterpretation_SemaphoreSlim_WaitRelease1.json", "net9.0")]
+    [InlineData($"{ConfigurationFolder}/MethodInterpretation_SemaphoreSlim_WaitRelease1.json", "net10.0")]
+    [InlineData($"{ConfigurationFolder}/MethodInterpretation_SemaphoreSlim_WaitRelease2.json", "net8.0")]
+    [InlineData($"{ConfigurationFolder}/MethodInterpretation_SemaphoreSlim_WaitRelease2.json", "net9.0")]
+    [InlineData($"{ConfigurationFolder}/MethodInterpretation_SemaphoreSlim_WaitRelease2.json", "net10.0")]
+    [InlineData($"{ConfigurationFolder}/MethodInterpretation_SemaphoreSlim_WaitRelease3.json", "net8.0")]
+    [InlineData($"{ConfigurationFolder}/MethodInterpretation_SemaphoreSlim_WaitRelease3.json", "net9.0")]
+    [InlineData($"{ConfigurationFolder}/MethodInterpretation_SemaphoreSlim_WaitRelease3.json", "net10.0")]
+    public async Task MethodInterpretation_SemaphoreSlim_WaitRelease(string configuration, string sdk)
+    {
+        // Arrange
+        var pluginAdditionalData = TestPluginAdditionalData.CreateWithFieldsAccessInstrumentationDisabled();
+        using var services = TestContextFactory.CreateServiceProvider(
+            configuration, sdk, pluginAdditionalData, testOutput);
+        var args = services.GetRequiredService<RunCommandArgs>();
+        var plugin = services.GetRequiredService<TestExecutionOrderingPlugin>();
+        var analysisWorker = services.GetRequiredService<IAnalysisWorker>();
+        var events = new TestEventsEnumerable(plugin);
+        var assert = EventuallyMethodEnter(args.Target.Args!, plugin)
+            .Then(EventuallyEventType(RecordedEventType.SemaphoreAcquire))
+            .Then(EventuallyEventType(RecordedEventType.SemaphoreAcquireResult))
+            .Then(EventuallyEventType(RecordedEventType.SemaphoreReleaseResult))
+            .Then(EventuallyMethodExit(args.Target.Args!, plugin));
+
+        // Execute
+        await analysisWorker.ExecuteAsync(CancellationToken.None);
+
+        // Assert
+        Assert.True(AssertStatus.Satisfied == assert.Evaluate(events), assert.GetDiagnosticInfo());
+    }
+
+    [Theory]
+    [InlineData($"{ConfigurationFolder}/MethodInterpretation_SemaphoreSlim_TryWaitRelease1.json", "net8.0")]
+    [InlineData($"{ConfigurationFolder}/MethodInterpretation_SemaphoreSlim_TryWaitRelease1.json", "net9.0")]
+    [InlineData($"{ConfigurationFolder}/MethodInterpretation_SemaphoreSlim_TryWaitRelease1.json", "net10.0")]
+    [InlineData($"{ConfigurationFolder}/MethodInterpretation_SemaphoreSlim_TryWaitRelease2.json", "net8.0")]
+    [InlineData($"{ConfigurationFolder}/MethodInterpretation_SemaphoreSlim_TryWaitRelease2.json", "net9.0")]
+    [InlineData($"{ConfigurationFolder}/MethodInterpretation_SemaphoreSlim_TryWaitRelease2.json", "net10.0")]
+    [InlineData($"{ConfigurationFolder}/MethodInterpretation_SemaphoreSlim_TryWaitRelease3.json", "net8.0")]
+    [InlineData($"{ConfigurationFolder}/MethodInterpretation_SemaphoreSlim_TryWaitRelease3.json", "net9.0")]
+    [InlineData($"{ConfigurationFolder}/MethodInterpretation_SemaphoreSlim_TryWaitRelease3.json", "net10.0")]
+    [InlineData($"{ConfigurationFolder}/MethodInterpretation_SemaphoreSlim_TryWaitRelease4.json", "net8.0")]
+    [InlineData($"{ConfigurationFolder}/MethodInterpretation_SemaphoreSlim_TryWaitRelease4.json", "net9.0")]
+    [InlineData($"{ConfigurationFolder}/MethodInterpretation_SemaphoreSlim_TryWaitRelease4.json", "net10.0")]
+    public async Task MethodInterpretation_SemaphoreSlim_TryWaitRelease(string configuration, string sdk)
+    {
+        // Arrange
+        var pluginAdditionalData = TestPluginAdditionalData.CreateWithFieldsAccessInstrumentationDisabled();
+        using var services = TestContextFactory.CreateServiceProvider(
+            configuration, sdk, pluginAdditionalData, testOutput);
+        var args = services.GetRequiredService<RunCommandArgs>();
+        var plugin = services.GetRequiredService<TestExecutionOrderingPlugin>();
+        var analysisWorker = services.GetRequiredService<IAnalysisWorker>();
+        var events = new TestEventsEnumerable(plugin);
+        var assert = EventuallyMethodEnter(args.Target.Args!, plugin)
+            .Then(EventuallyEventType(RecordedEventType.SemaphoreAcquire))
+            .Then(EventuallyEventType(RecordedEventType.SemaphoreAcquireResult))
+            .Then(EventuallyEventType(RecordedEventType.SemaphoreReleaseResult))
+            .Then(EventuallyMethodExit(args.Target.Args!, plugin));
+
+        // Execute
+        await analysisWorker.ExecuteAsync(CancellationToken.None);
+
+        // Assert
+        Assert.True(AssertStatus.Satisfied == assert.Evaluate(events), assert.GetDiagnosticInfo());
+    }
+
+    [Theory]
     [InlineData($"{ConfigurationFolder}/MethodInterpretation_Task_Await1.json", "net8.0")]
     [InlineData($"{ConfigurationFolder}/MethodInterpretation_Task_Await1.json", "net9.0")]
     [InlineData($"{ConfigurationFolder}/MethodInterpretation_Task_Await1.json", "net10.0")]

--- a/src/Tests/SharpDetect.E2ETests/SharpDetect.E2ETests.csproj
+++ b/src/Tests/SharpDetect.E2ETests/SharpDetect.E2ETests.csproj
@@ -304,6 +304,9 @@
     <None Update="DataRacePluginTestConfigurations\NoDataRace_VolatileExplicitAccess_Instance_ReadWriteNoRace.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="DataRacePluginTestConfigurations\NoDataRace_SemaphoreSlim_ProtectedWriteRead.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="MethodInterpretationTestConfigurations\MethodInterpretation_Task_Await2.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
@@ -320,6 +323,27 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Update="MethodInterpretationTestConfigurations\MethodInterpretation_Task_Wait5.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="MethodInterpretationTestConfigurations\MethodInterpretation_SemaphoreSlim_WaitRelease1.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="MethodInterpretationTestConfigurations\MethodInterpretation_SemaphoreSlim_WaitRelease2.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="MethodInterpretationTestConfigurations\MethodInterpretation_SemaphoreSlim_WaitRelease3.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="MethodInterpretationTestConfigurations\MethodInterpretation_SemaphoreSlim_TryWaitRelease1.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="MethodInterpretationTestConfigurations\MethodInterpretation_SemaphoreSlim_TryWaitRelease2.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="MethodInterpretationTestConfigurations\MethodInterpretation_SemaphoreSlim_TryWaitRelease3.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="MethodInterpretationTestConfigurations\MethodInterpretation_SemaphoreSlim_TryWaitRelease4.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>

--- a/src/Tests/SharpDetect.E2ETests/TestEventsEnumerable.cs
+++ b/src/Tests/SharpDetect.E2ETests/TestEventsEnumerable.cs
@@ -110,6 +110,12 @@ public sealed class TestEventsEnumerable : IEnumerable<IEvent<ulong, RecordedEve
             => _queue.Enqueue(new Event<ulong, RecordedEventType, (RecordedEventMetadata, TaskCompleteArgs)>(GetNextId(), RecordedEventType.TaskComplete, (new RecordedEventMetadata(args.ProcessThreadId.ProcessId, args.ProcessThreadId.ThreadId), args)));
         _plugin.TaskJoinFinished += args
             => _queue.Enqueue(new Event<ulong, RecordedEventType, (RecordedEventMetadata, TaskJoinFinishArgs)>(GetNextId(), RecordedEventType.TaskJoinFinish, (new RecordedEventMetadata(args.ProcessThreadId.ProcessId, args.ProcessThreadId.ThreadId), args)));
+        _plugin.SemaphoreAcquireAttempted += args
+            => _queue.Enqueue(new Event<ulong, RecordedEventType, (RecordedEventMetadata, SemaphoreAcquireAttemptArgs)>(GetNextId(), RecordedEventType.SemaphoreAcquire, (new RecordedEventMetadata(args.ProcessThreadId.ProcessId, args.ProcessThreadId.ThreadId), args)));
+        _plugin.SemaphoreAcquireReturned += args
+            => _queue.Enqueue(new Event<ulong, RecordedEventType, (RecordedEventMetadata, SemaphoreAcquireResultArgs)>(GetNextId(), RecordedEventType.SemaphoreAcquireResult, (new RecordedEventMetadata(args.ProcessThreadId.ProcessId, args.ProcessThreadId.ThreadId), args)));
+        _plugin.SemaphoreReleased += args
+            => _queue.Enqueue(new Event<ulong, RecordedEventType, (RecordedEventMetadata, SemaphoreReleaseArgs)>(GetNextId(), RecordedEventType.SemaphoreReleaseResult, (new RecordedEventMetadata(args.ProcessThreadId.ProcessId, args.ProcessThreadId.ThreadId), args)));
     }
     
     public IEnumerator<IEvent<ulong, RecordedEventType>> GetEnumerator()

--- a/src/Tests/SharpDetect.E2ETests/Utils/TestMethodDescriptors.cs
+++ b/src/Tests/SharpDetect.E2ETests/Utils/TestMethodDescriptors.cs
@@ -95,6 +95,14 @@ internal static class TestMethodDescriptors
             "Test_Field_Volatile_ValueType_Static_Write",
             "Test_Field_Volatile_ValueType_Instance_Read",
             "Test_Field_Volatile_ValueType_Instance_Write",
+            "Test_NoDataRace_SemaphoreSlim_ProtectedWriteRead",
+            "Test_SemaphoreSlimMethods_WaitRelease1",
+            "Test_SemaphoreSlimMethods_WaitRelease2",
+            "Test_SemaphoreSlimMethods_WaitRelease3",
+            "Test_SemaphoreSlimMethods_TryWaitRelease1",
+            "Test_SemaphoreSlimMethods_TryWaitRelease2",
+            "Test_SemaphoreSlimMethods_TryWaitRelease3",
+            "Test_SemaphoreSlimMethods_TryWaitRelease4",
         };
 
         foreach (var methodName in testMethodNames)

--- a/src/Tests/SharpDetect.E2ETests/Utils/TestPluginAdditionalData.cs
+++ b/src/Tests/SharpDetect.E2ETests/Utils/TestPluginAdditionalData.cs
@@ -21,6 +21,7 @@ public record TestPluginAdditionalData(
                     .Concat(LockMethodDescriptors.GetAllMethods())
                     .Concat(ThreadMethodDescriptors.GetAllMethods())
                     .Concat(TaskMethodDescriptors.GetAllMethods())
+                    .Concat(SemaphoreSlimMethodDescriptors.GetAllMethods())
                     .Concat(FieldAccessDescriptors.GetAllMethods())
                     .Concat(TestMethodDescriptors.GetAllTestMethods())
             ],
@@ -35,6 +36,7 @@ public record TestPluginAdditionalData(
                     .Concat(LockMethodDescriptors.GetAllMethods())
                     .Concat(ThreadMethodDescriptors.GetAllMethods())
                     .Concat(TaskMethodDescriptors.GetAllMethods())
+                    .Concat(SemaphoreSlimMethodDescriptors.GetAllMethods())
                     .Concat(FieldAccessDescriptors.GetAllMethods())
                     .Concat(TestMethodDescriptors.GetAllTestMethods())
             ],


### PR DESCRIPTION
This PR adds support for `System.Threading.SemaphoreSlim`'s `Wait` and `Release` method. This primitive is supported for `FastTrackPlugin`