### PR TITLE
Reduce false positives in data race analysis

### DIFF
--- a/src/Extensibility/SharpDetect.Plugins.DataRace.Common/FieldId.cs
+++ b/src/Extensibility/SharpDetect.Plugins.DataRace.Common/FieldId.cs
@@ -3,9 +3,10 @@
 
 using System.Diagnostics;
 using dnlib.DotNet;
+using SharpDetect.Core.Events.Profiler;
 
 namespace SharpDetect.Plugins.DataRace.Common;
 
-[DebuggerDisplay("Process:{ProcessId}/Field:{FieldDef.FullName}")]
-public readonly record struct FieldId(uint ProcessId, FieldDef FieldDef);
+[DebuggerDisplay("Process:{ProcessId}/Module:{ModuleId}/Token:{FieldToken}/Field:{FieldDef.FullName}")]
+public readonly record struct FieldId(uint ProcessId, ModuleId ModuleId, MdToken FieldToken, FieldDef FieldDef);
 

--- a/src/Extensibility/SharpDetect.Plugins.DataRace.Common/FieldResolver.cs
+++ b/src/Extensibility/SharpDetect.Plugins.DataRace.Common/FieldResolver.cs
@@ -14,6 +14,8 @@ public sealed class FieldResolver(IMetadataContext metadataContext, ILogger logg
     private readonly record struct ResolvedFieldInfo(FieldDef FieldDef, FieldFlags Flags);
     private readonly Dictionary<FieldDefOrRef, ResolvedFieldInfo> _resolvedFields = [];
     private TypeRef? _threadStaticAttributeTypeRef;
+    private TypeRef? _compilerGeneratedAttributeTypeRef;
+    private TypeRef? _multicastDelegateTypeRef;
     private TypeRef? _asyncStateMachineTypeRef;
     private TypeRef? _taskTypeRef;
     private TypeRef? _continuationTypeRef;
@@ -63,7 +65,8 @@ public sealed class FieldResolver(IMetadataContext metadataContext, ILogger logg
         return flags.HasFlag(FieldFlags.IsReadOnly) ||
                flags.HasFlag(FieldFlags.IsThreadStatic) ||
                flags.HasFlag(FieldFlags.IsAsyncStateMachineInternalField) ||
-               flags.HasFlag(FieldFlags.IsTaskOrContinuationInternalField);
+               flags.HasFlag(FieldFlags.IsTaskOrContinuationInternalField) ||
+               flags.HasFlag(FieldFlags.IsStaticDelegateType);
     }
 
     private FieldFlags ComputeFieldFlags(FieldDef fieldDef)
@@ -81,6 +84,9 @@ public sealed class FieldResolver(IMetadataContext metadataContext, ILogger logg
 
         if (IsFieldInternalTaskOrContinuationField(fieldDef))
             flags |= FieldFlags.IsTaskOrContinuationInternalField;
+
+        if (IsFieldDelegateCacheInCompilerGeneratedType(fieldDef))
+            flags |= FieldFlags.IsStaticDelegateType;
 
         return flags;
     }
@@ -126,6 +132,44 @@ public sealed class FieldResolver(IMetadataContext metadataContext, ILogger logg
                 return true;
 
             current = current.ResolveTypeDef()?.BaseType;
+        }
+
+        return false;
+    }
+
+    private bool IsFieldDelegateCacheInCompilerGeneratedType(FieldDef fieldDef)
+    {
+        var declaringType = fieldDef.DeclaringType;
+        if (!fieldDef.IsStatic ||
+            fieldDef.IsInitOnly ||
+            !declaringType.IsNested ||
+            declaringType.HasInterfaces)
+        {
+            return false;
+        }
+
+        _compilerGeneratedAttributeTypeRef ??= fieldDef.Module.CorLibTypes
+            .GetTypeRef(
+                @namespace: "System.Runtime.CompilerServices",
+                name: "CompilerGeneratedAttribute");
+
+        var sigComparer = new SigComparer();
+        var hasCompilerGenerated = declaringType.CustomAttributes.Any(a =>
+            sigComparer.Equals(a.AttributeType, _compilerGeneratedAttributeTypeRef));
+
+        if (!hasCompilerGenerated)
+            return false;
+
+        _multicastDelegateTypeRef ??= fieldDef.Module.CorLibTypes
+            .GetTypeRef(@namespace: "System", name: "MulticastDelegate");
+
+        var fieldType = fieldDef.FieldType.ToTypeDefOrRef();
+        while (fieldType != null)
+        {
+            if (sigComparer.Equals(fieldType, _multicastDelegateTypeRef))
+                return true;
+
+            fieldType = fieldType.ResolveTypeDef()?.BaseType;
         }
 
         return false;

--- a/src/Extensibility/SharpDetect.Plugins.DataRace.Eraser/EraserDetector.cs
+++ b/src/Extensibility/SharpDetect.Plugins.DataRace.Eraser/EraserDetector.cs
@@ -115,7 +115,7 @@ internal sealed class EraserDetector
             return null;
 
         // Get or create shadow variable for this field
-        var fieldId = new FieldId(threadId.ProcessId, fieldDef!);
+        var fieldId = new FieldId(threadId.ProcessId, moduleId, fieldToken, fieldDef!);
         var shadow = _shadowMemory.GetOrCreateVirgin(fieldId, objectId);
         var threadLockSet = _threadLockSetTracker.GetLockSet(threadId);
 

--- a/src/Extensibility/SharpDetect.Plugins.DataRace.FastTrack/FastTrackDetector.cs
+++ b/src/Extensibility/SharpDetect.Plugins.DataRace.FastTrack/FastTrackDetector.cs
@@ -174,7 +174,7 @@ internal sealed class FastTrackDetector
         if (!_fieldResolver.TryResolve(threadId.ProcessId, moduleId, fieldToken, out var fieldDef, out _))
             return;
 
-        var fieldId = new FieldId(threadId.ProcessId, fieldDef!);
+        var fieldId = new FieldId(threadId.ProcessId, moduleId, fieldToken, fieldDef!);
         var threadVc = GetOrCreateThreadClock(threadId);
         var volatileVc = GetOrCreateVolatileClock(fieldId, objectId);
         threadVc.Join(volatileVc);
@@ -189,7 +189,7 @@ internal sealed class FastTrackDetector
         if (!_fieldResolver.TryResolve(threadId.ProcessId, moduleId, fieldToken, out var fieldDef, out _))
             return;
 
-        var fieldId = new FieldId(threadId.ProcessId, fieldDef!);
+        var fieldId = new FieldId(threadId.ProcessId, moduleId, fieldToken, fieldDef!);
         var key = (fieldId, objectId);
         var threadVc = GetOrCreateThreadClock(threadId);
         var volatileVc = GetOrCreateVolatileClock(fieldId, objectId);
@@ -212,7 +212,7 @@ internal sealed class FastTrackDetector
             return null;
         }
 
