### PR TITLE
Add GitHub reporting for tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,6 +32,10 @@ jobs:
 
   tests:
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+      actions: read
+      checks: write
     strategy:
       fail-fast: false
       matrix:
@@ -56,3 +60,10 @@ jobs:
         cd src
         dotnet tool restore
         dotnet cake --rid=${{ matrix.rid }} --target=Tests
+    - name: Report test results
+      uses: dorny/test-reporter@v3
+      if: ${{ !cancelled() }}
+      with:
+        name: Tests (${{ matrix.rid }})
+        path: src/TestResults/**/*.trx
+        reporter: dotnet-trx

--- a/src/build.cake
+++ b/src/build.cake
@@ -156,7 +156,9 @@ Task("Tests")
 {
     DotNetTest("./SharpDetect.slnx", new DotNetTestSettings
     {
-        Configuration = configuration
+        Configuration = configuration,
+        Loggers = new[] { "trx" },
+        ResultsDirectory = "./TestResults"
     });
 });
 


### PR DESCRIPTION
This PR integrates `dorny/test-reporter` to create reports from trx collected during testing