### PR TITLE
Improve IPQ with better synchronization

### DIFF
--- a/src/SharpDetect.Communication/ServiceCollectionExtensions.cs
+++ b/src/SharpDetect.Communication/ServiceCollectionExtensions.cs
@@ -21,7 +21,8 @@ public static class ServiceCollectionExtensions
             return new ConsumerMemoryMappedQueueOptions(
                 plugin.Configuration.SharedMemoryName,
                 plugin.Configuration.SharedMemoryFile,
-                plugin.Configuration.SharedMemorySize);
+                plugin.Configuration.SharedMemorySize,
+                plugin.Configuration.SharedMemorySemaphoreName);
         });
     }
 }

--- a/src/SharpDetect.Communication/Services/ProfilerCommandSender.cs
+++ b/src/SharpDetect.Communication/Services/ProfilerCommandSender.cs
@@ -8,6 +8,7 @@ using SharpDetect.Core.Communication;
 using SharpDetect.Core.Serialization;
 using SharpDetect.InterProcessQueue;
 using SharpDetect.InterProcessQueue.Configuration;
+using SharpDetect.InterProcessQueue.Synchronization;
 
 namespace SharpDetect.Communication.Services;
 
@@ -23,11 +24,12 @@ internal sealed class ProfilerCommandSender : IProfilerCommandSender, IDisposabl
     
     public ProfilerCommandSender(
         ProducerMemoryMappedQueueOptions options,
+        ISemaphore semaphore,
         IProfilerCommandSerializer commandSerializer,
         ILogger<ProfilerCommandSender> logger)
     {
         _options = options;
-        _producer = new Producer(options);
+        _producer = new Producer(options, semaphore);
         _commandSerializer = commandSerializer;
         _logger = logger;
         _processId = (uint)Environment.ProcessId;
@@ -44,7 +46,7 @@ internal sealed class ProfilerCommandSender : IProfilerCommandSender, IDisposabl
         var command = new ProfilerCommand(new RecordedCommandMetadata(_processId, commandId), commandArgs);
         var serializedCommand = _commandSerializer.Serialize(command);
         
-        var result = _producer.Enqueue(serializedCommand);
+        var result = _producer.TryEnqueue(serializedCommand);
         if (!result.IsError)
             return new CommandId(commandId);
         
@@ -63,7 +65,7 @@ internal sealed class ProfilerCommandSender : IProfilerCommandSender, IDisposabl
         var command = new ProfilerCommand(new RecordedCommandMetadata(_processId, rawCommandId), commandArgs);
         var serializedCommand = _commandSerializer.Serialize(command);
             
-        var result = _producer.Enqueue(serializedCommand);
+        var result = _producer.TryEnqueue(serializedCommand);
         if (!result.IsError)
         {
             commandId = new CommandId(rawCommandId);
@@ -87,7 +89,7 @@ internal sealed class ProfilerCommandSender : IProfilerCommandSender, IDisposabl
         var command = new ProfilerCommand(new RecordedCommandMetadata(_processId, rawCommandId), commandArgs);
         var serializedCommand = _commandSerializer.Serialize(command);
             
-        var result = _producer.Enqueue(serializedCommand, timeout);
+        var result = _producer.TryEnqueue(serializedCommand, timeout);
         if (!result.IsError)
         {
             commandId = new CommandId(rawCommandId);

--- a/src/SharpDetect.Communication/Services/ProfilerCommandSenderProvider.cs
+++ b/src/SharpDetect.Communication/Services/ProfilerCommandSenderProvider.cs
@@ -4,6 +4,7 @@
 using Microsoft.Extensions.DependencyInjection;
 using SharpDetect.Core.Communication;
 using SharpDetect.InterProcessQueue.Configuration;
+using SharpDetect.InterProcessQueue.Synchronization;
 
 namespace SharpDetect.Communication.Services;
 
@@ -16,13 +17,20 @@ internal sealed class ProfilerCommandSenderProvider : IProfilerCommandSenderProv
         _serviceProvider = serviceProvider;
     }
     
-    public IProfilerCommandSender Create(string ipcQueueName, string? ipcQueueFileName, uint size)
+    public IProfilerCommandSender Create(string ipcQueueName, string? ipcQueueFileName, uint size, string semaphoreName)
     {
-        return ActivatorUtilities.CreateInstance<ProfilerCommandSender>(
-            _serviceProvider,
-            new ProducerMemoryMappedQueueOptions(
-                ipcQueueName,
-                ipcQueueFileName,
-                size));
+        var semaphore = InterProcessSemaphore.CreateOrOpen(semaphoreName, isOwner: true);
+        try
+        {
+            return ActivatorUtilities.CreateInstance<ProfilerCommandSender>(
+                _serviceProvider,
+                new ProducerMemoryMappedQueueOptions(ipcQueueName, ipcQueueFileName, size, semaphoreName),
+                semaphore);
+        }
+        catch (Exception)
+        {
+            semaphore.Dispose();
+            throw;
+        }
     }
 }

--- a/src/SharpDetect.Communication/Services/ProfilerEventReceiver.cs
+++ b/src/SharpDetect.Communication/Services/ProfilerEventReceiver.cs
@@ -10,6 +10,7 @@ using SharpDetect.Core.Serialization;
 using SharpDetect.InterProcessQueue;
 using SharpDetect.InterProcessQueue.Configuration;
 using SharpDetect.InterProcessQueue.Memory;
+using SharpDetect.InterProcessQueue.Synchronization;
 
 namespace SharpDetect.Communication.Services;
 
@@ -26,7 +27,9 @@ internal sealed class ProfilerEventReceiver : IProfilerEventReceiver, IDisposabl
         IRecordedEventParser recordedEventParser,
         ILogger<IProfilerEventReceiver> logger)
     {
-        _consumer = new Consumer(options, ArrayPool<byte>.Shared);
+        var semaphore = InterProcessSemaphore.CreateOrOpen(options.SemaphoreName, isOwner: true);
+        _consumer = new Consumer(options, semaphore, ArrayPool<byte>.Shared);
+        _consumer.Clear();
         _recordedEventParser = recordedEventParser;
         _logger = logger;
         _queueFilePath = options.File;
@@ -39,7 +42,26 @@ internal sealed class ProfilerEventReceiver : IProfilerEventReceiver, IDisposabl
     
     public bool TryReceiveNotification([NotNullWhen(true)] out RecordedEvent? recordedEvent)
     {
-        var result = _consumer.Dequeue();
+        var result = _consumer.TryDequeue();
+        if (result.IsError)
+        {
+            recordedEvent = null;
+            return false;
+        }
+
+        if (!TryParseEvent(result.Value, _recordedEventParser, out var parsedEvent))
+        {
+            recordedEvent = null;
+            return false;
+        }
+
+        recordedEvent = parsedEvent;
+        return true;
+    }
+
+    public bool TryReceiveNotification(TimeSpan timeout, [NotNullWhen(true)] out RecordedEvent? recordedEvent)
+    {
+        var result = _consumer.TryDequeue(timeout);
         if (result.IsError)
         {
             recordedEvent = null;

--- a/src/SharpDetect.Core/Communication/IProfilerCommandSenderProvider.cs
+++ b/src/SharpDetect.Core/Communication/IProfilerCommandSenderProvider.cs
@@ -5,5 +5,5 @@ namespace SharpDetect.Core.Communication;
 
 public interface IProfilerCommandSenderProvider
 {
-    IProfilerCommandSender Create(string ipcQueueName, string? ipcQueueFileName, uint size);
+    IProfilerCommandSender Create(string ipcQueueName, string? ipcQueueFileName, uint size, string semaphoreName);
 }

--- a/src/SharpDetect.Core/Communication/IProfilerEventReceiver.cs
+++ b/src/SharpDetect.Core/Communication/IProfilerEventReceiver.cs
@@ -9,4 +9,5 @@ namespace SharpDetect.Core.Communication;
 public interface IProfilerEventReceiver
 {
     bool TryReceiveNotification([NotNullWhen(true)] out RecordedEvent? recordedEvent);
+    bool TryReceiveNotification(TimeSpan timeout, [NotNullWhen(true)] out RecordedEvent? recordedEvent);
 }

--- a/src/SharpDetect.Core/Plugins/PluginBase.cs
+++ b/src/SharpDetect.Core/Plugins/PluginBase.cs
@@ -225,7 +225,8 @@ public abstract class PluginBase : RecordedEventActionVisitorBase, IDisposable
             ipcQueueFileName: Configuration.CommandQueueFile is not null
                 ? $"{Configuration.CommandQueueFile}.{processId}"
                 : null,
-            Configuration.CommandQueueSize);
+            Configuration.CommandQueueSize,
+            semaphoreName: $"{Configuration.CommandSemaphoreName}.{processId}");
         _profilerCommandSenders = _profilerCommandSenders.Add((int)processId, sender);
     }
 

--- a/src/SharpDetect.Core/Plugins/PluginConfiguration.cs
+++ b/src/SharpDetect.Core/Plugins/PluginConfiguration.cs
@@ -11,9 +11,11 @@ public record PluginConfiguration(
     string SharedMemoryName,
     string? SharedMemoryFile,
     uint SharedMemorySize,
+    string SharedMemorySemaphoreName,
     string CommandQueueName,
     string? CommandQueueFile,
     uint CommandQueueSize,
+    string CommandSemaphoreName,
     string? TemporaryFilesFolder,
     object? AdditionalData)
 {
@@ -34,9 +36,11 @@ public record PluginConfiguration(
             SharedMemoryName: "SharpDetect_NotificationsQueue",
             SharedMemoryFile: Path.Combine(tempFolder, "SharpDetect_NotificationsQueue.data"),
             SharedMemorySize: 20_971_520 /* 20 MB */,
+            SharedMemorySemaphoreName: "/SharpDetect_NotificationsQueue_Sem",
             CommandQueueName: "SharpDetect_CommandQueue",
             CommandQueueFile: Path.Combine(tempFolder, "SharpDetect_CommandQueue.data"),
             CommandQueueSize: 1_048_576 /* 1 MB */,
+            CommandSemaphoreName: "/SharpDetect_CommandQueue_Sem",
             temporaryFilesFolder,
             additionalData);
     }
