### PR TITLE
Fix review feedback

### DIFF
--- a/src/Extensibility/SharpDetect.Plugins.DataRace.FastTrack/FastTrackDetector.cs
+++ b/src/Extensibility/SharpDetect.Plugins.DataRace.FastTrack/FastTrackDetector.cs
@@ -221,6 +221,8 @@ internal sealed class FastTrackDetector
                     lastAccess,
                     _timeProvider.GetUtcNow().DateTime);
             }
+
+            return null;
         }
 
         var readAccess = _accessTracker.CreateAccessInfo(threadId, moduleId, methodToken, methodOffset, AccessType.Read);
@@ -268,6 +270,8 @@ internal sealed class FastTrackDetector
                     lastAccess,
                     _timeProvider.GetUtcNow().DateTime);
             }
+
+            return null;
         }
 
         var readWriteRace = CheckReadWriteRace(threadId, shadow, threadVc);
@@ -289,6 +293,8 @@ internal sealed class FastTrackDetector
                     lastAccess,
                     _timeProvider.GetUtcNow().DateTime);
             }
+
+            return null;
         }
 
         var writeAccess = _accessTracker.CreateAccessInfo(threadId, moduleId, methodToken, methodOffset, AccessType.Write);

--- a/src/SharpDetect.Cli/Commands/InitCommand.cs
+++ b/src/SharpDetect.Cli/Commands/InitCommand.cs
@@ -23,7 +23,8 @@ public sealed class InitCommand : ICommand
     public async ValueTask ExecuteAsync(IConsole console)
     {
         var handler = new InitCommandHandler(OutputFile, PluginType, TargetPath);
-        await handler.ExecuteAsync(console, CancellationToken.None);
+        var cancellationToken = console.RegisterCancellationHandler();
+        await handler.ExecuteAsync(console, cancellationToken);
     }
 }
 

--- a/src/SharpDetect.Cli/Commands/RunCommand.cs
+++ b/src/SharpDetect.Cli/Commands/RunCommand.cs
@@ -26,7 +26,8 @@ public sealed class RunCommand : ICommand
             Directory.SetCurrentDirectory(workingDirectory);
             var fileName = Path.GetFileName(ArgumentsFile);
             commandHandler = new RunCommandHandler(fileName);
-            await commandHandler.ExecuteAsync(console, CancellationToken.None);
+            var cancellationToken = console.RegisterCancellationHandler();
+            await commandHandler.ExecuteAsync(console, cancellationToken);
         }
         finally
         {

--- a/src/SharpDetect.Cli/Handlers/RunCommandHandler.cs
+++ b/src/SharpDetect.Cli/Handlers/RunCommandHandler.cs
@@ -54,8 +54,11 @@ internal sealed class RunCommandHandler : IDisposable
         var reportSummary = plugin.CreateDiagnostics();
         
         // Persist report summary
-        var reportFullPath = await RenderAndWriteReport(plugin, reportSummary, cancellationToken);
-        await console.Output.WriteLineAsync($"Report stored to file: {Path.GetFullPath(reportFullPath)}.");
+        if (_arguments.Analysis.RenderReport)
+        {
+            var reportFullPath = await RenderAndWriteReport(plugin, reportSummary, cancellationToken);
+            await console.Output.WriteLineAsync($"Report stored to file: {Path.GetFullPath(reportFullPath)}.");
+        }
     }
 
     private Task<string> RenderAndWriteReport(IPlugin plugin, Summary reportSummary, CancellationToken cancellationToken)

--- a/src/SharpDetect.Loader/Services/AssemblyLoadContext.cs
+++ b/src/SharpDetect.Loader/Services/AssemblyLoadContext.cs
@@ -5,14 +5,13 @@ using dnlib.DotNet;
 using Microsoft.Extensions.Logging;
 using OperationResult;
 using SharpDetect.Core.Loader;
-using System.Collections.Concurrent;
 using static OperationResult.Helpers;
 
 namespace SharpDetect.Loader.Services;
 
 internal class AssemblyLoadContext : IAssemblyLoadContext
 {
-    private readonly ConcurrentDictionary<string, AssemblyDef> _assemblies;
+    private readonly Dictionary<string, AssemblyDef> _assemblies;
     private readonly AssemblyResolver _assemblyResolver;
     private readonly ModuleCreationOptions _moduleCreationOptions;
     private readonly ILogger<AssemblyLoadContext> _logger;
@@ -44,6 +43,7 @@ internal class AssemblyLoadContext : IAssemblyLoadContext
                 return Error(AssemblyLoadErrorType.InvalidPath);
 
             assembly = AssemblyDef.Load(path, _moduleCreationOptions);
+            _assemblies.TryAdd(path, assembly);
             _assemblyResolver.AddToCache(assembly);
             return Ok(assembly);
         }