-        var fieldId = new FieldId(threadId.ProcessId, fieldDef!);
+        var fieldId = new FieldId(threadId.ProcessId, moduleId, fieldToken, fieldDef!);
         var shadow = _shadowMemory.GetOrCreateVirgin(fieldId, objectId);
         var threadVc = GetOrCreateThreadClock(threadId);
         
@@ -261,7 +261,7 @@ internal sealed class FastTrackDetector
             return null;
         }
 
-        var fieldId = new FieldId(threadId.ProcessId, fieldDef!);
+        var fieldId = new FieldId(threadId.ProcessId, moduleId, fieldToken, fieldDef!);
         var shadow = _shadowMemory.GetOrCreateVirgin(fieldId, objectId);
         var threadVc = GetOrCreateThreadClock(threadId);
         var currentEpoch = threadVc.GetEpoch(threadId);

--- a/src/SharpDetect.Profiler/LibProfiler/Instrumentation.cpp
+++ b/src/SharpDetect.Profiler/LibProfiler/Instrumentation.cpp
@@ -95,10 +95,10 @@ HRESULT LibProfiler::PatchMethodBody(
 					mdMethodDef,
 					injectedMethods,
 					&nextInstruction)))
-				{
-					isRewritten = true;
-					currentInstruction = nextInstruction;
-				}
+					{
+						isRewritten = true;
+						currentInstruction = nextInstruction;
+					}
 			}
 			// Instance field access
 			if (currentInstruction->m_opcode == CEE_LDFLD || currentInstruction->m_opcode == CEE_STFLD)