@@ -52,9 +56,11 @@ public record PluginConfiguration(
                 SharedMemoryName,
                 SharedMemoryFile,
                 SharedMemorySize,
+                SharedMemorySemaphoreName,
                 CommandQueueName,
                 CommandQueueFile,
                 CommandQueueSize,
+                CommandSemaphoreName,
                 AdditionalData
             }, _jsonSerializerOptions);
             using var writer = new StreamWriter(fileStream);

--- a/src/SharpDetect.InterProcessQueue/Configuration/ConsumerMemoryMappedQueueOptions.cs
+++ b/src/SharpDetect.InterProcessQueue/Configuration/ConsumerMemoryMappedQueueOptions.cs
@@ -5,8 +5,8 @@ namespace SharpDetect.InterProcessQueue.Configuration;
 
 public sealed record ConsumerMemoryMappedQueueOptions : MemoryMappedQueueOptions
 {
-    public ConsumerMemoryMappedQueueOptions(string name, string? file, long capacity)
-        : base(name, file, capacity)
+    public ConsumerMemoryMappedQueueOptions(string name, string? file, long capacity, string semaphoreName)
+        : base(name, file, capacity, semaphoreName)
     {
 
     }

--- a/src/SharpDetect.InterProcessQueue/Configuration/MemoryMappedQueueOptions.cs
+++ b/src/SharpDetect.InterProcessQueue/Configuration/MemoryMappedQueueOptions.cs
@@ -3,4 +3,4 @@
 
 namespace SharpDetect.InterProcessQueue.Configuration;
 
-public record MemoryMappedQueueOptions(string Name, string? File, long Capacity);
+public record MemoryMappedQueueOptions(string Name, string? File, long Capacity, string SemaphoreName);

--- a/src/SharpDetect.InterProcessQueue/Configuration/ProducerMemoryMappedQueueOptions.cs
+++ b/src/SharpDetect.InterProcessQueue/Configuration/ProducerMemoryMappedQueueOptions.cs
@@ -5,8 +5,8 @@ namespace SharpDetect.InterProcessQueue.Configuration;
 
 public sealed record ProducerMemoryMappedQueueOptions : MemoryMappedQueueOptions
 {
-    public ProducerMemoryMappedQueueOptions(string name, string? file, long capacity)
-        : base(name, file, capacity)
+    public ProducerMemoryMappedQueueOptions(string name, string? file, long capacity, string semaphoreName)
+        : base(name, file, capacity, semaphoreName)
     {
 
     }

--- a/src/SharpDetect.InterProcessQueue/Consumer.cs
+++ b/src/SharpDetect.InterProcessQueue/Consumer.cs
@@ -29,9 +29,7 @@ public sealed class Consumer : IDisposable
 
     internal Consumer(ConsumerMemoryMappedQueueOptions queueOptions, ArrayPool<byte>? arrayPool, TimeProvider timeProvider)
     {
-        _queue = arrayPool != null
-            ? new MemoryMappedQueue(queueOptions, arrayPool)
-            : new MemoryMappedQueue(queueOptions);
+        _queue = new MemoryMappedQueue(queueOptions, arrayPool, timeProvider);
         _timeProvider = timeProvider;
     }
 

--- a/src/SharpDetect.InterProcessQueue/Consumer.cs
+++ b/src/SharpDetect.InterProcessQueue/Consumer.cs
@@ -4,6 +4,7 @@
 using OperationResult;
 using SharpDetect.InterProcessQueue.Configuration;
 using SharpDetect.InterProcessQueue.Memory;
+using SharpDetect.InterProcessQueue.Synchronization;
 using System.Buffers;
 using static OperationResult.Helpers;
 
@@ -12,54 +13,53 @@ namespace SharpDetect.InterProcessQueue;
 public sealed class Consumer : IDisposable
 {
     private readonly MemoryMappedQueue _queue;
-    private readonly TimeProvider _timeProvider;
+    private readonly ISemaphore _semaphore;
     private bool _disposed;
 
-    public Consumer(ConsumerMemoryMappedQueueOptions queueOptions)
-        : this(queueOptions, arrayPool: null, TimeProvider.System)
+    public Consumer(ConsumerMemoryMappedQueueOptions queueOptions, ISemaphore semaphore)
+        : this(queueOptions, semaphore, arrayPool: null, TimeProvider.System)
     {
 
     }
 
-    public Consumer(ConsumerMemoryMappedQueueOptions queueOptions, ArrayPool<byte> arrayPool)
-        : this(queueOptions, arrayPool, TimeProvider.System)
+    public Consumer(ConsumerMemoryMappedQueueOptions queueOptions, ISemaphore semaphore, ArrayPool<byte> arrayPool)
+        : this(queueOptions, semaphore, arrayPool, TimeProvider.System)
     {
 
     }
 
-    internal Consumer(ConsumerMemoryMappedQueueOptions queueOptions, ArrayPool<byte>? arrayPool, TimeProvider timeProvider)
+    internal Consumer(
+        ConsumerMemoryMappedQueueOptions queueOptions,
+        ISemaphore semaphore,
+        ArrayPool<byte>? arrayPool,
+        TimeProvider timeProvider)
     {
         _queue = new MemoryMappedQueue(queueOptions, arrayPool, timeProvider);
-        _timeProvider = timeProvider;
+        _semaphore = semaphore;
     }
 
-    public Result<ILocalMemory<byte>, DequeueErrorType> Dequeue()
+    public void Clear()
+    {
+        _queue.Clear();
+    }
+
+    public Result<ILocalMemory<byte>, DequeueErrorType> TryDequeue()
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
+        if (!_semaphore.TryWait())
+            return Error(DequeueErrorType.NothingToRead);
+
         return _queue.Dequeue();
     }
 
-    public Result<ILocalMemory<byte>, DequeueErrorType> Dequeue(TimeSpan timeout)
+    public Result<ILocalMemory<byte>, DequeueErrorType> TryDequeue(TimeSpan timeout)
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
 
-        if (timeout < TimeSpan.Zero)
+        if (timeout < TimeSpan.Zero || !_semaphore.Wait(timeout))
             return Error(DequeueErrorType.TimeoutExceeded);
 
-        if (timeout == TimeSpan.Zero)
-            return Dequeue();
-
-        var endTimeStamp = _timeProvider.GetUtcNow() + timeout;
-        while (_timeProvider.GetUtcNow() < endTimeStamp)
-        {
-            var result = _queue.Dequeue();
-            if (result.IsSuccess)
-                return Ok(result.Value);
-
-            Thread.Yield();
-        }
-
-        return Error(DequeueErrorType.TimeoutExceeded);
+        return _queue.Dequeue();
     }
 
     public void Dispose()
@@ -69,5 +69,6 @@ public sealed class Consumer : IDisposable
 
         _disposed = true;
         _queue.Dispose();
+        _semaphore.Dispose();
     }
 }

--- a/src/SharpDetect.InterProcessQueue/FFI/Exports.cs
+++ b/src/SharpDetect.InterProcessQueue/FFI/Exports.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Concurrent;
 using System.Runtime.InteropServices;
+using SharpDetect.InterProcessQueue.Synchronization;
 
 namespace SharpDetect.InterProcessQueue.FFI;
 
@@ -14,22 +15,25 @@ internal static unsafe class Exports
     private static int _lastConsumerId;
 
     [UnmanagedCallersOnly(EntryPoint = "ipq_producer_create")]
-    public static nint CreateProducer(nint queueNamePtr, nint fileNamePtr, int size)
+    public static nint CreateProducer(nint queueNamePtr, nint fileNamePtr, nint semaphoreNamePtr, int size)
     {
         var clrQueueName = Marshal.PtrToStringAnsi(queueNamePtr);
         var clrFileName = Marshal.PtrToStringAnsi(fileNamePtr);
-        if (clrQueueName == null)
+        var clrSemaphoreName = Marshal.PtrToStringAnsi(semaphoreNamePtr);
+        if (clrQueueName == null || clrSemaphoreName == null)
             return IntPtr.Zero;
 
-        return CreateProducerImpl(clrQueueName, clrFileName, size);
+        return CreateProducerImpl(clrQueueName, clrFileName, clrSemaphoreName, size);
     }
 
-    internal static nint CreateProducerImpl(string queueName, string? fileName, int size)
+    internal static nint CreateProducerImpl(string queueName, string? fileName, string semaphoreName, int size)
     {
         try
         {
             var id = Interlocked.Increment(ref _lastProducerId);
-            var producer = new Producer(new Configuration.ProducerMemoryMappedQueueOptions(queueName, fileName, size));
+            var configuration = new Configuration.ProducerMemoryMappedQueueOptions(queueName, fileName, size, semaphoreName);
+            var semaphore = InterProcessSemaphore.CreateOrOpen(semaphoreName, isOwner: false);
+            var producer = new Producer(configuration, semaphore);
             _producers.TryAdd(id, producer);
             return id;
         }
@@ -64,7 +68,7 @@ internal static unsafe class Exports
         if (!_producers.TryGetValue(producerHandle, out var producer))
             return EnqueueErrorType.Unavailable;
 
-        var status = producer.Enqueue(new ReadOnlySpan<byte>(data, size));
+        var status = producer.TryEnqueue(new ReadOnlySpan<byte>(data, size));
         if (status.IsSuccess)
             return EnqueueErrorType.OK;
 
@@ -72,22 +76,25 @@ internal static unsafe class Exports
     }
 
     [UnmanagedCallersOnly(EntryPoint = "ipq_consumer_create")]
-    public static nint CreateConsumer(nint queueNamePtr, nint fileNamePtr, int size)
+    public static nint CreateConsumer(nint queueNamePtr, nint fileNamePtr, nint semaphoreNamePtr, int size)
     {
         var clrQueueName = Marshal.PtrToStringAnsi(queueNamePtr);
         var clrFileName = Marshal.PtrToStringAnsi(fileNamePtr);
-        if (clrQueueName == null)
+        var clrSemaphoreName = Marshal.PtrToStringAnsi(semaphoreNamePtr);
+        if (clrQueueName == null || clrSemaphoreName == null)
             return IntPtr.Zero;
 
-        return CreateConsumerImpl(clrQueueName, clrFileName, size);
+        return CreateConsumerImpl(clrQueueName, clrFileName, clrSemaphoreName, size);
     }
 