--- a/src/SharpDetect.Loader/Services/ModuleBindContext.cs
+++ b/src/SharpDetect.Loader/Services/ModuleBindContext.cs
@@ -7,7 +7,6 @@ using OperationResult;
 using SharpDetect.Core.Events;
 using SharpDetect.Core.Events.Profiler;
 using SharpDetect.Core.Loader;
-using System.Collections.Concurrent;
 using static OperationResult.Helpers;
 
 namespace SharpDetect.Loader.Services;
@@ -15,8 +14,8 @@ namespace SharpDetect.Loader.Services;
 internal class ModuleBindContext : IModuleBindContext
 {
     private readonly IAssemblyLoadContext _assemblyLoadContext;
-    private readonly ConcurrentDictionary<ModuleEntry, ModuleDef> _modules;
-    private readonly ConcurrentDictionary<uint, ModuleDef> _coreLibraries;
+    private readonly Dictionary<ModuleEntry, ModuleDef> _modules;
+    private readonly Dictionary<uint, ModuleDef> _coreLibraries;
     private readonly ILogger<ModuleBindContext> _logger;
 
     public ModuleBindContext(

--- a/src/SharpDetect.Serialization/Services/ArgumentsParserService.cs
+++ b/src/SharpDetect.Serialization/Services/ArgumentsParserService.cs
@@ -57,20 +57,28 @@ internal sealed class ArgumentsParserService : IArgumentsParser
         var argInfos = MemoryMarshal.Cast<byte, uint>(offsets);
         var arguments = _arrayPool.Rent(argInfos.Length);
 
-        // Read information about arguments and parse them
-        for (var i = 0; i < argInfos.Length; i++)
+        try
         {
-            // Argument index is stored in upper 16 bits
-            var index = (ushort)((argInfos[i] & 0xFFFF0000) >> 16);
-            // Argument size is stored in the lower 16 bits
-            var size = (ushort)(argInfos[i] & 0x0000FFFF);
+            // Read information about arguments and parse them
+            for (var i = 0; i < argInfos.Length; i++)
+            {
+                // Argument index is stored in upper 16 bits
+                var index = (ushort)((argInfos[i] & 0xFFFF0000) >> 16);
+                // Argument size is stored in the lower 16 bits
+                var size = (ushort)(argInfos[i] & 0x0000FFFF);
 
-            // Retrieve argument
-            var argument = ParseArgumentValue(method.Parameters[index].Type, values.Slice(pValues, size));
-            arguments[i] = new(index, argument);
+                // Retrieve argument
+                var argument = ParseArgumentValue(method.Parameters[index].Type, values.Slice(pValues, size));
+                arguments[i] = new(index, argument);
 
-            // Move values pointer
-            pValues += size;
+                // Move values pointer
+                pValues += size;
+            }
+        }
+        catch
+        {
+            _arrayPool.Return(arguments);
+            throw;
         }
 
         return new RuntimeArgumentList(arguments, argInfos.Length);

--- a/src/SharpDetect.Worker/Services/AnalysisWorker.cs
+++ b/src/SharpDetect.Worker/Services/AnalysisWorker.cs
@@ -37,7 +37,7 @@ public sealed class AnalysisWorker : IAnalysisWorker
         _logger = logger;
     }
 
-    public ValueTask ExecuteAsync(CancellationToken cancellationToken)
+    public async ValueTask ExecuteAsync(CancellationToken cancellationToken)
     {
         var configurationPath = GetFullConfigurationPath();
         _logger.LogTrace("Running with arguments: {Arguments}.", _arguments);
@@ -53,13 +53,15 @@ public sealed class AnalysisWorker : IAnalysisWorker
 
             ExecuteAnalysis(targetApplicationProcess.Task, cancellationToken);
             _logger.LogInformation("Terminating analysis of process with PID: {Pid}.", targetApplicationProcess.ProcessId);
+
+            var commandResult = await targetApplicationProcess;
+            if (commandResult.ExitCode != 0)
+                _logger.LogWarning("Target process exited with non-zero exit code: {ExitCode}.", commandResult.ExitCode);
         }
         finally
         {
             CleanupConfigurationFile(configurationPath);
         }
-        
-        return ValueTask.CompletedTask;
     }
     
     private Command BuildTargetApplicationCommand()


### PR DESCRIPTION
This PR fixes a couple of small issues discovered while testing and AI guided review

* Assembly cache was previously never populated. This caused some assemblies being loaded repeatedly.
* We are now logging exit code of analyzed application when it returns something non-zero
* Cancellation tokens are now properly passed into commands
* HTML reports are now rendered and stored only when requested
* Misc changes:
   * Improved storage for assemblies and modules
   * Fixed duplicated memory access info for FastTrack plugin