--- a/src/Tests/SharpDetect.E2ETests.Subject/Entrypoint.cs
+++ b/src/Tests/SharpDetect.E2ETests.Subject/Entrypoint.cs
@@ -485,6 +485,9 @@ namespace SharpDetect.E2ETests.Subject
                 case nameof(Test_NoDataRace_Task_SequentialTasks_WriteRead):
                     Test_NoDataRace_Task_SequentialTasks_WriteRead();
                     break;
+                case nameof(Test_NoDataRace_GenericType_Static_DifferentInstantiations_WriteWrite_NoRace):
+                    Test_NoDataRace_GenericType_Static_DifferentInstantiations_WriteWrite_NoRace();
+                    break;
                 case nameof(Test_NoDataRace_SemaphoreSlim_ProtectedWriteRead):
                     Test_NoDataRace_SemaphoreSlim_ProtectedWriteRead();
                     break;

--- a/src/Tests/SharpDetect.E2ETests.Subject/Helpers/GenericStaticField.cs
+++ b/src/Tests/SharpDetect.E2ETests.Subject/Helpers/GenericStaticField.cs
@@ -1,0 +1,10 @@
+// Copyright 2026 Andrej Čižmárik and Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+namespace SharpDetect.E2ETests.Subject.Helpers.DataRaces
+{
+    public class GenericStaticField<T>
+    {
+        public static T? Value;
+    }
+}

--- a/src/Tests/SharpDetect.E2ETests.Subject/SimpleTests.cs
+++ b/src/Tests/SharpDetect.E2ETests.Subject/SimpleTests.cs
@@ -1256,6 +1256,13 @@ namespace SharpDetect.E2ETests.Subject
                 sem.Release();
         }
 
+        public static void Test_NoDataRace_GenericType_Static_DifferentInstantiations_WriteWrite_NoRace()
+        {
+            var task1 = Task.Run(() => { GenericStaticField<int>.Value = 42; });
+            var task2 = Task.Run(() => { GenericStaticField<string>.Value = "hello"; });
+            Task.WaitAll(task1, task2);
+        }
+
         public static void Test_NoDataRace_SemaphoreSlim_ProtectedWriteRead()
         {
             var sem = new SemaphoreSlim(1, 1);

--- a/src/Tests/SharpDetect.E2ETests/DataRacePluginTestConfigurations/NoDataRace_GenericType_Static_DifferentInstantiations_WriteWrite_NoRace.json
+++ b/src/Tests/SharpDetect.E2ETests/DataRacePluginTestConfigurations/NoDataRace_GenericType_Static_DifferentInstantiations_WriteWrite_NoRace.json
@@ -1,0 +1,28 @@
+{
+  "Target": {
+    "Path": "../../../../SharpDetect.E2ETests.Subject/bin/%BUILD_CONFIGURATION%/%SDK%/SharpDetect.E2ETests.Subject.dll",
+    "Args": "Test_NoDataRace_GenericType_Static_DifferentInstantiations_WriteWrite_NoRace",
+    "RedirectInputOutput": {
+      "SingleConsoleMode": true
+    }
+  },
+  "Runtime": {
+    "Profiler": {
+      "LogLevel": "Information"
+    }
+  },
+  "Analysis": {
+    "Path": "SharpDetect.E2ETests.dll",
+    "PluginFullTypeName": "SharpDetect.E2ETests.Utils.TestEraserPlugin",
+    "RenderReport": false,
+    "LogLevel": "Information",
+    "Configuration":
+    {
+      "SkipInstrumentationForAssemblies":
+      [
+        "System.",
+        "Microsoft."
+      ]
+    }
+  }
+}

--- a/src/Tests/SharpDetect.E2ETests/DataRacePluginTests.cs
+++ b/src/Tests/SharpDetect.E2ETests/DataRacePluginTests.cs
@@ -297,6 +297,18 @@ public class DataRacePluginTests(ITestOutputHelper testOutput)
     }
 
     [Theory]