-    internal static nint CreateConsumerImpl(string queueName, string? fileName, int size)
+    internal static nint CreateConsumerImpl(string queueName, string? fileName, string semaphoreName, int size)
     {
         try
         {
             var id = Interlocked.Increment(ref _lastConsumerId);
-            var consumer = new Consumer(new Configuration.ConsumerMemoryMappedQueueOptions(queueName, fileName, size));
+            var configuration = new Configuration.ConsumerMemoryMappedQueueOptions(queueName, fileName, size, semaphoreName);
+            var semaphore = InterProcessSemaphore.CreateOrOpen(semaphoreName, isOwner: false);
+            var consumer = new Consumer(configuration, semaphore);
             _consumers.TryAdd(id, consumer);
             return id;
         }
@@ -123,7 +130,7 @@ internal static unsafe class Exports
         if (!_consumers.TryGetValue(consumerHandle, out var consumer))
             return DequeueErrorType.UnableToAcquireReadLock;
 
-        var result = consumer.Dequeue();
+        var result = consumer.TryDequeue();
         if (!result.IsSuccess)
             return result.Error;
 

--- a/src/SharpDetect.InterProcessQueue/Memory/CircularBuffer.cs
+++ b/src/SharpDetect.InterProcessQueue/Memory/CircularBuffer.cs
@@ -1,11 +1,9 @@
 // Copyright 2026 Andrej Čižmárik and Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-using System.Runtime.CompilerServices;
-
 namespace SharpDetect.InterProcessQueue.Memory;
 
-internal unsafe sealed class CircularBuffer
+internal sealed unsafe class CircularBuffer
 {
     private readonly byte* _pointer;
     private readonly long _capacity;
@@ -58,17 +56,6 @@ internal unsafe sealed class CircularBuffer
         Buffer.MemoryCopy(source, _pointer + offset, firstBlockSize, firstBlockSize);
         if (secondBlockSize != 0)
             Buffer.MemoryCopy(source + firstBlockSize, _pointer, secondBlockSize, secondBlockSize);
-    }
-
-    public void Clear()
-    {
-        long elementsToProcess = _capacity;
-        do
-        {
-            uint elementsToProcessStep = (uint)Math.Min(uint.MaxValue, elementsToProcess);
-            Unsafe.InitBlock(_pointer, 0, elementsToProcessStep);
-            elementsToProcess -= elementsToProcessStep;
-        } while (elementsToProcess > 0);
     }
 
     private readonly record struct BlockSizes(long FirstBlockSize, long SecondBlockSize);

--- a/src/SharpDetect.InterProcessQueue/MemoryMappedQueue.cs
+++ b/src/SharpDetect.InterProcessQueue/MemoryMappedQueue.cs
@@ -65,6 +65,18 @@ internal sealed unsafe class MemoryMappedQueue : IDisposable
         Dispose();
     }
 
+    internal void Clear()
+    {
+        var nowTicks = _timeProvider.GetUtcNow().UtcTicks;
+        var header = (QueueHeader*)_sharedMemory.GetPointer();
+        Volatile.Write(ref header->ReadLockToken, 0);
+        Volatile.Write(ref header->WriteLockToken, 0);
+        Volatile.Write(ref header->ReadOffset, 0);
+        Volatile.Write(ref header->WriteOffset, 0);
+        Volatile.Write(ref header->ReadLockAcquiredTimestampTicks, nowTicks);
+        Volatile.Write(ref header->WriteLockAcquiredTimestampTicks, nowTicks);
+    }
+
     public Status<EnqueueErrorType> Enqueue(ReadOnlySpan<byte> data)
     {
         var header = GetHeader();

--- a/src/SharpDetect.InterProcessQueue/MemoryMappedQueue.cs
+++ b/src/SharpDetect.InterProcessQueue/MemoryMappedQueue.cs
@@ -8,6 +8,7 @@ using System.Buffers;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using SharpDetect.InterProcessQueue.Synchronization;
 using static OperationResult.Helpers;
 
 namespace SharpDetect.InterProcessQueue;
@@ -35,7 +36,7 @@ internal sealed unsafe class MemoryMappedQueue : IDisposable
 
     }
 