+    [InlineData($"{ConfigurationFolder}/{nameof(NoDataRace_GenericType_Static_DifferentInstantiations_WriteWrite_NoRace)}.json", "net8.0", FastTrackPluginFullTypeName)]
+    [InlineData($"{ConfigurationFolder}/{nameof(NoDataRace_GenericType_Static_DifferentInstantiations_WriteWrite_NoRace)}.json", "net8.0", EraserPluginFullTypeName)]
+    [InlineData($"{ConfigurationFolder}/{nameof(NoDataRace_GenericType_Static_DifferentInstantiations_WriteWrite_NoRace)}.json", "net9.0", FastTrackPluginFullTypeName)]
+    [InlineData($"{ConfigurationFolder}/{nameof(NoDataRace_GenericType_Static_DifferentInstantiations_WriteWrite_NoRace)}.json", "net9.0", EraserPluginFullTypeName)]
+    [InlineData($"{ConfigurationFolder}/{nameof(NoDataRace_GenericType_Static_DifferentInstantiations_WriteWrite_NoRace)}.json", "net10.0", FastTrackPluginFullTypeName)]
+    [InlineData($"{ConfigurationFolder}/{nameof(NoDataRace_GenericType_Static_DifferentInstantiations_WriteWrite_NoRace)}.json", "net10.0", EraserPluginFullTypeName)]
+    public Task NoDataRace_GenericType_Static_DifferentInstantiations_WriteWrite_NoRace(string configuration, string sdk, string plugin)
+    {
+        return AssertDoesNotDetectDataRace(configuration, sdk, plugin);
+    }
+
+    [Theory]
     [InlineData($"{ConfigurationFolder}/{nameof(CanRenderReport)}.json", "net10.0", FastTrackPluginFullTypeName)]
     [InlineData($"{ConfigurationFolder}/{nameof(CanRenderReport)}.json", "net10.0", EraserPluginFullTypeName)]
     public async Task CanRenderReport(string configuration, string sdk, string pluginFullTypeName)

--- a/src/Tests/SharpDetect.E2ETests/SharpDetect.E2ETests.csproj
+++ b/src/Tests/SharpDetect.E2ETests/SharpDetect.E2ETests.csproj
@@ -343,6 +343,9 @@
     <None Update="DataRacePluginTestConfigurations\NoDataRace_SemaphoreSlim_ProtectedWriteRead.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="DataRacePluginTestConfigurations\NoDataRace_GenericType_Static_DifferentInstantiations_WriteWrite_NoRace.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="MethodInterpretationTestConfigurations\MethodInterpretation_Task_Await2.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>


### PR DESCRIPTION
This PR identifies 2 common false positive types:

- Cache for delegates (stored in compiler-generated inner class types; in static fields).
   - Benign but technically a data-race. It will be now ignored in analysis.
- Previously static fields were incorrectly modeled in case their declaring type was generic.
   - When generic type declares a static field, there is a single field per instantiation.
   - SharpDetect used to ignore generics and treated static fields as only one global instance (caused false positives)