-    private MemoryMappedQueue(MemoryMappedQueueOptions options, ArrayPool<byte>? arrayPool, TimeProvider timeProvider)
+    internal MemoryMappedQueue(MemoryMappedQueueOptions options, ArrayPool<byte>? arrayPool, TimeProvider timeProvider)
     {
         _options = options;
         var headerSize = Unsafe.SizeOf<QueueHeader>();
@@ -67,13 +68,12 @@ internal sealed unsafe class MemoryMappedQueue : IDisposable
     public Status<EnqueueErrorType> Enqueue(ReadOnlySpan<byte> data)
     {
         var header = GetHeader();
-        var timestampUtc = _timeProvider.GetUtcNow();
-        var timestampUtcTicks = timestampUtc.UtcTicks;
+        var token = LockToken.Next();
         var lockAcquired = false;
 
         try
         {
-            lockAcquired = TryAcquireLock(timestampUtc, ref header->WriteLockTimeStampTicksUtc);
+            lockAcquired = TryAcquireLock(token, ref header->WriteLockToken, ref header->WriteLockAcquiredTimestampTicks);
             if (!lockAcquired)
                 return Error(EnqueueErrorType.UnableToAcquireWriteLock);
 
@@ -94,7 +94,7 @@ internal sealed unsafe class MemoryMappedQueue : IDisposable
         {
             if (lockAcquired)
             {
-                if (Interlocked.CompareExchange(ref header->WriteLockTimeStampTicksUtc, 0, timestampUtcTicks) != timestampUtcTicks)
+                if (Interlocked.CompareExchange(ref header->WriteLockToken, 0, token) != token)
                     ThrowDataCorruptionDetected();
             }
         }
@@ -105,13 +105,12 @@ internal sealed unsafe class MemoryMappedQueue : IDisposable
     public Result<ILocalMemory<byte>, DequeueErrorType> Dequeue()
     {
         var header = GetHeader();
-        var timestampUtc = _timeProvider.GetUtcNow();
-        var timestampUtcTicks = timestampUtc.UtcTicks;
+        var token = LockToken.Next();
         var lockAcquired = false;
 
         try
         {
-            lockAcquired = TryAcquireLock(timestampUtc, ref header->ReadLockTimeStampTicksUtc);
+            lockAcquired = TryAcquireLock(token, ref header->ReadLockToken, ref header->ReadLockAcquiredTimestampTicks);
             if (!lockAcquired)
                 return Error(DequeueErrorType.UnableToAcquireReadLock);
 
@@ -144,30 +143,30 @@ internal sealed unsafe class MemoryMappedQueue : IDisposable
         {
             if (lockAcquired)
             {
-                if (Interlocked.CompareExchange(ref header->ReadLockTimeStampTicksUtc, 0, timestampUtcTicks) != timestampUtcTicks)
+                if (Interlocked.CompareExchange(ref header->ReadLockToken, 0, token) != token)
                     ThrowDataCorruptionDetected();
             }
         }
     }
 
-    private bool TryAcquireLock(DateTimeOffset timestampUtc, ref long lockField)
+    private bool TryAcquireLock(long token, ref long lockTokenField, ref long lockTimestampField)
     {
-        var timestampUtcTicks = timestampUtc.UtcTicks;
-        var lastLockTimeStamp = Interlocked.CompareExchange(ref lockField, timestampUtcTicks, 0);
-        if (lastLockTimeStamp != 0)
+        var now = _timeProvider.GetUtcNow();
+        var prevToken = Interlocked.CompareExchange(ref lockTokenField, token, 0);
+        if (prevToken != 0)
         {
             // Could not acquire lock - check if the previous lock can be invalidated
-            var lastLockDuration = timestampUtc - new DateTimeOffset(ticks: lastLockTimeStamp, offset: TimeSpan.Zero);
-            if (lastLockDuration <= _maxLockDuration)
+            var prevTimestamp = Volatile.Read(ref lockTimestampField);
+            var prevLockAge = now - new DateTimeOffset(ticks: prevTimestamp, offset: TimeSpan.Zero);
+            if (prevLockAge <= _maxLockDuration)
             {
                 // Lock is still valid
                 return false;
             }
             else
             {
-                // Attempt to clear previous lock and acquire for ourselves
-                var result = Interlocked.CompareExchange(ref lockField, timestampUtcTicks, lastLockTimeStamp);
-                if (result != lastLockTimeStamp)
+                // Attempt to steal the stale lock: replace the old token with ours
+                if (Interlocked.CompareExchange(ref lockTokenField, token, prevToken) != prevToken)
                 {
                     // Somebody was faster to acquire the lock
                     return false;
@@ -175,6 +174,8 @@ internal sealed unsafe class MemoryMappedQueue : IDisposable
             }
         }
 
+        // Record acquisition timestamp for stale-lock detection by other processes
+        Volatile.Write(ref lockTimestampField, now.UtcTicks);
         return true;
     }
 

--- a/src/SharpDetect.InterProcessQueue/Producer.cs
+++ b/src/SharpDetect.InterProcessQueue/Producer.cs
@@ -21,7 +21,7 @@ public sealed class Producer : IDisposable
 
     internal Producer(MemoryMappedQueueOptions queueOptions, TimeProvider timeProvider)
     {
-        _queue = new MemoryMappedQueue(queueOptions);
+        _queue = new MemoryMappedQueue(queueOptions, null, timeProvider);
         _timeProvider = timeProvider;
     }
 

--- a/src/SharpDetect.InterProcessQueue/Producer.cs
+++ b/src/SharpDetect.InterProcessQueue/Producer.cs
@@ -3,6 +3,7 @@
 
 using OperationResult;
 using SharpDetect.InterProcessQueue.Configuration;
+using SharpDetect.InterProcessQueue.Synchronization;
 using static OperationResult.Helpers;
 
 namespace SharpDetect.InterProcessQueue;
@@ -10,28 +11,33 @@ namespace SharpDetect.InterProcessQueue;
 public sealed class Producer : IDisposable
 {
     private readonly MemoryMappedQueue _queue;
+    private readonly ISemaphore _semaphore;
     private readonly TimeProvider _timeProvider;
     private bool _disposed;
 
-    public Producer(ProducerMemoryMappedQueueOptions queueOptions)
-        : this(queueOptions, TimeProvider.System)
+    public Producer(ProducerMemoryMappedQueueOptions queueOptions, ISemaphore semaphore)
+        : this(queueOptions, semaphore, TimeProvider.System)
     {
 
     }
 
-    internal Producer(MemoryMappedQueueOptions queueOptions, TimeProvider timeProvider)
+    internal Producer(MemoryMappedQueueOptions queueOptions, ISemaphore semaphore, TimeProvider timeProvider)
     {
         _queue = new MemoryMappedQueue(queueOptions, null, timeProvider);
+        _semaphore = semaphore;
         _timeProvider = timeProvider;
     }
 
-    public Status<EnqueueErrorType> Enqueue(ReadOnlySpan<byte> data)
+    public Status<EnqueueErrorType> TryEnqueue(ReadOnlySpan<byte> data)
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
-        return _queue.Enqueue(data);
+        var result = _queue.Enqueue(data);
+        if (result.IsSuccess)
+            _semaphore.Release();
+        return result;
     }
 
-    public Status<EnqueueErrorType> Enqueue(ReadOnlySpan<byte> data, TimeSpan timeout)
+    public Status<EnqueueErrorType> TryEnqueue(ReadOnlySpan<byte> data, TimeSpan timeout)
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
 
@@ -39,14 +45,17 @@ public sealed class Producer : IDisposable
             return Error(EnqueueErrorType.TimeoutExceeded);
 
         if (timeout == TimeSpan.Zero)
-            return Enqueue(data);
+            return TryEnqueue(data);
 
         var endTimeStamp = _timeProvider.GetUtcNow() + timeout;
         while (_timeProvider.GetUtcNow() < endTimeStamp)
         {
             var result = _queue.Enqueue(data);
             if (result.IsSuccess)
+            {
+                _semaphore.Release();
                 return Ok();
+            }
 
             Thread.Yield();
         }
@@ -61,5 +70,6 @@ public sealed class Producer : IDisposable
 
         _disposed = true;
         _queue.Dispose();
+        _semaphore.Dispose();
     }
 }

--- a/src/SharpDetect.InterProcessQueue/QueueHeader.cs
+++ b/src/SharpDetect.InterProcessQueue/QueueHeader.cs
@@ -5,7 +5,10 @@ using System.Runtime.InteropServices;
 
 namespace SharpDetect.InterProcessQueue;
 
-[StructLayout(LayoutKind.Explicit, Size = 32)]
+/// <summary>
+/// Header placed at byte 0 of every shared-memory queue region.
+/// </summary>
+[StructLayout(LayoutKind.Explicit, Size = 48)]
 internal struct QueueHeader
 {
     [FieldOffset(0)]
@@ -15,8 +18,14 @@ internal struct QueueHeader
     public long WriteOffset;
 
     [FieldOffset(16)]
-    public long ReadLockTimeStampTicksUtc;
+    public long ReadLockToken;
 
     [FieldOffset(24)]
-    public long WriteLockTimeStampTicksUtc;
+    public long ReadLockAcquiredTimestampTicks;
+
+    [FieldOffset(32)]
+    public long WriteLockToken;
+
+    [FieldOffset(40)]
+    public long WriteLockAcquiredTimestampTicks;
 }

--- a/src/SharpDetect.InterProcessQueue/SharpDetect.InterProcessQueue.csproj
+++ b/src/SharpDetect.InterProcessQueue/SharpDetect.InterProcessQueue.csproj
@@ -7,4 +7,8 @@
   <ItemGroup>
     <PackageReference Include="CSharp.OperationResult" />
   </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="SharpDetect.InterProcessQueue.Tests" />
+  </ItemGroup>
 </Project>

--- a/src/SharpDetect.InterProcessQueue/Synchronization/ISemaphore.cs
+++ b/src/SharpDetect.InterProcessQueue/Synchronization/ISemaphore.cs
@@ -1,0 +1,11 @@
+// Copyright 2026 Andrej Čižmárik and Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+namespace SharpDetect.InterProcessQueue.Synchronization;
+
+public interface ISemaphore : IDisposable
+{
+    bool TryWait();
+    bool Wait(TimeSpan timeout);
+    void Release();
+}

--- a/src/SharpDetect.InterProcessQueue/Synchronization/InterProcessSemaphore.cs
+++ b/src/SharpDetect.InterProcessQueue/Synchronization/InterProcessSemaphore.cs
@@ -1,0 +1,19 @@
+// Copyright 2026 Andrej Čižmárik and Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+using SharpDetect.InterProcessQueue.Synchronization.Linux;
+using SharpDetect.InterProcessQueue.Synchronization.Windows;
+
+namespace SharpDetect.InterProcessQueue.Synchronization;
+
+public static class InterProcessSemaphore
+{
+    public static ISemaphore CreateOrOpen(string name, bool isOwner)
+    {
+        return OperatingSystem.IsLinux()
+            ? LinuxSemaphore.CreateOrOpen(name, isOwner)
+                : OperatingSystem.IsWindows() 
+                ? WindowsSemaphore.CreateOrOpen(name)
+                    : throw new PlatformNotSupportedException();
+    }
+}

--- a/src/SharpDetect.InterProcessQueue/Synchronization/Linux/LinuxSemaphore.cs
+++ b/src/SharpDetect.InterProcessQueue/Synchronization/Linux/LinuxSemaphore.cs
@@ -1,0 +1,63 @@
+// Copyright 2026 Andrej Čižmárik and Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+namespace SharpDetect.InterProcessQueue.Synchronization.Linux;
+
+internal sealed class LinuxSemaphore : ISemaphore
+{
+    private readonly bool _isOwner;
+    private readonly string _name;
+    private IntPtr _handle;
+    private volatile bool _isDisposed;
+    
+    private LinuxSemaphore(IntPtr handle, string name, bool isOwner)
+    {
+        _handle = handle;
+        _name = name;
+        _isOwner = isOwner;
+    }
+
+    public static LinuxSemaphore CreateOrOpen(string name, bool isOwner)
+    {
+        var handle = LinuxSemaphoreInterop.CreateOrOpen(name, initialCount: 0);
+        return new LinuxSemaphore(handle, name, isOwner);
+    }
+
+    ~LinuxSemaphore()
+    {
+        if (!_isDisposed)
+            Dispose();
+    }
+
+    public bool TryWait()
+    {
+        ObjectDisposedException.ThrowIf(_isDisposed, this);
+        return LinuxSemaphoreInterop.TryWait(_handle);
+    }
+    
+    public bool Wait(TimeSpan timeout)
+    {
+        ObjectDisposedException.ThrowIf(_isDisposed, this);
+        return LinuxSemaphoreInterop.Wait(_handle, timeout);
+    }
+
+    public void Release()
+    {
+        ObjectDisposedException.ThrowIf(_isDisposed, this);
+        LinuxSemaphoreInterop.Release(_handle);
+    }
+
+    public void Dispose()
+    {
+        if (_isDisposed)
+            return;
+
+        _isDisposed = true;
+        LinuxSemaphoreInterop.Close(_handle);
+        _handle = IntPtr.Zero;
+        if (_isOwner)
+            LinuxSemaphoreInterop.Unlink(_name);
+        
+        GC.SuppressFinalize(this);
+    }
+}

--- a/src/SharpDetect.InterProcessQueue/Synchronization/Linux/LinuxSemaphoreInterop.cs
+++ b/src/SharpDetect.InterProcessQueue/Synchronization/Linux/LinuxSemaphoreInterop.cs
@@ -1,0 +1,127 @@
+// Copyright 2026 Andrej Čižmárik and Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace SharpDetect.InterProcessQueue.Synchronization.Linux;
+
+internal static partial class LinuxSemaphoreInterop
+{
+    private const string Library = "libc";
+    
+    public static IntPtr CreateOrOpen(string name, uint initialCount)
+    {
+        const int openOrCreateFlag = 0x40;
+        const uint mode = 0x1B6;
+        var handle = SemaphoreOpen(name, openOrCreateFlag, mode, initialCount);
+        // Note: sem_open does not return 0 but rather -1 on failure
+        if (handle != new IntPtr(-1))
+            return handle;
+        
+        ThrowInteropFailed();
+        throw new UnreachableException();
+    }
+
+    public static bool TryWait(IntPtr handle)
+    {
+        const int EAGAIN = 11;
+        var result = SemaphoreTryWait(handle);
+        if (result == 0)
+            return true;
+        
+        var error = Marshal.GetLastPInvokeError();
+        if (error == EAGAIN)
+            return false;
+        
+        ThrowInteropFailed();
+        throw new UnreachableException();
+    }
+    
+    public static bool Wait(IntPtr handle, TimeSpan timeout)
+    {
+        var deadline = DateTimeOffset.UtcNow.Add(timeout);
+        var absTime = new Timespec
+        {
+            tv_sec = deadline.ToUnixTimeSeconds(),
+            tv_nsec = (deadline.Ticks % TimeSpan.TicksPerSecond) * 100
+        };
+
+        const int EINTR = 4;
+        const int ETIMEDOUT = 110;
+        int error;
+        
+        do
+        {
+            var result = SemaphoreTimedWait(handle, ref absTime);
+            if (result == 0)
+                return true;
+
+            error = Marshal.GetLastPInvokeError();
+        } while (error == EINTR);
+
+        if (error == ETIMEDOUT)
+            return false;
+
+        ThrowInteropFailed();
+        throw new UnreachableException();
+    }
+
+    public static void Release(IntPtr handle)
+    {
+        if (SemaphorePost(handle) == 0)
+            return;
+
+        ThrowInteropFailed();
+    }
+
+    public static void Close(IntPtr handle)
+    {
+        if (SemaphoreClose(handle) == 0)
+            return;
+        
+        ThrowInteropFailed();
+    }
+
+    public static void Unlink(string name)
+    {
+        if (SemaphoreUnlink(name) == 0)
+            return;
+        
+        ThrowInteropFailed();
+    }
+    
+    [DoesNotReturn]
+    private static void ThrowInteropFailed([CallerMemberName] string caller = "")
+    {
+        var error = Marshal.GetLastPInvokeError();
+        throw new Exception($"Operation {caller} failed. Error = {error}");
+    }
+    
+    [LibraryImport(Library, EntryPoint = "sem_open", SetLastError = true, StringMarshalling = StringMarshalling.Utf8)]
+    private static partial nint SemaphoreOpen(string name, int flags, uint mode, uint value);
+
+    [LibraryImport(Library, EntryPoint = "sem_post", SetLastError = true)]
+    private static partial int SemaphorePost(nint semaphore);
+
+    [LibraryImport(Library, EntryPoint = "sem_trywait", SetLastError = true)]
+    private static partial int SemaphoreTryWait(nint semaphore);
+    
+    [LibraryImport(Library, EntryPoint = "sem_timedwait", SetLastError = true)]
+    private static partial int SemaphoreTimedWait(nint semaphore, ref Timespec absTime);
+
+    [LibraryImport(Library, EntryPoint = "sem_close", SetLastError = true)]
+    private static partial int SemaphoreClose(nint semaphore);
+
+    [LibraryImport(Library, EntryPoint = "sem_unlink", SetLastError = true, StringMarshalling = StringMarshalling.Utf8)]
+    private static partial int SemaphoreUnlink(string name);
+    
+    [StructLayout(LayoutKind.Sequential)]
+    private struct Timespec
+    {
+        public long tv_sec;
+        public long tv_nsec;
+    }
+}

--- a/src/SharpDetect.InterProcessQueue/Synchronization/LockToken.cs
+++ b/src/SharpDetect.InterProcessQueue/Synchronization/LockToken.cs
@@ -1,0 +1,21 @@
+// Copyright 2026 Andrej Čižmárik and Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+namespace SharpDetect.InterProcessQueue.Synchronization;
+
+/// <summary>
+/// Generates unique 64-bit lock tokens for the shared-memory spin lock.
+/// The token is a composite (upper 32 bits - PID; lower 32 bits - sequence number)
+/// </summary>
+internal static class LockToken
+{
+    private static int _sequenceNumber;
+
+    public static long Next()
+    {
+        // Use uint to avoid negative values after int overflow; sign-extend to long.
+        var sequence = (uint)Interlocked.Increment(ref _sequenceNumber);
+        var pid = (uint)Environment.ProcessId;
+        return (long)((ulong)pid << 32 | sequence);
+    }
+}

--- a/src/SharpDetect.InterProcessQueue/Synchronization/Windows/WindowsSemaphore.cs
+++ b/src/SharpDetect.InterProcessQueue/Synchronization/Windows/WindowsSemaphore.cs
@@ -1,0 +1,57 @@
+// Copyright 2026 Andrej Čižmárik and Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+namespace SharpDetect.InterProcessQueue.Synchronization.Windows;
+
+internal sealed class WindowsSemaphore : ISemaphore
+{
+    private IntPtr _handle;
+    private volatile bool _isDisposed;
+
+    private WindowsSemaphore(IntPtr handle)
+    {
+        _handle = handle;
+    }
+    
+    public static WindowsSemaphore CreateOrOpen(string name)
+    {
+        var handle = WindowsSemaphoreInterop.Open(name, initialCount: 0);
+        return new WindowsSemaphore(handle);
+    }
+    
+    ~WindowsSemaphore()
+    {
+        if (!_isDisposed)
+            Dispose();
+    }
+
+    public bool TryWait()
+    {
+        ObjectDisposedException.ThrowIf(_isDisposed, this);
+        return WindowsSemaphoreInterop.TimedWait(_handle, timeoutMs: 0);
+    }
+    
+    public bool Wait(TimeSpan timeout)
+    {
+        ObjectDisposedException.ThrowIf(_isDisposed, this);
+        return WindowsSemaphoreInterop.TimedWait(_handle, (int)timeout.TotalMilliseconds);
+    }
+
+    public void Release()
+    {
+        ObjectDisposedException.ThrowIf(_isDisposed, this);
+        WindowsSemaphoreInterop.Release(_handle);
+    }
+
+    public void Dispose()
+    {
+        if (_isDisposed)
+            return;
+        
+        _isDisposed = true;
+        WindowsSemaphoreInterop.Close(_handle);
+        _handle = IntPtr.Zero;
+        
+        GC.SuppressFinalize(this);
+    }
+}

--- a/src/SharpDetect.InterProcessQueue/Synchronization/Windows/WindowsSemaphoreInterop.cs
+++ b/src/SharpDetect.InterProcessQueue/Synchronization/Windows/WindowsSemaphoreInterop.cs
@@ -1,0 +1,49 @@
+// Copyright 2026 Andrej Čižmárik and Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Runtime.InteropServices;
+
+namespace SharpDetect.InterProcessQueue.Synchronization.Windows;
+
+internal static partial class WindowsSemaphoreInterop
+{
+    private const string Lib = "kernel32";
+
+    internal static nint Open(string name, int initialCount)
+    {
+        var handle = CreateSemaphore(0, initialCount, int.MaxValue, name);
+        if (handle == 0)
+            throw new InvalidOperationException(
+                $"CreateSemaphoreW(\"{name}\") failed. Error = {Marshal.GetLastPInvokeError()}");
+        return handle;
+    }
+
+    internal static void Release(nint sem)
+    {
+        ReleaseSemaphore(sem, 1, out _);
+    }
+
+    internal static bool TimedWait(nint sem, int timeoutMs)
+    {
+        return WaitForSingleObject(sem, timeoutMs) == 0;
+    }
+
+    internal static void Close(nint sem)
+    {
+        CloseSemaphore(sem);
+    }
+    
+    [LibraryImport(Lib, EntryPoint = "CreateSemaphoreW", SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
+    private static partial nint CreateSemaphore(nint lpSecurityAttributes, int lInitialCount, int lMaximumCount, string? lpName);
+
+    [LibraryImport(Lib, EntryPoint = "ReleaseSemaphore", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static partial bool ReleaseSemaphore(nint hSemaphore, int lReleaseCount, out int lpPreviousCount);
+
+    [LibraryImport(Lib, EntryPoint = "WaitForSingleObject", SetLastError = true)]
+    private static partial uint WaitForSingleObject(nint hHandle, int dwMilliseconds);
+
+    [LibraryImport(Lib, EntryPoint = "CloseHandle", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static partial bool CloseSemaphore(nint hObject);
+}

--- a/src/SharpDetect.Profiler/LibIPC/CMakeLists.txt
+++ b/src/SharpDetect.Profiler/LibIPC/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(SOURCES
 	"Client.cpp"
-	"Messages.cpp")
+	"Messages.cpp"
+	"Semaphore.cpp")
 
 add_library (LibIPC STATIC ${SOURCES})
 

--- a/src/SharpDetect.Profiler/LibIPC/Client.cpp
+++ b/src/SharpDetect.Profiler/LibIPC/Client.cpp
@@ -19,11 +19,15 @@ const std::string LibIPC::Client::_ipqFreeMemorySymbolName = "ipq_free_memory";
 
 
 LibIPC::Client::Client(std::string commandQueueName, std::string commandQueueFile, const UINT commandQueueSize,
-					   std::string eventQueueName, std::string eventQueueFile, const UINT eventQueueSize) :
+					   std::string commandSemaphoreName,
+					   std::string eventQueueName, std::string eventQueueFile, const UINT eventQueueSize,
+					   std::string eventSemaphoreName) :
 	_ipqName(std::move(eventQueueName)),
 	_mmfName(std::move(eventQueueFile)),
+	_eventSemaphoreName(std::move(eventSemaphoreName)),
 	_commandQueueName(std::move(commandQueueName)),
 	_commandMmfName(std::move(commandQueueFile)),
+	_commandSemaphoreName(std::move(commandSemaphoreName)),
 	_ipqModuleHandle(nullptr),
 	_ffiProducer(nullptr),
 	_ffiConsumer(nullptr),
@@ -38,7 +42,9 @@ LibIPC::Client::Client(std::string commandQueueName, std::string commandQueueFil
 	_ipqConsumerCreateSymbolAddress(nullptr),
 	_ipqConsumerDestroySymbolAddress(nullptr),
 	_ipqConsumerDequeueSymbolAddress(nullptr),
-	_ipqFreeMemorySymbolAddress(nullptr)
+	_ipqFreeMemorySymbolAddress(nullptr),
+	_eventSemaphore(InvalidSemaphore),
+	_commandSemaphore(InvalidSemaphore)
 {
 	auto const ipqPathStringPointer = std::getenv("SharpDetect_IPQ_PATH");
 	if (ipqPathStringPointer == nullptr)
@@ -78,7 +84,7 @@ LibIPC::Client::Client(std::string commandQueueName, std::string commandQueueFil
 	
 	// Create producer for events
 	LOG_F(INFO, "IPC event worker configuration: { name: %s, file: %s, size: %d }", _ipqName.c_str(), _mmfName.c_str(), _eventQueueSize);
-	_ffiProducer = reinterpret_cast<ipq_producer_create>(_ipqProducerCreateSymbolAddress)(_ipqName.c_str(), _mmfName.c_str(), _eventQueueSize);
+	_ffiProducer = reinterpret_cast<ipq_producer_create>(_ipqProducerCreateSymbolAddress)(_ipqName.c_str(), _mmfName.c_str(), _eventSemaphoreName.c_str(), _eventQueueSize);
 	if (_ffiProducer == nullptr)
 	{
 		LOG_F(FATAL, "Communication library could not create producer.");
@@ -87,11 +93,26 @@ LibIPC::Client::Client(std::string commandQueueName, std::string commandQueueFil
 
 	// Create consumer for commands
 	LOG_F(INFO, "IPC command worker configuration: { name: %s, file: %s, size: %d }", _commandQueueName.c_str(), _commandMmfName.c_str(), _commandQueueSize);
-	_ffiConsumer = reinterpret_cast<ipq_consumer_create>(_ipqConsumerCreateSymbolAddress)(_commandQueueName.c_str(), _commandMmfName.c_str(), _commandQueueSize);
+	_ffiConsumer = reinterpret_cast<ipq_consumer_create>(_ipqConsumerCreateSymbolAddress)(_commandQueueName.c_str(), _commandMmfName.c_str(), _commandSemaphoreName.c_str(), _commandQueueSize);
 	if (_ffiConsumer == nullptr)
 	{
 		LOG_F(FATAL, "Communication library could not create consumer.");
 		throw std::runtime_error("Could not obtain read access to IPC command queue.");
+	}
+
+	// Open inter-process semaphores (created/owned by the managed side)
+	_eventSemaphore = Semaphore_Open(_eventSemaphoreName);
+	if (_eventSemaphore == InvalidSemaphore)
+	{
+		LOG_F(FATAL, "Could not open event semaphore \"%s\".", _eventSemaphoreName.c_str());
+		throw std::runtime_error("Could not open event semaphore.");
+	}
+
+	_commandSemaphore = Semaphore_Open(_commandSemaphoreName);
+	if (_commandSemaphore == InvalidSemaphore)
+	{
+		LOG_F(FATAL, "Could not open command semaphore \"%s\".", _commandSemaphoreName.c_str());
+		throw std::runtime_error("Could not open command semaphore.");
 	}
 
 	LOG_F(INFO, "Communication library initialized with command receiving enabled.");
@@ -124,6 +145,7 @@ void LibIPC::Client::EventThreadLoop()
 			}
 			while (result != 0);
 
+
 			_eventQueue.pop();
 		}
 	}
@@ -138,15 +160,16 @@ void LibIPC::Client::CommandThreadLoop()
 
 	while (!_terminating)
 	{
+		// Block until the managed producer signals that a command is available (or timeout)
+		if (!Semaphore_TimedWait(_commandSemaphore, 5000))
+			continue;
+
 		BYTE* dataPtr = nullptr;
 		INT size = 0;
 
 		auto result = dequeueFn(_ffiConsumer, &dataPtr, &size);
 		if (result != 0)
-		{
-			std::this_thread::yield();
 			continue;
-		}
 
 		try
 		{
@@ -256,4 +279,9 @@ LibIPC::Client::~Client()
 		reinterpret_cast<ipq_consumer_destroy>(_ipqConsumerDestroySymbolAddress)(_ffiConsumer);
 		_ffiConsumer = nullptr;
 	}
+
+	Semaphore_Close(_eventSemaphore);
+	Semaphore_Close(_commandSemaphore);
+	_eventSemaphore = InvalidSemaphore;
+	_commandSemaphore = InvalidSemaphore;
 }

--- a/src/SharpDetect.Profiler/LibIPC/Client.h
+++ b/src/SharpDetect.Profiler/LibIPC/Client.h
@@ -15,6 +15,7 @@
 #include "Messages.h"
 
 #include "../LibProfiler/PAL.h"
+#include "Semaphore.h"
 
 namespace LibIPC
 {
@@ -30,7 +31,9 @@ namespace LibIPC
 	{
 	public:
 		Client(std::string commandQueueName, std::string commandQueueFile, UINT commandQueueSize,
-			   std::string eventQueueName, std::string eventQueueFile, UINT eventQueueSize);
+			   std::string commandSemaphoreName,
+			   std::string eventQueueName, std::string eventQueueFile, UINT eventQueueSize,
+			   std::string eventSemaphoreName);
 		Client(Client&& other) = delete;
 		Client& operator=(Client&&) = delete;
 		Client(Client& other) = delete;
@@ -65,18 +68,20 @@ namespace LibIPC
 		static const std::string _ipqConsumerDequeueSymbolName;
 		static const std::string _ipqFreeMemorySymbolName;
 
-		using ipq_producer_create = PVOID(*)(const char*, const char*, INT);
+		using ipq_producer_create = PVOID(*)(const char*, const char*, const char*, INT);
 		using ipq_producer_destroy = void (*)(PVOID);
 		using ipq_producer_enqueue = INT(*)(PVOID, BYTE*, INT);
-		using ipq_consumer_create = PVOID(*)(const char*, const char*, INT);
+		using ipq_consumer_create = PVOID(*)(const char*, const char*, const char*, INT);
 		using ipq_consumer_destroy = void (*)(PVOID);
 		using ipq_consumer_dequeue = INT(*)(PVOID, BYTE**, INT*);
 		using ipq_free_memory = void (*)(BYTE*);
 
 		std::string _ipqName;
 		std::string _mmfName;
+		std::string _eventSemaphoreName;
 		std::string _commandQueueName;
 		std::string _commandMmfName;
+		std::string _commandSemaphoreName;
 		MODULE_HANDLE _ipqModuleHandle;
 		PVOID _ffiProducer;
 		PVOID _ffiConsumer;
@@ -98,5 +103,8 @@ namespace LibIPC
 		PVOID _ipqConsumerDestroySymbolAddress;
 		PVOID _ipqConsumerDequeueSymbolAddress;
 		PVOID _ipqFreeMemorySymbolAddress;
+
+		SemaphoreHandle _eventSemaphore;
+		SemaphoreHandle _commandSemaphore;
 	};
 }

--- a/src/SharpDetect.Profiler/LibIPC/Semaphore.cpp
+++ b/src/SharpDetect.Profiler/LibIPC/Semaphore.cpp
@@ -1,0 +1,59 @@
+// Copyright 2026 Andrej Čižmárik and Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "Semaphore.h"
+
+#ifdef _WIN32
+#include <windows.h>
+#else
+#include <semaphore.h>
+#include <time.h>
+#endif
+
+LibIPC::SemaphoreHandle LibIPC::Semaphore_Open(const std::string& name)
+{
+#ifdef _WIN32
+	return OpenSemaphoreA(SEMAPHORE_ALL_ACCESS, FALSE, name.c_str());
+#else
+	const auto handle = sem_open(name.c_str(), 0);
+	return handle == SEM_FAILED ? InvalidSemaphore : handle;
+#endif
+}
+
+void LibIPC::Semaphore_Post(SemaphoreHandle sem)
+{
+#ifdef _WIN32
+	ReleaseSemaphore(sem, 1, nullptr);
+#else
+	sem_post(sem);
+#endif
+}
+
+bool LibIPC::Semaphore_TimedWait(SemaphoreHandle sem, int timeoutMs)
+{
+#ifdef _WIN32
+	return WaitForSingleObject(sem, static_cast<DWORD>(timeoutMs)) == WAIT_OBJECT_0;
+#else
+	struct timespec deadline;
+	clock_gettime(CLOCK_REALTIME, &deadline);
+	deadline.tv_sec += timeoutMs / 1000;
+	deadline.tv_nsec += (timeoutMs % 1000) * 1000000L;
+	if (deadline.tv_nsec >= 1000000000L)
+	{
+		deadline.tv_sec++;
+		deadline.tv_nsec -= 1000000000L;
+	}
+	return sem_timedwait(sem, &deadline) == 0;
+#endif
+}
+
+void LibIPC::Semaphore_Close(SemaphoreHandle sem)
+{
+#ifdef _WIN32
+	if (sem != nullptr)
+		CloseHandle(sem);
+#else
+	if (sem != SEM_FAILED)
+		sem_close(sem);
+#endif
+}

--- a/src/SharpDetect.Profiler/LibIPC/Semaphore.h
+++ b/src/SharpDetect.Profiler/LibIPC/Semaphore.h
@@ -1,0 +1,30 @@
+// Copyright 2026 Andrej Čižmárik and Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <string>
+
+#include "cor.h"
+
+#ifdef _WIN32
+#include <windows.h>
+#else
+#include <semaphore.h>
+#endif
+
+namespace LibIPC
+{
+#ifdef _WIN32
+	using SemaphoreHandle = HANDLE;
+	inline constexpr SemaphoreHandle InvalidSemaphore = nullptr;
+#else
+	using SemaphoreHandle = sem_t*;
+	inline const SemaphoreHandle InvalidSemaphore = SEM_FAILED;
+#endif
+	
+	SemaphoreHandle Semaphore_Open(const std::string& name);
+	void Semaphore_Post(SemaphoreHandle sem);
+	bool Semaphore_TimedWait(SemaphoreHandle sem, int timeoutMs);
+	void Semaphore_Close(SemaphoreHandle sem);
+}

--- a/src/SharpDetect.Profiler/SharpDetect.Concurrency.Profiler/Configuration.cpp
+++ b/src/SharpDetect.Profiler/SharpDetect.Concurrency.Profiler/Configuration.cpp
@@ -12,11 +12,13 @@ void Profiler::to_json(nlohmann::json& json, const Configuration& descriptor)
     if (descriptor.sharedMemoryFile.has_value())
         json["sharedMemoryFile"] = descriptor.sharedMemoryFile.value();
     json["sharedMemorySize"] = descriptor.sharedMemorySize;
+    json["sharedMemorySemaphoreName"] = descriptor.sharedMemorySemaphoreName;
 
     json["commandQueueName"] = descriptor.commandQueueName;
     if (descriptor.commandQueueFile.has_value())
         json["commandQueueFile"] = descriptor.commandQueueFile.value();
     json["commandQueueSize"] = descriptor.commandQueueSize;
+    json["commandSemaphoreName"] = descriptor.commandSemaphoreName;
 
     json["additionalData"]["methodDescriptors"] = descriptor.methodDescriptors;
     json["additionalData"]["typeInjectionDescriptors"] = descriptor.typeInjectionDescriptors;
@@ -36,6 +38,7 @@ void Profiler::from_json(const nlohmann::json& json, Configuration& descriptor)
             descriptor.sharedMemoryFile = sharedMemoryFile;
     }
     descriptor.sharedMemorySize = json.at("sharedMemorySize");
+    descriptor.sharedMemorySemaphoreName = json.at("sharedMemorySemaphoreName");
 
 	descriptor.commandQueueName = json.at("commandQueueName");
 	descriptor.commandQueueName = descriptor.commandQueueName + "." + std::to_string(LibProfiler::PAL_GetCurrentPid());
@@ -49,6 +52,8 @@ void Profiler::from_json(const nlohmann::json& json, Configuration& descriptor)
 		}
     }
     descriptor.commandQueueSize = json.at("commandQueueSize");
+    descriptor.commandSemaphoreName = json.at("commandSemaphoreName");
+    descriptor.commandSemaphoreName = descriptor.commandSemaphoreName + "." + std::to_string(LibProfiler::PAL_GetCurrentPid());
 
     const auto& additionalData = json.at("additionalData");
     descriptor.methodDescriptors = additionalData.at("methodDescriptors").get<std::vector<MethodDescriptor>>();

--- a/src/SharpDetect.Profiler/SharpDetect.Concurrency.Profiler/Configuration.h
+++ b/src/SharpDetect.Profiler/SharpDetect.Concurrency.Profiler/Configuration.h
@@ -22,10 +22,12 @@ namespace Profiler
 		std::string sharedMemoryName;
 		std::optional<std::string> sharedMemoryFile;
 		UINT sharedMemorySize;
+		std::string sharedMemorySemaphoreName;
 
 		std::string commandQueueName;
 		std::optional<std::string> commandQueueFile;
         UINT commandQueueSize;
+        std::string commandSemaphoreName;
 
         std::vector<MethodDescriptor> methodDescriptors;
         std::vector<TypeInjectionDescriptor> typeInjectionDescriptors;

--- a/src/SharpDetect.Profiler/SharpDetect.Concurrency.Profiler/CorProfiler.cpp
+++ b/src/SharpDetect.Profiler/SharpDetect.Concurrency.Profiler/CorProfiler.cpp
@@ -37,9 +37,11 @@ Profiler::CorProfiler::CorProfiler(const Configuration &configuration) :
 		configuration.commandQueueName,
 		configuration.commandQueueFile.value_or(std::string()),
 		configuration.commandQueueSize,
+		configuration.commandSemaphoreName,
         configuration.sharedMemoryName,
         configuration.sharedMemoryFile.value_or(std::string()),
-        configuration.sharedMemorySize),
+        configuration.sharedMemorySize,
+        configuration.sharedMemorySemaphoreName),
     _coreModule(0)
 {
     _terminating = false;

--- a/src/SharpDetect.Worker/Services/AnalysisWorker.cs
+++ b/src/SharpDetect.Worker/Services/AnalysisWorker.cs
@@ -14,6 +14,7 @@ namespace SharpDetect.Worker.Services;
 
 public sealed class AnalysisWorker : IAnalysisWorker
 {
+    private static readonly TimeSpan ProfilerEventReceiveTimeout = TimeSpan.FromMilliseconds(50);
     private readonly RunCommandArgs _arguments;
     private readonly IPlugin _plugin;
     private readonly IPluginHost _pluginHost;
@@ -129,7 +130,7 @@ public sealed class AnalysisWorker : IAnalysisWorker
         RecordedEvent? previousRecordedEvent = null;
         while (!ShouldTerminateAnalysis(targetProcessTask, previousRecordedEvent, cancellationToken))
         {
-            if (!_eventReceiver.TryReceiveNotification(out var currentEvent))
+            if (!_eventReceiver.TryReceiveNotification(ProfilerEventReceiveTimeout, out var currentEvent))
             {
                 previousRecordedEvent = null;
                 continue;

--- a/src/Tests/SharpDetect.InterProcessQueue.Tests/EnqueueDequeueTests.cs
+++ b/src/Tests/SharpDetect.InterProcessQueue.Tests/EnqueueDequeueTests.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using SharpDetect.InterProcessQueue.Configuration;
+using SharpDetect.InterProcessQueue.Synchronization;
 using Xunit;
 
 namespace SharpDetect.InterProcessQueue.Tests;
@@ -12,7 +13,8 @@ public class EnqueueDequeueTests : InterProcessQueueTestsBase
         : base(
             queueName: "SharpDetect_IPQ_EnqueueDequeue_Test_Queue",
             queueFile: "SharpDetect_IPQ_EnqueueDequeue__Test.data",
-            size: 1024 * 1024)
+            size: 1024 * 1024,
+            semaphoreName: "SHARPDETECT_IPQ_EnqueueDequeue_Test_Semaphore")
     {
         
     }
@@ -21,15 +23,15 @@ public class EnqueueDequeueTests : InterProcessQueueTestsBase
     public void InterProcessQueue_Enqueue_SingleMessage_Succeeds()
     {
         // Arrange
-        var producerOptions = new ProducerMemoryMappedQueueOptions(TestQueueName, TestFileName, TestQueueSize);
-        var consumerOptions = new ConsumerMemoryMappedQueueOptions(TestQueueName, TestFileName, TestQueueSize);
-        using var producer = new Producer(producerOptions);
-        using var consumer = new Consumer(consumerOptions);
+        var producerOptions = new ProducerMemoryMappedQueueOptions(TestQueueName, TestFileName, TestQueueSize, TestSemaphoreName);
+        var consumerOptions = new ConsumerMemoryMappedQueueOptions(TestQueueName, TestFileName, TestQueueSize, TestSemaphoreName);
+        using var producer = new Producer(producerOptions, InterProcessSemaphore.CreateOrOpen(TestSemaphoreName, isOwner: true));
+        using var consumer = new Consumer(consumerOptions, InterProcessSemaphore.CreateOrOpen(TestSemaphoreName, isOwner: false));
         
         var message = "Hello, World!"u8.ToArray();
         
         // Act
-        var enqueueResult = producer.Enqueue(message);
+        var enqueueResult = producer.TryEnqueue(message);
         
         // Assert
         Assert.True(enqueueResult.IsSuccess);
@@ -40,16 +42,16 @@ public class EnqueueDequeueTests : InterProcessQueueTestsBase
     public void InterProcessQueue_Dequeue_SingleMessage_ReturnsCorrectData()
     {
         // Arrange
-        var producerOptions = new ProducerMemoryMappedQueueOptions(TestQueueName, TestFileName, TestQueueSize);
-        var consumerOptions = new ConsumerMemoryMappedQueueOptions(TestQueueName, TestFileName, TestQueueSize);
-        using var producer = new Producer(producerOptions);
-        using var consumer = new Consumer(consumerOptions);
+        var producerOptions = new ProducerMemoryMappedQueueOptions(TestQueueName, TestFileName, TestQueueSize, TestSemaphoreName);
+        var consumerOptions = new ConsumerMemoryMappedQueueOptions(TestQueueName, TestFileName, TestQueueSize, TestSemaphoreName);
+        using var producer = new Producer(producerOptions, InterProcessSemaphore.CreateOrOpen(TestSemaphoreName, isOwner: true));
+        using var consumer = new Consumer(consumerOptions, InterProcessSemaphore.CreateOrOpen(TestSemaphoreName, isOwner: false));
         
         var expectedMessage = "Test Message"u8.ToArray();
-        producer.Enqueue(expectedMessage);
+        producer.TryEnqueue(expectedMessage);
         
         // Act
-        var dequeueResult = consumer.Dequeue();
+        var dequeueResult = consumer.TryDequeue();
         
         // Assert
         Assert.True(dequeueResult.IsSuccess);
@@ -64,10 +66,10 @@ public class EnqueueDequeueTests : InterProcessQueueTestsBase
     public void InterProcessQueue_EnqueueDequeue_MultipleMessages_MaintainsOrder()
     {
         // Arrange
-        var producerOptions = new ProducerMemoryMappedQueueOptions(TestQueueName, TestFileName, TestQueueSize);
-        var consumerOptions = new ConsumerMemoryMappedQueueOptions(TestQueueName, TestFileName, TestQueueSize);
-        using var producer = new Producer(producerOptions);
-        using var consumer = new Consumer(consumerOptions);
+        var producerOptions = new ProducerMemoryMappedQueueOptions(TestQueueName, TestFileName, TestQueueSize, TestSemaphoreName);
+        var consumerOptions = new ConsumerMemoryMappedQueueOptions(TestQueueName, TestFileName, TestQueueSize, TestSemaphoreName);
+        using var producer = new Producer(producerOptions, InterProcessSemaphore.CreateOrOpen(TestSemaphoreName, isOwner: true));
+        using var consumer = new Consumer(consumerOptions, InterProcessSemaphore.CreateOrOpen(TestSemaphoreName, isOwner: false));
         
         var messages = new[]
         {
@@ -78,12 +80,12 @@ public class EnqueueDequeueTests : InterProcessQueueTestsBase
         
         // Act
         foreach (var message in messages)
-            producer.Enqueue(message);
+            producer.TryEnqueue(message);
         
         // Assert
         foreach (var message in messages)
         {
-            var dequeueResult = consumer.Dequeue();
+            var dequeueResult = consumer.TryDequeue();
             Assert.True(dequeueResult.IsSuccess);
             
             var memory = dequeueResult.Value;
@@ -98,11 +100,11 @@ public class EnqueueDequeueTests : InterProcessQueueTestsBase
     public void InterProcessQueue_Enqueue_MessageLargerThanQueue_ReturnsNotEnoughMemory()
     {
         // Arrange
-        var producerOptions = new ProducerMemoryMappedQueueOptions(TestQueueName, TestFileName, TestQueueSize);
-        using var producer = new Producer(producerOptions);
+        var producerOptions = new ProducerMemoryMappedQueueOptions(TestQueueName, TestFileName, TestQueueSize, TestSemaphoreName);
+        using var producer = new Producer(producerOptions, InterProcessSemaphore.CreateOrOpen(TestSemaphoreName, isOwner: true));
         
         // Act
-        var result = producer.Enqueue(new byte[TestQueueSize]);
+        var result = producer.TryEnqueue(new byte[TestQueueSize]);
         
         // Assert
         Assert.True(result.IsError);

--- a/src/Tests/SharpDetect.InterProcessQueue.Tests/InitializationTests.cs
+++ b/src/Tests/SharpDetect.InterProcessQueue.Tests/InitializationTests.cs
@@ -1,4 +1,5 @@
 using SharpDetect.InterProcessQueue.Configuration;
+using SharpDetect.InterProcessQueue.Synchronization;
 using Xunit;
 
 namespace SharpDetect.InterProcessQueue.Tests;
@@ -9,7 +10,8 @@ public class InitializationTests : InterProcessQueueTestsBase
         : base(
             queueName: "SharpDetect_IPQ_Initialization_Test_Queue",
             queueFile: "SharpDetect_IPQ_Initialization_Test.data",
-            size: 1024 * 1024)
+            size: 1024 * 1024,
+            semaphoreName: "SHARPDETECT_IPQ_Initialization_Test_Semaphore")
     {
         
     }
@@ -18,13 +20,13 @@ public class InitializationTests : InterProcessQueueTestsBase
     public void InterProcessQueue_Initialize_CreatesEmpty()
     {
         // Arrange
-        var producerOptions = new ProducerMemoryMappedQueueOptions(TestQueueName, TestFileName, TestQueueSize);
-        var consumerOptions = new ConsumerMemoryMappedQueueOptions(TestQueueName, TestFileName, TestQueueSize);
-        using var producer = new Producer(producerOptions);
-        using var consumer = new Consumer(consumerOptions);
+        var producerOptions = new ProducerMemoryMappedQueueOptions(TestQueueName, TestFileName, TestQueueSize, TestSemaphoreName);
+        var consumerOptions = new ConsumerMemoryMappedQueueOptions(TestQueueName, TestFileName, TestQueueSize, TestSemaphoreName);
+        using var producer = new Producer(producerOptions, InterProcessSemaphore.CreateOrOpen(TestSemaphoreName, isOwner: true));
+        using var consumer = new Consumer(consumerOptions, InterProcessSemaphore.CreateOrOpen(TestSemaphoreName, isOwner: false));
         
         // Act
-        var result = consumer.Dequeue();
+        var result = consumer.TryDequeue();
         
         // Assert
         Assert.True(result.IsError);

--- a/src/Tests/SharpDetect.InterProcessQueue.Tests/InterProcessQueueTestsBase.cs
+++ b/src/Tests/SharpDetect.InterProcessQueue.Tests/InterProcessQueueTestsBase.cs
@@ -8,13 +8,15 @@ public abstract class InterProcessQueueTestsBase : IDisposable
     protected readonly string TestQueueName;
     protected readonly string TestFileName;
     protected readonly int TestQueueSize;
+    protected readonly string TestSemaphoreName;
     private bool _disposed;
 
-    protected InterProcessQueueTestsBase(string queueName, string queueFile, int size)
+    protected InterProcessQueueTestsBase(string queueName, string queueFile, int size, string semaphoreName)
     {
         TestQueueName = queueName;
         TestFileName = queueFile;
         TestQueueSize = size;
+        TestSemaphoreName = semaphoreName;
     }
     
     public void Dispose()

--- a/src/Tests/SharpDetect.InterProcessQueue.Tests/InterProcessSemaphoreTests.cs
+++ b/src/Tests/SharpDetect.InterProcessQueue.Tests/InterProcessSemaphoreTests.cs
@@ -1,0 +1,146 @@
+// Copyright 2026 Andrej Čižmárik and Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+using SharpDetect.InterProcessQueue.Synchronization;
+using Xunit;
+
+namespace SharpDetect.InterProcessQueue.Tests;
+
+public class InterProcessSemaphoreTests : IDisposable
+{
+    private const string SemaphoreName = "/SharpDetect_IPQ_Semaphore_Tests";
+    private bool _disposed;
+
+    [Fact]
+    public void InterProcessSemaphore_CreateOrOpen_AsOwner_Succeeds()
+    {
+        // Act & Assert — no exception
+        using var semaphore = InterProcessSemaphore.CreateOrOpen(SemaphoreName, isOwner: true);
+        Assert.NotNull(semaphore);
+    }
+
+    [Fact]
+    public void InterProcessSemaphore_CreateOrOpen_AsNonOwner_Succeeds()
+    {
+        // A non-owner opens (or creates) the same named semaphore
+        using var owner = InterProcessSemaphore.CreateOrOpen(SemaphoreName, isOwner: true);
+        using var nonOwner = InterProcessSemaphore.CreateOrOpen(SemaphoreName, isOwner: false);
+        Assert.NotNull(nonOwner);
+    }
+
+    [Fact]
+    public void InterProcessSemaphore_Wait_AfterRelease_ReturnsTrue()
+    {
+        // Arrange
+        using var semaphore = InterProcessSemaphore.CreateOrOpen(SemaphoreName, isOwner: true);
+
+        // Act
+        semaphore.Release();
+        var acquired = semaphore.Wait(TimeSpan.FromSeconds(5));
+
+        // Assert
+        Assert.True(acquired);
+    }
+
+    [Fact]
+    public void InterProcessSemaphore_Wait_WithoutRelease_TimesOut()
+    {
+        // Arrange
+        using var semaphore = InterProcessSemaphore.CreateOrOpen(SemaphoreName, isOwner: true);
+
+        // Act
+        var acquired = semaphore.Wait(TimeSpan.FromMilliseconds(100));
+
+        // Assert
+        Assert.False(acquired);
+    }
+
+    [Fact]
+    public void InterProcessSemaphore_Release_MultipleTimesAllowsMultipleWaits()
+    {
+        // Arrange
+        using var semaphore = InterProcessSemaphore.CreateOrOpen(SemaphoreName, isOwner: true);
+        const int count = 3;
+
+        // Act
+        for (var i = 0; i < count; i++)
+            semaphore.Release();
+
+        // Assert
+        for (var i = 0; i < count; i++)
+            Assert.True(semaphore.Wait(TimeSpan.FromSeconds(5)));
+
+        // And the next wait should time out
+        Assert.False(semaphore.Wait(TimeSpan.FromMilliseconds(100)));
+    }
+
+    [Fact]
+    public void InterProcessSemaphore_CrossInstance_OwnerReleases_NonOwnerAcquires()
+    {
+        // Arrange
+        using var owner = InterProcessSemaphore.CreateOrOpen(SemaphoreName, isOwner: true);
+        using var nonOwner = InterProcessSemaphore.CreateOrOpen(SemaphoreName, isOwner: false);
+
+        // Act
+        owner.Release();
+        var acquired = nonOwner.Wait(TimeSpan.FromSeconds(5));
+
+        // Assert
+        Assert.True(acquired);
+    }
+
+    [Fact]
+    public void InterProcessSemaphore_CrossInstance_NonOwnerReleases_OwnerAcquires()
+    {
+        // Arrange
+        using var owner = InterProcessSemaphore.CreateOrOpen(SemaphoreName, isOwner: true);
+        using var nonOwner = InterProcessSemaphore.CreateOrOpen(SemaphoreName, isOwner: false);
+
+        // Act
+        nonOwner.Release();
+        var acquired = owner.Wait(TimeSpan.FromSeconds(5));
+
+        // Assert
+        Assert.True(acquired);
+    }
+
+    [Fact]
+    public void InterProcessSemaphore_Dispose_DoesNotThrow()
+    {
+        // Arrange
+        var semaphore = InterProcessSemaphore.CreateOrOpen(SemaphoreName, isOwner: true);
+
+        // Act & Assert — no exception
+        semaphore.Dispose();
+    }
+
+    [Fact]
+    public void InterProcessSemaphore_Dispose_NonOwner_DoesNotThrow()
+    {
+        // Arrange
+        using var owner = InterProcessSemaphore.CreateOrOpen(SemaphoreName, isOwner: true);
+        var nonOwner = InterProcessSemaphore.CreateOrOpen(SemaphoreName, isOwner: false);
+
+        // Non-owner disposes first — should not unlink, so owner can still dispose cleanly
+        nonOwner.Dispose();
+        owner.Dispose();
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+            return;
+
+        _disposed = true;
+
+        // Best-effort cleanup: open as owner to unlink any leftover named semaphore
+        try
+        {
+            using var cleanup = InterProcessSemaphore.CreateOrOpen(SemaphoreName, isOwner: true);
+        }
+        catch
+        {
+            // Ignore — semaphore may already be unlinked by the test
+        }
+    }
+}

--- a/src/Tests/SharpDetect.InterProcessQueue.Tests/LockTokenTests.cs
+++ b/src/Tests/SharpDetect.InterProcessQueue.Tests/LockTokenTests.cs
@@ -1,0 +1,37 @@
+// Copyright 2026 Andrej Čižmárik and Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+using SharpDetect.InterProcessQueue.Synchronization;
+using Xunit;
+
+namespace SharpDetect.InterProcessQueue.Tests;
+
+public class LockTokenTests
+{
+    [Fact]
+    public void LockToken_Next_ReturnsNonZero()
+    {
+        var token = LockToken.Next();
+        Assert.NotEqual(0L, token);
+    }
+
+    [Fact]
+    public void LockToken_Next_TwoConsecutiveCalls_ReturnDifferentValues()
+    {
+        var token1 = LockToken.Next();
+        var token2 = LockToken.Next();
+        Assert.NotEqual(token1, token2);
+    }
+
+    [Fact]
+    public void LockToken_Next_EmbedsPidInUpperBits()
+    {
+        var expectedPid = (uint)Environment.ProcessId;
+        for (var i = 0; i < 100; i++)
+        {
+            var token = LockToken.Next();
+            var embeddedPid = (uint)((ulong)token >> 32);
+            Assert.Equal(expectedPid, embeddedPid);
+        }
+    }
+}


### PR DESCRIPTION
This PR addresses a couple of issues:

- Fixed potential race when 2 processes tried to take IPQ lock in a very similar time
- Fixed CPU busy-wait issue when profiler generates events slower than analyzer processes them