### PR TITLE
Improve ordering of synchronization events

### DIFF
--- a/src/Extensibility/SharpDetect.PluginHost/Services/PluginHostFactory.cs
+++ b/src/Extensibility/SharpDetect.PluginHost/Services/PluginHostFactory.cs
@@ -22,9 +22,13 @@ internal sealed class PluginHostFactory
 
     public IPluginHost CreateHost(IPlugin plugin)
     {
-        return new PassthroughPluginHost(
+        var passthrough = new PassthroughPluginHost(
             _recordedEventBindingsCompiler,
             plugin,
             _loggerFactory.CreateLogger<PassthroughPluginHost>());
+
+        return new ReorderingPluginHost(
+            passthrough,
+            _loggerFactory.CreateLogger<ReorderingPluginHost>());
     }
 }

--- a/src/Extensibility/SharpDetect.PluginHost/Services/Strategies/ReorderingPluginHost.cs
+++ b/src/Extensibility/SharpDetect.PluginHost/Services/Strategies/ReorderingPluginHost.cs
@@ -83,10 +83,16 @@ internal sealed class ReorderingPluginHost(IPluginHost inner, ILogger<Reordering
             case RecordedEventType.LockRelease:
             case RecordedEventType.SemaphoreAcquire:
             case RecordedEventType.SemaphoreTryAcquire:
-            case RecordedEventType.SemaphoreRelease:
             case RecordedEventType.TaskJoinStart:
                 thread.SyncTargetStack.Push(ReadTargetId(enter.ArgumentValues, tid.ProcessId));
                 return inner.ProcessEvent(recordedEvent);
+
+            case RecordedEventType.SemaphoreRelease:
+            {
+                thread.SyncTargetStack.Push(ReadTargetId(enter.ArgumentValues, tid.ProcessId));
+                thread.PendingReleaseCount = MemoryMarshal.Read<int>(enter.ArgumentValues.AsSpan()[(byte)nint.Size..]);
+                return inner.ProcessEvent(recordedEvent);
+            }
 
             case RecordedEventType.TaskStart:
             {
@@ -216,8 +222,12 @@ internal sealed class ReorderingPluginHost(IPluginHost inner, ILogger<Reordering
         if (!TryPopTarget(thread, out var semaphoreId))
             return inner.ProcessEvent(recordedEvent);
 
+        var count = thread.PendingReleaseCount!.Value;
+        thread.PendingReleaseCount = null;
+
         var result = inner.ProcessEvent(recordedEvent);
-        EnqueueDrain(_semaphores[semaphoreId].Release(tid));
+        foreach (var waiter in _semaphores[semaphoreId].Release(tid, count))
+            _drainQueue.Enqueue(waiter);
         return result;
     }
 

--- a/src/Extensibility/SharpDetect.PluginHost/Services/Strategies/ReorderingPluginHost.cs
+++ b/src/Extensibility/SharpDetect.PluginHost/Services/Strategies/ReorderingPluginHost.cs
@@ -70,7 +70,8 @@ internal sealed class ReorderingPluginHost(IPluginHost inner, ILogger<Reordering
             {
                 var semaphoreId = ReadTargetId(enter.ArgumentValues, tid.ProcessId);
                 var initialCount = MemoryMarshal.Read<int>(enter.ArgumentValues.AsSpan()[(byte)nint.Size..]);
-                GetOrCreateSemaphore(semaphoreId).Initialize(initialCount);
+                var capacity = MemoryMarshal.Read<int>(enter.ArgumentValues.AsSpan()[((byte)nint.Size + sizeof(int))..]);
+                CreateSemaphore(semaphoreId, initialCount, capacity);
                 return inner.ProcessEvent(recordedEvent);
             }
 
@@ -203,7 +204,7 @@ internal sealed class ReorderingPluginHost(IPluginHost inner, ILogger<Reordering
         if (!TryPeekTarget(thread, out var semaphoreId))
             return inner.ProcessEvent(recordedEvent);
 
-        if (success && !GetOrCreateSemaphore(semaphoreId).TryAcquire(tid))
+        if (success && !_semaphores[semaphoreId].TryAcquire(tid))
             return Defer(thread, semaphoreId);
         
         thread.SyncTargetStack.Pop();
@@ -216,7 +217,7 @@ internal sealed class ReorderingPluginHost(IPluginHost inner, ILogger<Reordering
             return inner.ProcessEvent(recordedEvent);
 
         var result = inner.ProcessEvent(recordedEvent);
-        EnqueueDrain(GetOrCreateSemaphore(semaphoreId).Release(tid));
+        EnqueueDrain(_semaphores[semaphoreId].Release(tid));
         return result;
     }
 
@@ -381,11 +382,9 @@ internal sealed class ReorderingPluginHost(IPluginHost inner, ILogger<Reordering
         return shadow;
     }
 
-    private ShadowSemaphore GetOrCreateSemaphore(ProcessTrackedObjectId semaphoreId)
+    private ShadowSemaphore CreateSemaphore(ProcessTrackedObjectId semaphoreId, int initialCount, int capacity)
     {
-        if (!_semaphores.TryGetValue(semaphoreId, out var shadow))
-            _semaphores[semaphoreId] = shadow = new ShadowSemaphore();
-        return shadow;
+        return _semaphores[semaphoreId] = new ShadowSemaphore(initialCount, capacity);
     }
 
     private ShadowTask GetOrCreateTask(ProcessTrackedObjectId taskId)

--- a/src/Extensibility/SharpDetect.PluginHost/Services/Strategies/ReorderingPluginHost.cs
+++ b/src/Extensibility/SharpDetect.PluginHost/Services/Strategies/ReorderingPluginHost.cs
@@ -19,6 +19,10 @@ internal sealed class ReorderingPluginHost(IPluginHost inner, ILogger<Reordering
     private readonly Queue<ProcessThreadId> _drainQueue = [];
     private bool _isDisposed;
 
+    internal int ShadowLockCount => _locks.Count;
+    internal int ShadowSemaphoreCount => _semaphores.Count;
+    internal int ShadowTaskCount => _tasks.Count;
+
     public RecordedEventState ProcessEvent(RecordedEvent recordedEvent)
     {
         var topResult = ProcessOne(recordedEvent);
@@ -48,6 +52,7 @@ internal sealed class ReorderingPluginHost(IPluginHost inner, ILogger<Reordering
             MethodExitRecordedEvent exit => HandleExit(recordedEvent, exit.Interpretation, tid, thread, returnValue: null),
             MethodExitWithArgumentsRecordedEvent exit => HandleExit(recordedEvent, exit.Interpretation, tid, thread, exit.ReturnValue),
             ThreadDestroyRecordedEvent destroy => HandleThreadDestroy(recordedEvent, destroy),
+            GarbageCollectedTrackedObjectsRecordedEvent gc => HandleGarbageCollectedTrackedObjects(recordedEvent, gc),
             _ => inner.ProcessEvent(recordedEvent)
         };
     }
@@ -329,6 +334,42 @@ internal sealed class ReorderingPluginHost(IPluginHost inner, ILogger<Reordering
         }
 
         _threads.Remove(destroyedTid);
+        return inner.ProcessEvent(recordedEvent);
+    }
+
+    private RecordedEventState HandleGarbageCollectedTrackedObjects(
+        RecordedEvent recordedEvent,
+        GarbageCollectedTrackedObjectsRecordedEvent gc)
+    {
+        var pid = recordedEvent.Metadata.Pid;
+        foreach (var objectId in gc.RemovedTrackedObjectIds)
+        {
+            var key = new ProcessTrackedObjectId(pid, objectId);
+
+            if (_locks.TryGetValue(key, out var shadowLock))
+            {
+                if (shadowLock.TryDescribeResidualState(out var description))
+                    logger.LogWarning("Lock {Lock} garbage collected with residual state: {State}.", key, description);
+                _locks.Remove(key);
+                continue;
+            }
+
+            if (_semaphores.TryGetValue(key, out var shadowSemaphore))
+            {
+                if (shadowSemaphore.TryDescribeResidualState(out var description))
+                    logger.LogWarning("Semaphore {Semaphore} garbage collected with residual state: {State}.", key, description);
+                _semaphores.Remove(key);
+                continue;
+            }
+
+            if (_tasks.TryGetValue(key, out var shadowTask))
+            {
+                if (shadowTask.TryDescribeResidualState(out var description))
+                    logger.LogWarning("Task {Task} garbage collected with residual state: {State}.", key, description);
+                _tasks.Remove(key);
+            }
+        }
+
         return inner.ProcessEvent(recordedEvent);
     }
 

--- a/src/Extensibility/SharpDetect.PluginHost/Services/Strategies/ReorderingPluginHost.cs
+++ b/src/Extensibility/SharpDetect.PluginHost/Services/Strategies/ReorderingPluginHost.cs
@@ -17,6 +17,8 @@ internal sealed class ReorderingPluginHost(IPluginHost inner, ILogger<Reordering
     private readonly Dictionary<ProcessTrackedObjectId, ShadowTask> _tasks = [];
     private readonly Dictionary<ProcessThreadId, ShadowThread> _threads = [];
     private readonly Queue<ProcessThreadId> _drainQueue = [];
+    private readonly HashSet<ProcessTrackedObjectId> _pendingThreadStarts = [];
+    private readonly Dictionary<ProcessTrackedObjectId, ShadowThread> _pendingThreadStartWaiters = [];
     private bool _isDisposed;
 
     internal int ShadowLockCount => _locks.Count;
@@ -44,7 +46,14 @@ internal sealed class ReorderingPluginHost(IPluginHost inner, ILogger<Reordering
     private RecordedEventState ProcessOne(ShadowThread thread, RecordedEvent recordedEvent)
     {
         if (thread.BlockedOn is not null)
+        {
+            if (recordedEvent.EventArgs is MethodEnterWithArgumentsRecordedEvent deferredEnter &&
+                (RecordedEventType)deferredEnter.Interpretation == RecordedEventType.ThreadStartCore)
+            {
+                _pendingThreadStarts.Add(ReadTargetId(deferredEnter.ArgumentValues, thread.Id.ProcessId));
+            }
             return RecordedEventState.Deferred;
+        }
 
         return recordedEvent.EventArgs switch
         {
@@ -118,6 +127,25 @@ internal sealed class ReorderingPluginHost(IPluginHost inner, ILogger<Reordering
                 if (nextWaiter is not null)
                     _drainQueue.Enqueue(nextWaiter.Value);
                 return inner.ProcessEvent(recordedEvent);
+            }
+
+            case RecordedEventType.ThreadStartCore:
+            {
+                var objectId = ReadTargetId(enter.ArgumentValues, tid.ProcessId);
+                _pendingThreadStarts.Remove(objectId);
+                if (_pendingThreadStartWaiters.Remove(objectId, out var childThread))
+                    _drainQueue.Enqueue(childThread.Id);
+                return inner.ProcessEvent(recordedEvent);
+            }
+
+            case RecordedEventType.ThreadStartCallback:
+            {
+                var objectId = ReadTargetId(enter.ArgumentValues, tid.ProcessId);
+                if (!_pendingThreadStarts.Contains(objectId))
+                    return inner.ProcessEvent(recordedEvent);
+                
+                _pendingThreadStartWaiters[objectId] = thread;
+                return Defer(thread, objectId);
             }
 
             default:

--- a/src/Extensibility/SharpDetect.PluginHost/Services/Strategies/ReorderingPluginHost.cs
+++ b/src/Extensibility/SharpDetect.PluginHost/Services/Strategies/ReorderingPluginHost.cs
@@ -61,6 +61,14 @@ internal sealed class ReorderingPluginHost(IPluginHost inner, ILogger<Reordering
         var kind = (RecordedEventType)enter.Interpretation;
         switch (kind)
         {
+            case RecordedEventType.SemaphoreCreate:
+            {
+                var semaphoreId = ReadTargetId(enter.ArgumentValues, tid.ProcessId);
+                var initialCount = MemoryMarshal.Read<int>(enter.ArgumentValues.AsSpan()[(byte)nint.Size..]);
+                GetOrCreateSemaphore(semaphoreId).Initialize(initialCount);
+                return inner.ProcessEvent(recordedEvent);
+            }
+
             case RecordedEventType.MonitorLockAcquire:
             case RecordedEventType.MonitorLockTryAcquire:
             case RecordedEventType.LockAcquire:

--- a/src/Extensibility/SharpDetect.PluginHost/Services/Strategies/ReorderingPluginHost.cs
+++ b/src/Extensibility/SharpDetect.PluginHost/Services/Strategies/ReorderingPluginHost.cs
@@ -25,7 +25,13 @@ internal sealed class ReorderingPluginHost(IPluginHost inner, ILogger<Reordering
 
     public RecordedEventState ProcessEvent(RecordedEvent recordedEvent)
     {
-        var topResult = ProcessOne(recordedEvent);
+        var tid = new ProcessThreadId(recordedEvent.Metadata.Pid, recordedEvent.Metadata.Tid);
+        var thread = GetOrCreateThread(tid);
+        
+        var topResult = ProcessOne(thread, recordedEvent);
+        if (topResult == RecordedEventState.Deferred)
+            thread.EnqueuePendingEvent(recordedEvent);
+        
         if (topResult == RecordedEventState.Failed)
             return RecordedEventState.Failed;
 
@@ -35,68 +41,19 @@ internal sealed class ReorderingPluginHost(IPluginHost inner, ILogger<Reordering
             : topResult;
     }
 
-    private RecordedEventState ProcessOne(RecordedEvent recordedEvent)
+    private RecordedEventState ProcessOne(ShadowThread thread, RecordedEvent recordedEvent)
     {
-        var tid = new ProcessThreadId(recordedEvent.Metadata.Pid, recordedEvent.Metadata.Tid);
-        var thread = GetOrCreateThread(tid);
-
-        if (thread.BlockedOn is not null && ShouldDeferIfBlocked(recordedEvent))
-        {
-            thread.PendingQueue.AddLast(recordedEvent);
+        if (thread.BlockedOn is not null)
             return RecordedEventState.Deferred;
-        }
 
         return recordedEvent.EventArgs switch
         {
-            MethodEnterWithArgumentsRecordedEvent enter => HandleEnter(recordedEvent, enter, tid, thread),
-            MethodExitRecordedEvent exit => HandleExit(recordedEvent, exit.Interpretation, tid, thread, returnValue: null),
-            MethodExitWithArgumentsRecordedEvent exit => HandleExit(recordedEvent, exit.Interpretation, tid, thread, exit.ReturnValue),
+            MethodEnterWithArgumentsRecordedEvent enter => HandleEnter(recordedEvent, enter, thread.Id, thread),
+            MethodExitRecordedEvent exit => HandleExit(recordedEvent, exit.Interpretation, thread.Id, thread, returnValue: null),
+            MethodExitWithArgumentsRecordedEvent exit => HandleExit(recordedEvent, exit.Interpretation, thread.Id, thread, exit.ReturnValue),
             ThreadDestroyRecordedEvent destroy => HandleThreadDestroy(recordedEvent, destroy),
             GarbageCollectedTrackedObjectsRecordedEvent gc => HandleGarbageCollectedTrackedObjects(recordedEvent, gc),
             _ => inner.ProcessEvent(recordedEvent)
-        };
-    }
-
-    // Defer only events that participate in the happens-before (sync operations and shared-memory accesses)
-    private static bool ShouldDeferIfBlocked(RecordedEvent recordedEvent)
-    {
-        if (recordedEvent.EventArgs is not ICustomizableEventType customizable)
-            return false;
-
-        return (RecordedEventType)customizable.Interpretation switch
-        {
-            RecordedEventType.StaticFieldRead or
-            RecordedEventType.StaticFieldWrite or
-            RecordedEventType.InstanceFieldRead or
-            RecordedEventType.InstanceFieldWrite or
-            RecordedEventType.MonitorLockAcquire or
-            RecordedEventType.MonitorLockTryAcquire or
-            RecordedEventType.MonitorLockAcquireResult or
-            RecordedEventType.MonitorLockRelease or
-            RecordedEventType.MonitorLockReleaseResult or
-            RecordedEventType.MonitorWaitAttempt or
-            RecordedEventType.MonitorWaitResult or
-            RecordedEventType.MonitorPulseOneAttempt or
-            RecordedEventType.MonitorPulseOneResult or
-            RecordedEventType.MonitorPulseAllAttempt or
-            RecordedEventType.MonitorPulseAllResult or
-            RecordedEventType.LockAcquire or
-            RecordedEventType.LockTryAcquire or
-            RecordedEventType.LockAcquireResult or
-            RecordedEventType.LockRelease or
-            RecordedEventType.LockReleaseResult or
-            RecordedEventType.SemaphoreAcquire or
-            RecordedEventType.SemaphoreTryAcquire or
-            RecordedEventType.SemaphoreAcquireResult or
-            RecordedEventType.SemaphoreRelease or
-            RecordedEventType.SemaphoreReleaseResult or
-            RecordedEventType.ThreadJoinAttempt or
-            RecordedEventType.ThreadJoinResult or
-            RecordedEventType.TaskStart or
-            RecordedEventType.TaskComplete or
-            RecordedEventType.TaskJoinStart or
-            RecordedEventType.TaskJoinFinish => true,
-            _ => false
         };
     }
 
@@ -180,7 +137,7 @@ internal sealed class ReorderingPluginHost(IPluginHost inner, ILogger<Reordering
                 return HandleReleaseResult(recordedEvent, tid, thread);
 
             case RecordedEventType.MonitorWaitResult:
-                return HandleWaitResult(recordedEvent, tid, thread, ReadBoolOrDefault(returnValue, true));
+                return HandleWaitResult(recordedEvent, tid, thread);
 
             case RecordedEventType.SemaphoreAcquireResult:
                 return HandleSemaphoreAcquireResult(recordedEvent, tid, thread, ReadBoolOrDefault(returnValue, true));
@@ -208,7 +165,7 @@ internal sealed class ReorderingPluginHost(IPluginHost inner, ILogger<Reordering
             return inner.ProcessEvent(recordedEvent);
 
         if (success && !GetOrCreateLock(lockId).TryAcquire(tid))
-            return Defer(thread, lockId, recordedEvent);
+            return Defer(thread, lockId);
         
         thread.SyncTargetStack.Pop();
         return inner.ProcessEvent(recordedEvent);
@@ -226,7 +183,7 @@ internal sealed class ReorderingPluginHost(IPluginHost inner, ILogger<Reordering
         return result;
     }
 
-    private RecordedEventState HandleWaitResult(RecordedEvent recordedEvent, ProcessThreadId tid, ShadowThread thread, bool success)
+    private RecordedEventState HandleWaitResult(RecordedEvent recordedEvent, ProcessThreadId tid, ShadowThread thread)
     {
         if (!TryPeekTarget(thread, out var lockId))
             return inner.ProcessEvent(recordedEvent);
@@ -234,7 +191,7 @@ internal sealed class ReorderingPluginHost(IPluginHost inner, ILogger<Reordering
 
         var suspended = thread.SuspendedWaitCount ?? 1;
         if (!GetOrCreateLock(lockId).TryReacquireAfterWait(tid, suspended))
-            return Defer(thread, lockId, recordedEvent);
+            return Defer(thread, lockId);
         
         thread.SyncTargetStack.Pop();
         thread.SuspendedWaitCount = null;
@@ -247,7 +204,7 @@ internal sealed class ReorderingPluginHost(IPluginHost inner, ILogger<Reordering
             return inner.ProcessEvent(recordedEvent);
 
         if (success && !GetOrCreateSemaphore(semaphoreId).TryAcquire(tid))
-            return Defer(thread, semaphoreId, recordedEvent);
+            return Defer(thread, semaphoreId);
         
         thread.SyncTargetStack.Pop();
         return inner.ProcessEvent(recordedEvent);
@@ -288,7 +245,7 @@ internal sealed class ReorderingPluginHost(IPluginHost inner, ILogger<Reordering
 
         // Only tasks whose start we observed can defer; others like Task.CompletedTask are pass-through
         if (_tasks.TryGetValue(taskId, out var shadow) && shadow.RegisterWaiter(tid))
-            return Defer(thread, taskId, recordedEvent);
+            return Defer(thread, taskId);
 
         thread.SyncTargetStack.Pop();
         return inner.ProcessEvent(recordedEvent);
@@ -381,32 +338,26 @@ internal sealed class ReorderingPluginHost(IPluginHost inner, ILogger<Reordering
             if (!_threads.TryGetValue(tid, out var thread))
                 continue;
 
-            thread.BlockedOn = null;
-            while (thread.BlockedOn is null && thread.PendingQueue.Count > 0)
+            thread.ClearBlockedOn();
+            while (thread.BlockedOn is null && thread.PendingQueueCount > 0)
             {
-                var pendingEvent = thread.PendingQueue.First!.Value;
-                thread.PendingQueue.RemoveFirst();
-                var state = ProcessOne(pendingEvent);
-
+                var pendingEvent = thread.PeekPendingEvent();
+                var state = ProcessOne(thread, pendingEvent);
                 if (state == RecordedEventState.Failed)
                     return RecordedEventState.Failed;
 
-                if (state != RecordedEventState.Deferred)
-                    continue;
+                if (state == RecordedEventState.Deferred)
+                    break;
                 
-                var node = thread.PendingQueue.Last!;
-                thread.PendingQueue.RemoveLast();
-                thread.PendingQueue.AddFirst(node);
-                break;
+                thread.DequeuePendingEvent();
             }
         }
         return RecordedEventState.Executed;
     }
 
-    private static RecordedEventState Defer(ShadowThread thread, ProcessTrackedObjectId target, RecordedEvent recordedEvent)
+    private static RecordedEventState Defer(ShadowThread thread, ProcessTrackedObjectId target)
     {
-        thread.BlockedOn = target;
-        thread.PendingQueue.AddLast(recordedEvent);
+        thread.SetBlockedOn(target);
         return RecordedEventState.Deferred;
     }
 
@@ -419,7 +370,7 @@ internal sealed class ReorderingPluginHost(IPluginHost inner, ILogger<Reordering
     private ShadowThread GetOrCreateThread(ProcessThreadId tid)
     {
         if (!_threads.TryGetValue(tid, out var thread))
-            _threads[tid] = thread = new ShadowThread();
+            _threads[tid] = thread = new ShadowThread(tid, logger);
         return thread;
     }
 

--- a/src/Extensibility/SharpDetect.PluginHost/Services/Strategies/ReorderingPluginHost.cs
+++ b/src/Extensibility/SharpDetect.PluginHost/Services/Strategies/ReorderingPluginHost.cs
@@ -1,0 +1,378 @@
+// Copyright 2026 Andrej Čižmárik and Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Runtime.InteropServices;
+using Microsoft.Extensions.Logging;
+using SharpDetect.Core.Events;
+using SharpDetect.Core.Events.Profiler;
+using SharpDetect.Core.Plugins;
+using SharpDetect.PluginHost.Services.Strategies.Shadows;
+
+namespace SharpDetect.PluginHost.Services.Strategies;
+
+internal sealed class ReorderingPluginHost(IPluginHost inner, ILogger<ReorderingPluginHost> logger) : IPluginHost, IDisposable
+{
+    private readonly Dictionary<ProcessTrackedObjectId, ShadowLock> _locks = [];
+    private readonly Dictionary<ProcessTrackedObjectId, ShadowSemaphore> _semaphores = [];
+    private readonly Dictionary<ProcessTrackedObjectId, ShadowTask> _tasks = [];
+    private readonly Dictionary<ProcessThreadId, ShadowThread> _threads = [];
+    private readonly Queue<ProcessThreadId> _drainQueue = [];
+    private bool _isDisposed;
+
+    public RecordedEventState ProcessEvent(RecordedEvent recordedEvent)
+    {
+        var topResult = ProcessOne(recordedEvent);
+        if (topResult == RecordedEventState.Failed)
+            return RecordedEventState.Failed;
+
+        var drainResult = DrainPendingThreads();
+        return drainResult == RecordedEventState.Failed
+            ? RecordedEventState.Failed
+            : topResult;
+    }
+
+    private RecordedEventState ProcessOne(RecordedEvent recordedEvent)
+    {
+        var tid = new ProcessThreadId(recordedEvent.Metadata.Pid, recordedEvent.Metadata.Tid);
+        var thread = GetOrCreateThread(tid);
+
+        if (thread.BlockedOn is not null)
+        {
+            thread.PendingQueue.AddLast(recordedEvent);
+            return RecordedEventState.Deferred;
+        }
+
+        return recordedEvent.EventArgs switch
+        {
+            MethodEnterWithArgumentsRecordedEvent enter => HandleEnter(recordedEvent, enter, tid, thread),
+            MethodExitRecordedEvent exit => HandleExit(recordedEvent, exit.Interpretation, tid, thread, returnValue: null),
+            MethodExitWithArgumentsRecordedEvent exit => HandleExit(recordedEvent, exit.Interpretation, tid, thread, exit.ReturnValue),
+            ThreadDestroyRecordedEvent destroy => HandleThreadDestroy(recordedEvent, destroy),
+            _ => inner.ProcessEvent(recordedEvent)
+        };
+    }
+
+    private RecordedEventState HandleEnter(
+        RecordedEvent recordedEvent,
+        MethodEnterWithArgumentsRecordedEvent enter,
+        ProcessThreadId tid,
+        ShadowThread thread)
+    {
+        var kind = (RecordedEventType)enter.Interpretation;
+        switch (kind)
+        {
+            case RecordedEventType.MonitorLockAcquire:
+            case RecordedEventType.MonitorLockTryAcquire:
+            case RecordedEventType.LockAcquire:
+            case RecordedEventType.LockTryAcquire:
+            case RecordedEventType.MonitorLockRelease:
+            case RecordedEventType.LockRelease:
+            case RecordedEventType.SemaphoreAcquire:
+            case RecordedEventType.SemaphoreTryAcquire:
+            case RecordedEventType.SemaphoreRelease:
+            case RecordedEventType.TaskJoinStart:
+                thread.SyncTargetStack.Push(ReadTargetId(enter.ArgumentValues, tid.ProcessId));
+                return inner.ProcessEvent(recordedEvent);
+
+            case RecordedEventType.TaskStart:
+            {
+                var taskId = ReadTargetId(enter.ArgumentValues, tid.ProcessId);
+                thread.SyncTargetStack.Push(taskId);
+                GetOrCreateTask(taskId);
+                return inner.ProcessEvent(recordedEvent);
+            }
+
+            case RecordedEventType.MonitorWaitAttempt:
+            {
+                var target = ReadTargetId(enter.ArgumentValues, tid.ProcessId);
+                thread.SyncTargetStack.Push(target);
+                var shadowLock = GetOrCreateLock(target);
+                if (!shadowLock.TryReleaseForWait(tid, out var nextWaiter, out var suspendedCount))
+                    return RecordedEventState.Discarded;
+                
+                thread.SuspendedWaitCount = suspendedCount.Value;
+                if (nextWaiter is not null)
+                    _drainQueue.Enqueue(nextWaiter.Value);
+                return inner.ProcessEvent(recordedEvent);
+            }
+
+            default:
+                return inner.ProcessEvent(recordedEvent);
+        }
+    }
+
+    private RecordedEventState HandleExit(
+        RecordedEvent recordedEvent,
+        ushort interpretation,
+        ProcessThreadId tid,
+        ShadowThread thread,
+        byte[]? returnValue)
+    {
+        var kind = (RecordedEventType)interpretation;
+        switch (kind)
+        {
+            case RecordedEventType.MonitorLockAcquireResult:
+            case RecordedEventType.LockAcquireResult:
+                return HandleAcquireResult(recordedEvent, tid, thread, ReadBoolOrDefault(returnValue, true));
+
+            case RecordedEventType.MonitorLockReleaseResult:
+            case RecordedEventType.LockReleaseResult:
+                return HandleReleaseResult(recordedEvent, tid, thread);
+
+            case RecordedEventType.MonitorWaitResult:
+                return HandleWaitResult(recordedEvent, tid, thread, ReadBoolOrDefault(returnValue, true));
+
+            case RecordedEventType.SemaphoreAcquireResult:
+                return HandleSemaphoreAcquireResult(recordedEvent, tid, thread, ReadBoolOrDefault(returnValue, true));
+
+            case RecordedEventType.SemaphoreReleaseResult:
+                return HandleSemaphoreReleaseResult(recordedEvent, thread);
+
+            case RecordedEventType.TaskComplete:
+                return HandleTaskComplete(recordedEvent, thread);
+
+            case RecordedEventType.TaskJoinFinish:
+                return HandleTaskJoinFinish(recordedEvent, tid, thread, ReadBoolOrDefault(returnValue, true));
+
+            case RecordedEventType.MonitorPulseOneResult:
+            case RecordedEventType.MonitorPulseAllResult:
+            case RecordedEventType.ThreadJoinResult:
+            default:
+                return inner.ProcessEvent(recordedEvent);
+        }
+    }
+
+    private RecordedEventState HandleAcquireResult(RecordedEvent recordedEvent, ProcessThreadId tid, ShadowThread thread, bool success)
+    {
+        if (!TryPeekTarget(thread, out var lockId))
+            return inner.ProcessEvent(recordedEvent);
+
+        if (success && !GetOrCreateLock(lockId).TryAcquire(tid))
+            return Defer(thread, lockId, recordedEvent);
+        
+        thread.SyncTargetStack.Pop();
+        return inner.ProcessEvent(recordedEvent);
+    }
+
+    private RecordedEventState HandleReleaseResult(RecordedEvent recordedEvent, ProcessThreadId tid, ShadowThread thread)
+    {
+        if (!TryPopTarget(thread, out var lockId))
+            return inner.ProcessEvent(recordedEvent);
+
+        var result = inner.ProcessEvent(recordedEvent);
+        if (_locks.TryGetValue(lockId, out var shadow))
+            EnqueueDrain(shadow.Release(tid));
+        
+        return result;
+    }
+
+    private RecordedEventState HandleWaitResult(RecordedEvent recordedEvent, ProcessThreadId tid, ShadowThread thread, bool success)
+    {
+        if (!TryPeekTarget(thread, out var lockId))
+            return inner.ProcessEvent(recordedEvent);
+
+        if (!success)
+        {
+            thread.SyncTargetStack.Pop();
+            thread.SuspendedWaitCount = null;
+            return inner.ProcessEvent(recordedEvent);
+        }
+
+        var suspended = thread.SuspendedWaitCount ?? 1;
+        if (!GetOrCreateLock(lockId).TryReacquireAfterWait(tid, suspended))
+            return Defer(thread, lockId, recordedEvent);
+        
+        thread.SyncTargetStack.Pop();
+        thread.SuspendedWaitCount = null;
+        return inner.ProcessEvent(recordedEvent);
+    }
+
+    private RecordedEventState HandleSemaphoreAcquireResult(RecordedEvent recordedEvent, ProcessThreadId tid, ShadowThread thread, bool success)
+    {
+        if (!TryPeekTarget(thread, out var semaphoreId))
+            return inner.ProcessEvent(recordedEvent);
+
+        if (success && !GetOrCreateSemaphore(semaphoreId).TryAcquire(tid))
+            return Defer(thread, semaphoreId, recordedEvent);
+        
+        thread.SyncTargetStack.Pop();
+        return inner.ProcessEvent(recordedEvent);
+    }
+
+    private RecordedEventState HandleSemaphoreReleaseResult(RecordedEvent recordedEvent, ShadowThread thread)
+    {
+        if (!TryPopTarget(thread, out var semaphoreId))
+            return inner.ProcessEvent(recordedEvent);
+
+        var result = inner.ProcessEvent(recordedEvent);
+        EnqueueDrain(GetOrCreateSemaphore(semaphoreId).Release());
+        return result;
+    }
+
+    private RecordedEventState HandleTaskComplete(RecordedEvent recordedEvent, ShadowThread thread)
+    {
+        if (!TryPopTarget(thread, out var taskId))
+            return inner.ProcessEvent(recordedEvent);
+
+        var result = inner.ProcessEvent(recordedEvent);
+        foreach (var waiter in GetOrCreateTask(taskId).Complete())
+            _drainQueue.Enqueue(waiter);
+        
+        return result;
+    }
+
+    private RecordedEventState HandleTaskJoinFinish(RecordedEvent recordedEvent, ProcessThreadId tid, ShadowThread thread, bool success)
+    {
+        if (!TryPeekTarget(thread, out var taskId))
+            return inner.ProcessEvent(recordedEvent);
+
+        if (!success)
+        {
+            thread.SyncTargetStack.Pop();
+            return inner.ProcessEvent(recordedEvent);
+        }
+
+        // Only tasks whose start we observed can defer; others like Task.CompletedTask are pass-through
+        if (_tasks.TryGetValue(taskId, out var shadow) && shadow.RegisterWaiter(tid))
+            return Defer(thread, taskId, recordedEvent);
+
+        thread.SyncTargetStack.Pop();
+        return inner.ProcessEvent(recordedEvent);
+    }
+
+    private RecordedEventState HandleThreadDestroy(RecordedEvent recordedEvent, ThreadDestroyRecordedEvent destroy)
+    {
+        var pid = recordedEvent.Metadata.Pid;
+        var destroyedTid = new ProcessThreadId(pid, destroy.ThreadId);
+
+        foreach (var (lockId, shadow) in _locks)
+        {
+            var next = shadow.AbandonByDestroy(destroyedTid);
+            if (next is null)
+                continue;
+            
+            logger.LogWarning("Thread {Thread} destroyed while still owning lock {Lock}.", destroyedTid, lockId);
+            _drainQueue.Enqueue(next.Value);
+        }
+
+        _threads.Remove(destroyedTid);
+        return inner.ProcessEvent(recordedEvent);
+    }
+
+    private RecordedEventState DrainPendingThreads()
+    {
+        while (_drainQueue.Count > 0)
+        {
+            var tid = _drainQueue.Dequeue();
+            if (!_threads.TryGetValue(tid, out var thread))
+                continue;
+
+            thread.BlockedOn = null;
+            while (thread.BlockedOn is null && thread.PendingQueue.Count > 0)
+            {
+                var pendingEvent = thread.PendingQueue.First!.Value;
+                thread.PendingQueue.RemoveFirst();
+                var state = ProcessOne(pendingEvent);
+
+                if (state == RecordedEventState.Failed)
+                    return RecordedEventState.Failed;
+
+                if (state != RecordedEventState.Deferred)
+                    continue;
+                
+                var node = thread.PendingQueue.Last!;
+                thread.PendingQueue.RemoveLast();
+                thread.PendingQueue.AddFirst(node);
+                break;
+            }
+        }
+        return RecordedEventState.Executed;
+    }
+
+    private static RecordedEventState Defer(ShadowThread thread, ProcessTrackedObjectId target, RecordedEvent recordedEvent)
+    {
+        thread.BlockedOn = target;
+        thread.PendingQueue.AddLast(recordedEvent);
+        return RecordedEventState.Deferred;
+    }
+
+    private void EnqueueDrain(ProcessThreadId? waiter)
+    {
+        if (waiter is not null)
+            _drainQueue.Enqueue(waiter.Value);
+    }
+
+    private ShadowThread GetOrCreateThread(ProcessThreadId tid)
+    {
+        if (!_threads.TryGetValue(tid, out var thread))
+            _threads[tid] = thread = new ShadowThread();
+        return thread;
+    }
+
+    private ShadowLock GetOrCreateLock(ProcessTrackedObjectId lockId)
+    {
+        if (!_locks.TryGetValue(lockId, out var shadow))
+            _locks[lockId] = shadow = new ShadowLock();
+        return shadow;
+    }
+
+    private ShadowSemaphore GetOrCreateSemaphore(ProcessTrackedObjectId semaphoreId)
+    {
+        if (!_semaphores.TryGetValue(semaphoreId, out var shadow))
+            _semaphores[semaphoreId] = shadow = new ShadowSemaphore();
+        return shadow;
+    }
+
+    private ShadowTask GetOrCreateTask(ProcessTrackedObjectId taskId)
+    {
+        if (!_tasks.TryGetValue(taskId, out var shadow))
+            _tasks[taskId] = shadow = new ShadowTask();
+        return shadow;
+    }
+
+    private static ProcessTrackedObjectId ReadTargetId(byte[] argumentValues, uint pid)
+    {
+        var raw = MemoryMarshal.Read<nuint>(argumentValues);
+        return new ProcessTrackedObjectId(pid, new TrackedObjectId(raw));
+    }
+
+    private static bool ReadBoolOrDefault(byte[]? buffer, bool defaultValue)
+    {
+        if (buffer is null || buffer.Length == 0)
+            return defaultValue;
+        return MemoryMarshal.Read<bool>(buffer);
+    }
+    
+    private static bool TryPeekTarget(ShadowThread thread, out ProcessTrackedObjectId target)
+    {
+        if (thread.SyncTargetStack.Count == 0)
+        {
+            target = default;
+            return false;
+        }
+        
+        target = thread.SyncTargetStack.Peek();
+        return true;
+    }
+
+    private static bool TryPopTarget(ShadowThread thread, out ProcessTrackedObjectId target)
+    {
+        if (thread.SyncTargetStack.Count == 0)
+        {
+            target = default;
+            return false;
+        }
+        
+        target = thread.SyncTargetStack.Pop();
+        return true;
+    }
+
+    public void Dispose()
+    {
+        if (_isDisposed)
+            return;
+        _isDisposed = true;
+        if (inner is IDisposable disposable)
+            disposable.Dispose();
+    }
+}

--- a/src/Extensibility/SharpDetect.PluginHost/Services/Strategies/ReorderingPluginHost.cs
+++ b/src/Extensibility/SharpDetect.PluginHost/Services/Strategies/ReorderingPluginHost.cs
@@ -36,7 +36,7 @@ internal sealed class ReorderingPluginHost(IPluginHost inner, ILogger<Reordering
         var tid = new ProcessThreadId(recordedEvent.Metadata.Pid, recordedEvent.Metadata.Tid);
         var thread = GetOrCreateThread(tid);
 
-        if (thread.BlockedOn is not null)
+        if (thread.BlockedOn is not null && ShouldDeferIfBlocked(recordedEvent))
         {
             thread.PendingQueue.AddLast(recordedEvent);
             return RecordedEventState.Deferred;
@@ -49,6 +49,49 @@ internal sealed class ReorderingPluginHost(IPluginHost inner, ILogger<Reordering
             MethodExitWithArgumentsRecordedEvent exit => HandleExit(recordedEvent, exit.Interpretation, tid, thread, exit.ReturnValue),
             ThreadDestroyRecordedEvent destroy => HandleThreadDestroy(recordedEvent, destroy),
             _ => inner.ProcessEvent(recordedEvent)
+        };
+    }
+
+    // Defer only events that participate in the happens-before (sync operations and shared-memory accesses)
+    private static bool ShouldDeferIfBlocked(RecordedEvent recordedEvent)
+    {
+        if (recordedEvent.EventArgs is not ICustomizableEventType customizable)
+            return false;
+
+        return (RecordedEventType)customizable.Interpretation switch
+        {
+            RecordedEventType.StaticFieldRead or
+            RecordedEventType.StaticFieldWrite or
+            RecordedEventType.InstanceFieldRead or
+            RecordedEventType.InstanceFieldWrite or
+            RecordedEventType.MonitorLockAcquire or
+            RecordedEventType.MonitorLockTryAcquire or
+            RecordedEventType.MonitorLockAcquireResult or
+            RecordedEventType.MonitorLockRelease or
+            RecordedEventType.MonitorLockReleaseResult or
+            RecordedEventType.MonitorWaitAttempt or
+            RecordedEventType.MonitorWaitResult or
+            RecordedEventType.MonitorPulseOneAttempt or
+            RecordedEventType.MonitorPulseOneResult or
+            RecordedEventType.MonitorPulseAllAttempt or
+            RecordedEventType.MonitorPulseAllResult or
+            RecordedEventType.LockAcquire or
+            RecordedEventType.LockTryAcquire or
+            RecordedEventType.LockAcquireResult or
+            RecordedEventType.LockRelease or
+            RecordedEventType.LockReleaseResult or
+            RecordedEventType.SemaphoreAcquire or
+            RecordedEventType.SemaphoreTryAcquire or
+            RecordedEventType.SemaphoreAcquireResult or
+            RecordedEventType.SemaphoreRelease or
+            RecordedEventType.SemaphoreReleaseResult or
+            RecordedEventType.ThreadJoinAttempt or
+            RecordedEventType.ThreadJoinResult or
+            RecordedEventType.TaskStart or
+            RecordedEventType.TaskComplete or
+            RecordedEventType.TaskJoinStart or
+            RecordedEventType.TaskJoinFinish => true,
+            _ => false
         };
     }
 
@@ -86,18 +129,22 @@ internal sealed class ReorderingPluginHost(IPluginHost inner, ILogger<Reordering
             {
                 var taskId = ReadTargetId(enter.ArgumentValues, tid.ProcessId);
                 thread.SyncTargetStack.Push(taskId);
-                GetOrCreateTask(taskId);
+                GetOrCreateTask(taskId).AttachOwner(tid);
                 return inner.ProcessEvent(recordedEvent);
             }
 
             case RecordedEventType.MonitorWaitAttempt:
             {
                 var target = ReadTargetId(enter.ArgumentValues, tid.ProcessId);
-                thread.SyncTargetStack.Push(target);
                 var shadowLock = GetOrCreateLock(target);
                 if (!shadowLock.TryReleaseForWait(tid, out var nextWaiter, out var suspendedCount))
-                    return RecordedEventState.Discarded;
-                
+                {
+                    // Waiting without ownership throws at runtime
+                    // We are not pushing the target (there won't be matching reacquire
+                    return inner.ProcessEvent(recordedEvent);
+                }
+
+                thread.SyncTargetStack.Push(target);
                 thread.SuspendedWaitCount = suspendedCount.Value;
                 if (nextWaiter is not null)
                     _drainQueue.Enqueue(nextWaiter.Value);
@@ -134,7 +181,7 @@ internal sealed class ReorderingPluginHost(IPluginHost inner, ILogger<Reordering
                 return HandleSemaphoreAcquireResult(recordedEvent, tid, thread, ReadBoolOrDefault(returnValue, true));
 
             case RecordedEventType.SemaphoreReleaseResult:
-                return HandleSemaphoreReleaseResult(recordedEvent, thread);
+                return HandleSemaphoreReleaseResult(recordedEvent, tid, thread);
 
             case RecordedEventType.TaskComplete:
                 return HandleTaskComplete(recordedEvent, thread);
@@ -179,12 +226,6 @@ internal sealed class ReorderingPluginHost(IPluginHost inner, ILogger<Reordering
         if (!TryPeekTarget(thread, out var lockId))
             return inner.ProcessEvent(recordedEvent);
 
-        if (!success)
-        {
-            thread.SyncTargetStack.Pop();
-            thread.SuspendedWaitCount = null;
-            return inner.ProcessEvent(recordedEvent);
-        }
 
         var suspended = thread.SuspendedWaitCount ?? 1;
         if (!GetOrCreateLock(lockId).TryReacquireAfterWait(tid, suspended))
@@ -207,13 +248,13 @@ internal sealed class ReorderingPluginHost(IPluginHost inner, ILogger<Reordering
         return inner.ProcessEvent(recordedEvent);
     }
 
-    private RecordedEventState HandleSemaphoreReleaseResult(RecordedEvent recordedEvent, ShadowThread thread)
+    private RecordedEventState HandleSemaphoreReleaseResult(RecordedEvent recordedEvent, ProcessThreadId tid, ShadowThread thread)
     {
         if (!TryPopTarget(thread, out var semaphoreId))
             return inner.ProcessEvent(recordedEvent);
 
         var result = inner.ProcessEvent(recordedEvent);
-        EnqueueDrain(GetOrCreateSemaphore(semaphoreId).Release());
+        EnqueueDrain(GetOrCreateSemaphore(semaphoreId).Release(tid));
         return result;
     }
 
@@ -255,12 +296,36 @@ internal sealed class ReorderingPluginHost(IPluginHost inner, ILogger<Reordering
 
         foreach (var (lockId, shadow) in _locks)
         {
+            shadow.RemoveWaiter(destroyedTid);
             var next = shadow.AbandonByDestroy(destroyedTid);
             if (next is null)
                 continue;
             
             logger.LogWarning("Thread {Thread} destroyed while still owning lock {Lock}.", destroyedTid, lockId);
             _drainQueue.Enqueue(next.Value);
+        }
+
+        foreach (var (semaphoreId, shadow) in _semaphores)
+        {
+            shadow.RemoveWaiter(destroyedTid);
+            var abandonedPermits = shadow.AbandonPermitsByDestroy(destroyedTid);
+            if (abandonedPermits > 0)
+            {
+                logger.LogWarning(
+                    "Thread {Thread} destroyed while holding {Permits} outstanding permit(s) on semaphore {Semaphore}; permits will not be released.",
+                    destroyedTid, abandonedPermits, semaphoreId);
+            }
+        }
+
+        foreach (var (taskId, shadow) in _tasks)
+        {
+            shadow.RemoveWaiter(destroyedTid);
+            if (shadow.Completed || shadow.OwnerThreadId != destroyedTid)
+                continue;
+
+            logger.LogWarning("Thread {Thread} destroyed mid-task {Task}; completing task and waking joiners.", destroyedTid, taskId);
+            foreach (var waiter in shadow.Complete())
+                _drainQueue.Enqueue(waiter);
         }
 
         _threads.Remove(destroyedTid);

--- a/src/Extensibility/SharpDetect.PluginHost/Services/Strategies/Shadows/ShadowLock.cs
+++ b/src/Extensibility/SharpDetect.PluginHost/Services/Strategies/Shadows/ShadowLock.cs
@@ -10,7 +10,7 @@ internal sealed class ShadowLock
 {
     public ProcessThreadId? Owner { get; private set; }
     public int ReentrantCount { get; private set; }
-    private readonly Queue<ProcessThreadId> _waiters = [];
+    private readonly LinkedList<ProcessThreadId> _waiters = [];
 
     public bool TryAcquire(ProcessThreadId tid)
     {
@@ -27,7 +27,7 @@ internal sealed class ShadowLock
             return true;
         }
         
-        _waiters.Enqueue(tid);
+        _waiters.AddLast(tid);
         return false;
     }
 
@@ -73,7 +73,7 @@ internal sealed class ShadowLock
             return true;
         }
         
-        _waiters.Enqueue(tid);
+        _waiters.AddLast(tid);
         return false;
     }
 
@@ -87,6 +87,18 @@ internal sealed class ShadowLock
         return DequeueWaiterOrNull();
     }
 
+    public void RemoveWaiter(ProcessThreadId tid)
+    {
+        _waiters.Remove(tid);
+    }
+
     private ProcessThreadId? DequeueWaiterOrNull()
-        => _waiters.Count > 0 ? _waiters.Dequeue() : null;
+    {
+        if (_waiters.Count == 0)
+            return null;
+
+        var result = _waiters.First();
+        _waiters.RemoveFirst();
+        return result;
+    }
 }

--- a/src/Extensibility/SharpDetect.PluginHost/Services/Strategies/Shadows/ShadowLock.cs
+++ b/src/Extensibility/SharpDetect.PluginHost/Services/Strategies/Shadows/ShadowLock.cs
@@ -1,0 +1,92 @@
+// Copyright 2026 Andrej Čižmárik and Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Diagnostics.CodeAnalysis;
+using SharpDetect.Core.Plugins;
+
+namespace SharpDetect.PluginHost.Services.Strategies.Shadows;
+
+internal sealed class ShadowLock
+{
+    public ProcessThreadId? Owner { get; private set; }
+    public int ReentrantCount { get; private set; }
+    private readonly Queue<ProcessThreadId> _waiters = [];
+
+    public bool TryAcquire(ProcessThreadId tid)
+    {
+        if (Owner is null)
+        {
+            Owner = tid;
+            ReentrantCount = 1;
+            return true;
+        }
+        
+        if (Owner == tid)
+        {
+            ReentrantCount++;
+            return true;
+        }
+        
+        _waiters.Enqueue(tid);
+        return false;
+    }
+
+    public ProcessThreadId? Release(ProcessThreadId tid)
+    {
+        if (Owner != tid)
+            return null;
+        
+        if (--ReentrantCount > 0)
+            return null;
+        
+        Owner = null;
+        ReentrantCount = 0;
+        return DequeueWaiterOrNull();
+    }
+
+    public bool TryReleaseForWait(
+        ProcessThreadId tid,
+        out ProcessThreadId? nextWaiter,
+        [NotNullWhen(true)] out int? suspendedCount)
+    {
+        if (Owner != tid)
+        {
+            // Wait without owning lock - causes exception
+            suspendedCount = null;
+            nextWaiter = null;
+            return false;
+        }
+        
+        suspendedCount = ReentrantCount;
+        nextWaiter = DequeueWaiterOrNull();
+        Owner = null;
+        ReentrantCount = 0;
+        return true;
+    }
+
+    public bool TryReacquireAfterWait(ProcessThreadId tid, int suspendedCount)
+    {
+        if (Owner is null)
+        {
+            Owner = tid;
+            ReentrantCount = suspendedCount;
+            return true;
+        }
+        
+        _waiters.Enqueue(tid);
+        return false;
+    }
+
+    public ProcessThreadId? AbandonByDestroy(ProcessThreadId tid)
+    {
+        if (Owner != tid)
+            return null;
+        
+        Owner = null;
+        ReentrantCount = 0;
+        return DequeueWaiterOrNull();
+    }
+
+    private ProcessThreadId? DequeueWaiterOrNull()
+        => _waiters.Count > 0 ? _waiters.Dequeue() : null;
+}

--- a/src/Extensibility/SharpDetect.PluginHost/Services/Strategies/Shadows/ShadowLock.cs
+++ b/src/Extensibility/SharpDetect.PluginHost/Services/Strategies/Shadows/ShadowLock.cs
@@ -92,6 +92,18 @@ internal sealed class ShadowLock
         _waiters.Remove(tid);
     }
 
+    public bool TryDescribeResidualState([NotNullWhen(true)] out string? description)
+    {
+        if (Owner is null && _waiters.Count == 0)
+        {
+            description = null;
+            return false;
+        }
+
+        description = $"owner={Owner?.ToString() ?? "none"}, reentrantCount={ReentrantCount}, waiters={_waiters.Count}";
+        return true;
+    }
+
     private ProcessThreadId? DequeueWaiterOrNull()
     {
         if (_waiters.Count == 0)

--- a/src/Extensibility/SharpDetect.PluginHost/Services/Strategies/Shadows/ShadowSemaphore.cs
+++ b/src/Extensibility/SharpDetect.PluginHost/Services/Strategies/Shadows/ShadowSemaphore.cs
@@ -1,6 +1,7 @@
 // Copyright 2026 Andrej Čižmárik and Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+using System.Diagnostics.CodeAnalysis;
 using SharpDetect.Core.Plugins;
 
 namespace SharpDetect.PluginHost.Services.Strategies.Shadows;
@@ -53,5 +54,21 @@ internal sealed class ShadowSemaphore
     public int AbandonPermitsByDestroy(ProcessThreadId tid)
     {
         return _outstandingPermits.Remove(tid, out var held) ? held : 0;
+    }
+
+    public bool TryDescribeResidualState([NotNullWhen(true)] out string? description)
+    {
+        if (_waiters.Count == 0 && _outstandingPermits.Count == 0)
+        {
+            description = null;
+            return false;
+        }
+
+        var totalPermits = 0;
+        foreach (var kvp in _outstandingPermits)
+            totalPermits += kvp.Value;
+
+        description = $"waiters={_waiters.Count}, outstandingPermits={totalPermits} across {_outstandingPermits.Count} thread(s)";
+        return true;
     }
 }

--- a/src/Extensibility/SharpDetect.PluginHost/Services/Strategies/Shadows/ShadowSemaphore.cs
+++ b/src/Extensibility/SharpDetect.PluginHost/Services/Strategies/Shadows/ShadowSemaphore.cs
@@ -8,7 +8,8 @@ namespace SharpDetect.PluginHost.Services.Strategies.Shadows;
 internal sealed class ShadowSemaphore
 {
     public int Count { get; private set; }
-    private readonly Queue<ProcessThreadId> _waiters = [];
+    private readonly LinkedList<ProcessThreadId> _waiters = [];
+    private readonly Dictionary<ProcessThreadId, int> _outstandingPermits = [];
 
     public void Initialize(int initialCount) => Count = initialCount;
 
@@ -17,16 +18,40 @@ internal sealed class ShadowSemaphore
         if (Count > 0)
         {
             Count--;
+            _outstandingPermits[tid] = _outstandingPermits.GetValueOrDefault(tid) + 1;
             return true;
         }
         
-        _waiters.Enqueue(tid);
+        _waiters.AddLast(tid);
         return false;
     }
 
-    public ProcessThreadId? Release()
+    public ProcessThreadId? Release(ProcessThreadId tid)
     {
         Count++;
-        return _waiters.Count > 0 ? _waiters.Dequeue() : null;
+        if (_outstandingPermits.TryGetValue(tid, out var held) && held > 0)
+        {
+            if (held == 1)
+                _outstandingPermits.Remove(tid);
+            else
+                _outstandingPermits[tid] = held - 1;
+        }
+
+        if (_waiters.Count == 0)
+            return null;
+
+        var result = _waiters.First();
+        _waiters.RemoveFirst();
+        return result;
+    }
+
+    public void RemoveWaiter(ProcessThreadId tid)
+    {
+        _waiters.Remove(tid);
+    }
+
+    public int AbandonPermitsByDestroy(ProcessThreadId tid)
+    {
+        return _outstandingPermits.Remove(tid, out var held) ? held : 0;
     }
 }

--- a/src/Extensibility/SharpDetect.PluginHost/Services/Strategies/Shadows/ShadowSemaphore.cs
+++ b/src/Extensibility/SharpDetect.PluginHost/Services/Strategies/Shadows/ShadowSemaphore.cs
@@ -1,0 +1,38 @@
+// Copyright 2026 Andrej Čižmárik and Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+using SharpDetect.Core.Plugins;
+
+namespace SharpDetect.PluginHost.Services.Strategies.Shadows;
+
+internal sealed class ShadowSemaphore
+{
+    // FIXME: add instrumentation for semaphore ctor to capture properly its capacity.
+    // Null until the first acquire is observed; treated as authoritative there.
+    public int? Count { get; private set; }
+    private readonly Queue<ProcessThreadId> _waiters = [];
+
+    public bool TryAcquire(ProcessThreadId tid)
+    {
+        if (Count is null)
+        {
+            Count = 0;
+            return true;
+        }
+        
+        if (Count > 0)
+        {
+            Count--;
+            return true;
+        }
+        
+        _waiters.Enqueue(tid);
+        return false;
+    }
+
+    public ProcessThreadId? Release()
+    {
+        Count = (Count ?? 0) + 1;
+        return _waiters.Count > 0 ? _waiters.Dequeue() : null;
+    }
+}

--- a/src/Extensibility/SharpDetect.PluginHost/Services/Strategies/Shadows/ShadowSemaphore.cs
+++ b/src/Extensibility/SharpDetect.PluginHost/Services/Strategies/Shadows/ShadowSemaphore.cs
@@ -6,13 +6,12 @@ using SharpDetect.Core.Plugins;
 
 namespace SharpDetect.PluginHost.Services.Strategies.Shadows;
 
-internal sealed class ShadowSemaphore
+internal sealed class ShadowSemaphore(int initialCount, int capacity)
 {
-    public int Count { get; private set; }
+    public int Capacity { get; } = capacity;
+    public int Count { get; private set; } = initialCount;
     private readonly LinkedList<ProcessThreadId> _waiters = [];
     private readonly Dictionary<ProcessThreadId, int> _outstandingPermits = [];
-
-    public void Initialize(int initialCount) => Count = initialCount;
 
     public bool TryAcquire(ProcessThreadId tid)
     {

--- a/src/Extensibility/SharpDetect.PluginHost/Services/Strategies/Shadows/ShadowSemaphore.cs
+++ b/src/Extensibility/SharpDetect.PluginHost/Services/Strategies/Shadows/ShadowSemaphore.cs
@@ -7,19 +7,13 @@ namespace SharpDetect.PluginHost.Services.Strategies.Shadows;
 
 internal sealed class ShadowSemaphore
 {
-    // FIXME: add instrumentation for semaphore ctor to capture properly its capacity.
-    // Null until the first acquire is observed; treated as authoritative there.
-    public int? Count { get; private set; }
+    public int Count { get; private set; }
     private readonly Queue<ProcessThreadId> _waiters = [];
+
+    public void Initialize(int initialCount) => Count = initialCount;
 
     public bool TryAcquire(ProcessThreadId tid)
     {
-        if (Count is null)
-        {
-            Count = 0;
-            return true;
-        }
-        
         if (Count > 0)
         {
             Count--;
@@ -32,7 +26,7 @@ internal sealed class ShadowSemaphore
 
     public ProcessThreadId? Release()
     {
-        Count = (Count ?? 0) + 1;
+        Count++;
         return _waiters.Count > 0 ? _waiters.Dequeue() : null;
     }
 }

--- a/src/Extensibility/SharpDetect.PluginHost/Services/Strategies/Shadows/ShadowSemaphore.cs
+++ b/src/Extensibility/SharpDetect.PluginHost/Services/Strategies/Shadows/ShadowSemaphore.cs
@@ -26,23 +26,30 @@ internal sealed class ShadowSemaphore(int initialCount, int capacity)
         return false;
     }
 
-    public ProcessThreadId? Release(ProcessThreadId tid)
+    public IReadOnlyList<ProcessThreadId> Release(ProcessThreadId tid, int count)
     {
-        Count++;
+        Count += count;
         if (_outstandingPermits.TryGetValue(tid, out var held) && held > 0)
         {
-            if (held == 1)
+            var decrement = Math.Min(held, count);
+            var remaining = held - decrement;
+            if (remaining == 0)
                 _outstandingPermits.Remove(tid);
             else
-                _outstandingPermits[tid] = held - 1;
+                _outstandingPermits[tid] = remaining;
         }
 
-        if (_waiters.Count == 0)
-            return null;
+        var wakeCount = Math.Min(count, _waiters.Count);
+        if (wakeCount == 0)
+            return [];
 
-        var result = _waiters.First();
-        _waiters.RemoveFirst();
-        return result;
+        var woken = new ProcessThreadId[wakeCount];
+        for (var i = 0; i < wakeCount; i++)
+        {
+            woken[i] = _waiters.First!.Value;
+            _waiters.RemoveFirst();
+        }
+        return woken;
     }
 
     public void RemoveWaiter(ProcessThreadId tid)

--- a/src/Extensibility/SharpDetect.PluginHost/Services/Strategies/Shadows/ShadowTask.cs
+++ b/src/Extensibility/SharpDetect.PluginHost/Services/Strategies/Shadows/ShadowTask.cs
@@ -1,6 +1,7 @@
 // Copyright 2026 Andrej Čižmárik and Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+using System.Diagnostics.CodeAnalysis;
 using SharpDetect.Core.Plugins;
 
 namespace SharpDetect.PluginHost.Services.Strategies.Shadows;
@@ -36,5 +37,17 @@ internal sealed class ShadowTask
     public void RemoveWaiter(ProcessThreadId tid)
     {
         _waiters.Remove(tid);
+    }
+
+    public bool TryDescribeResidualState([NotNullWhen(true)] out string? description)
+    {
+        if (Completed && _waiters.Count == 0)
+        {
+            description = null;
+            return false;
+        }
+
+        description = $"completed={Completed}, owner={OwnerThreadId?.ToString() ?? "none"}, waiters={_waiters.Count}";
+        return true;
     }
 }

--- a/src/Extensibility/SharpDetect.PluginHost/Services/Strategies/Shadows/ShadowTask.cs
+++ b/src/Extensibility/SharpDetect.PluginHost/Services/Strategies/Shadows/ShadowTask.cs
@@ -1,0 +1,27 @@
+// Copyright 2026 Andrej Čižmárik and Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+using SharpDetect.Core.Plugins;
+
+namespace SharpDetect.PluginHost.Services.Strategies.Shadows;
+
+internal sealed class ShadowTask
+{
+    public bool Completed { get; private set; }
+    private readonly Queue<ProcessThreadId> _waiters = [];
+
+    public bool RegisterWaiter(ProcessThreadId tid)
+    {
+        if (Completed)
+            return false;
+        
+        _waiters.Enqueue(tid);
+        return true;
+    }
+
+    public IReadOnlyCollection<ProcessThreadId> Complete()
+    {
+        Completed = true;
+        return _waiters.Count == 0 ? [] : _waiters;
+    }
+}

--- a/src/Extensibility/SharpDetect.PluginHost/Services/Strategies/Shadows/ShadowTask.cs
+++ b/src/Extensibility/SharpDetect.PluginHost/Services/Strategies/Shadows/ShadowTask.cs
@@ -8,20 +8,33 @@ namespace SharpDetect.PluginHost.Services.Strategies.Shadows;
 internal sealed class ShadowTask
 {
     public bool Completed { get; private set; }
-    private readonly Queue<ProcessThreadId> _waiters = [];
+    public ProcessThreadId? OwnerThreadId { get; private set; }
+    private LinkedList<ProcessThreadId> _waiters = [];
+
+    public void AttachOwner(ProcessThreadId tid) => OwnerThreadId ??= tid;
 
     public bool RegisterWaiter(ProcessThreadId tid)
     {
         if (Completed)
             return false;
         
-        _waiters.Enqueue(tid);
+        _waiters.AddLast(tid);
         return true;
     }
 
     public IReadOnlyCollection<ProcessThreadId> Complete()
     {
         Completed = true;
-        return _waiters.Count == 0 ? [] : _waiters;
+        if (_waiters.Count == 0)
+            return [];
+
+        var result = _waiters;
+        _waiters = [];
+        return result;
+    }
+
+    public void RemoveWaiter(ProcessThreadId tid)
+    {
+        _waiters.Remove(tid);
     }
 }

--- a/src/Extensibility/SharpDetect.PluginHost/Services/Strategies/Shadows/ShadowThread.cs
+++ b/src/Extensibility/SharpDetect.PluginHost/Services/Strategies/Shadows/ShadowThread.cs
@@ -1,0 +1,15 @@
+// Copyright 2026 Andrej Čižmárik and Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+using SharpDetect.Core.Events;
+using SharpDetect.Core.Plugins;
+
+namespace SharpDetect.PluginHost.Services.Strategies.Shadows;
+
+internal sealed class ShadowThread
+{
+    public ProcessTrackedObjectId? BlockedOn { get; set; }
+    public LinkedList<RecordedEvent> PendingQueue { get; } = [];
+    public Stack<ProcessTrackedObjectId> SyncTargetStack { get; } = [];
+    public int? SuspendedWaitCount { get; set; }
+}

--- a/src/Extensibility/SharpDetect.PluginHost/Services/Strategies/Shadows/ShadowThread.cs
+++ b/src/Extensibility/SharpDetect.PluginHost/Services/Strategies/Shadows/ShadowThread.cs
@@ -11,6 +11,7 @@ internal sealed class ShadowThread(ProcessThreadId id, ILogger logger)
 {
     public Stack<ProcessTrackedObjectId> SyncTargetStack { get; } = [];
     public int? SuspendedWaitCount { get; set; }
+    public int? PendingReleaseCount { get; set; }
 
     public ProcessThreadId Id { get; } = id;
     public ProcessTrackedObjectId? BlockedOn { get; private set; }

--- a/src/Extensibility/SharpDetect.PluginHost/Services/Strategies/Shadows/ShadowThread.cs
+++ b/src/Extensibility/SharpDetect.PluginHost/Services/Strategies/Shadows/ShadowThread.cs
@@ -1,15 +1,46 @@
 // Copyright 2026 Andrej Čižmárik and Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+using Microsoft.Extensions.Logging;
 using SharpDetect.Core.Events;
 using SharpDetect.Core.Plugins;
 
 namespace SharpDetect.PluginHost.Services.Strategies.Shadows;
 
-internal sealed class ShadowThread
+internal sealed class ShadowThread(ProcessThreadId id, ILogger logger)
 {
-    public ProcessTrackedObjectId? BlockedOn { get; set; }
-    public LinkedList<RecordedEvent> PendingQueue { get; } = [];
     public Stack<ProcessTrackedObjectId> SyncTargetStack { get; } = [];
     public int? SuspendedWaitCount { get; set; }
+
+    public ProcessThreadId Id { get; } = id;
+    public ProcessTrackedObjectId? BlockedOn { get; private set; }
+    public int PendingQueueCount => _pendingQueue.Count;
+    private readonly Queue<RecordedEvent> _pendingQueue = [];
+
+    public void EnqueuePendingEvent(RecordedEvent recordedEvent)
+    {
+        _pendingQueue.Enqueue(recordedEvent);
+        if (_pendingQueue.Count % 64 == 0)
+            logger.LogWarning("Thread {tid}'s queue {size} is getting too large", Id, _pendingQueue.Count);
+    }
+
+    public RecordedEvent PeekPendingEvent()
+    {
+        return _pendingQueue.Peek();
+    }
+
+    public RecordedEvent DequeuePendingEvent()
+    {
+        return _pendingQueue.Dequeue();
+    }
+
+    public void SetBlockedOn(ProcessTrackedObjectId blockedOn)
+    {
+        BlockedOn = blockedOn;
+    }
+
+    public void ClearBlockedOn()
+    {
+        BlockedOn = null;
+    }
 }

--- a/src/Extensibility/SharpDetect.PluginHost/SharpDetect.PluginHost.csproj
+++ b/src/Extensibility/SharpDetect.PluginHost/SharpDetect.PluginHost.csproj
@@ -5,4 +5,7 @@
     <ItemGroup>
         <ProjectReference Include="..\..\SharpDetect.Core\SharpDetect.Core.csproj" />
     </ItemGroup>
+    <ItemGroup>
+        <InternalsVisibleTo Include="SharpDetect.PluginHost.Tests" />
+    </ItemGroup>
 </Project>

--- a/src/Extensibility/SharpDetect.Plugins.DataRace.FastTrack/FastTrackDetector.cs
+++ b/src/Extensibility/SharpDetect.Plugins.DataRace.FastTrack/FastTrackDetector.cs
@@ -18,7 +18,7 @@ internal sealed class FastTrackDetector
     private readonly TimeProvider _timeProvider;
     private readonly Dictionary<ProcessThreadId, VectorClock> _threadClocks = [];
     private readonly Dictionary<ProcessTrackedObjectId, VectorClock> _lockClocks = [];
-    private readonly Dictionary<ProcessTrackedObjectId, VectorClock> _semaphoreClocks = [];
+    private readonly Dictionary<ProcessTrackedObjectId, Queue<VectorClock>> _semaphoreClocks = [];
     private readonly Dictionary<ProcessTrackedObjectId, VectorClock> _taskClocks = [];
     private readonly Dictionary<(FieldId, ProcessTrackedObjectId?), VectorClock> _volatileClocks = [];
     private readonly Dictionary<ProcessTrackedObjectId, HashSet<FieldId>> _volatileClocksObjectIndex = [];
@@ -140,18 +140,25 @@ internal sealed class FastTrackDetector
         threadVc.Increment(threadId);
     }
 
+    public void RecordSemaphoreCreated(ProcessTrackedObjectId semaphoreId, int initialCount)
+    {
+        var pool = new Queue<VectorClock>(capacity: initialCount);
+        for (var i = 0; i < initialCount; i++)
+            pool.Enqueue(new VectorClock());
+        _semaphoreClocks[semaphoreId] = pool;
+    }
+
     public void RecordSemaphoreAcquired(ProcessThreadId threadId, ProcessTrackedObjectId semaphoreId)
     {
         var threadVc = GetOrCreateThreadClock(threadId);
-        var semaphoreVc = GetOrCreateSemaphoreClock(semaphoreId);
-        threadVc.Join(semaphoreVc);
+        var slotVc = _semaphoreClocks[semaphoreId].Dequeue();
+        threadVc.Join(slotVc);
     }
 
     public void RecordSemaphoreReleased(ProcessThreadId threadId, ProcessTrackedObjectId semaphoreId)
     {
         var threadVc = GetOrCreateThreadClock(threadId);
-        var semaphoreVc = GetOrCreateSemaphoreClock(semaphoreId);
-        semaphoreVc.Join(threadVc);
+        _semaphoreClocks[semaphoreId].Enqueue(threadVc.Clone());
         threadVc.Increment(threadId);
     }
 
@@ -382,16 +389,6 @@ internal sealed class FastTrackDetector
         return vc;
     }
 
-    private VectorClock GetOrCreateSemaphoreClock(ProcessTrackedObjectId semaphoreId)
-    {
-        if (!_semaphoreClocks.TryGetValue(semaphoreId, out var vc))
-        {
-            vc = new VectorClock();
-            _semaphoreClocks[semaphoreId] = vc;
-        }
-
-        return vc;
-    }
 
     private VectorClock GetOrCreateVolatileClock(FieldId fieldId, ProcessTrackedObjectId? objectId)
     {

--- a/src/Extensibility/SharpDetect.Plugins.DataRace.FastTrack/FastTrackDetector.cs
+++ b/src/Extensibility/SharpDetect.Plugins.DataRace.FastTrack/FastTrackDetector.cs
@@ -155,10 +155,12 @@ internal sealed class FastTrackDetector
         threadVc.Join(slotVc);
     }
 
-    public void RecordSemaphoreReleased(ProcessThreadId threadId, ProcessTrackedObjectId semaphoreId)
+    public void RecordSemaphoreReleased(ProcessThreadId threadId, ProcessTrackedObjectId semaphoreId, int releaseCount)
     {
         var threadVc = GetOrCreateThreadClock(threadId);
-        _semaphoreClocks[semaphoreId].Enqueue(threadVc.Clone());
+        var pool = _semaphoreClocks[semaphoreId];
+        for (var i = 0; i < releaseCount; i++)
+            pool.Enqueue(threadVc.Clone());
         threadVc.Increment(threadId);
     }
 

--- a/src/Extensibility/SharpDetect.Plugins.DataRace.FastTrack/FastTrackPlugin.cs
+++ b/src/Extensibility/SharpDetect.Plugins.DataRace.FastTrack/FastTrackPlugin.cs
@@ -298,7 +298,7 @@ public partial class FastTrackPlugin : PerThreadOrderingPluginBase, IPlugin
 
     private void OnSemaphoreReleased(SemaphoreReleaseArgs args)
     {
-        _detector.RecordSemaphoreReleased(args.ProcessThreadId, args.SemaphoreId);
+        _detector.RecordSemaphoreReleased(args.ProcessThreadId, args.SemaphoreId, args.ReleaseCount);
     }
 
     protected override void Visit(RecordedEventMetadata metadata, ThreadRenameRecordedEvent args)

--- a/src/Extensibility/SharpDetect.Plugins.DataRace.FastTrack/FastTrackPlugin.cs
+++ b/src/Extensibility/SharpDetect.Plugins.DataRace.FastTrack/FastTrackPlugin.cs
@@ -100,6 +100,7 @@ public partial class FastTrackPlugin : PerThreadOrderingPluginBase, IPlugin
         TaskStarted += OnTaskStarted;
         TaskCompleted += OnTaskCompleted;
         TaskJoinFinished += OnTaskJoinFinished;
+        SemaphoreCreated += OnSemaphoreCreated;
         SemaphoreAcquireReturned += OnSemaphoreAcquireReturned;
         SemaphoreReleased += OnSemaphoreReleased;
 
@@ -282,6 +283,11 @@ public partial class FastTrackPlugin : PerThreadOrderingPluginBase, IPlugin
     {
         if (args.IsSuccess)
             _detector.RecordTaskJoinFinished(args.ProcessThreadId, args.TaskObjectId);
+    }
+
+    private void OnSemaphoreCreated(SemaphoreCreatedArgs args)
+    {
+        _detector.RecordSemaphoreCreated(args.SemaphoreId, args.InitialCount);
     }
 
     private void OnSemaphoreAcquireReturned(SemaphoreAcquireResultArgs args)

--- a/src/Extensibility/SharpDetect.Plugins.Descriptors/Methods/FieldAccessDescriptors.cs
+++ b/src/Extensibility/SharpDetect.Plugins.Descriptors/Methods/FieldAccessDescriptors.cs
@@ -35,7 +35,7 @@ public static class FieldAccessDescriptors
                 ],
                 ReturnValue: null,
                 MethodEnterInterpretation: (ushort)RecordedEventType.StaticFieldRead,
-                MethodExitInterpretation: null));
+                MethodExitInterpretation: (ushort)RecordedEventType.StaticFieldRead));
         
         ReadInstanceField = new MethodDescriptor(
             MethodName: "ReadInstanceField",
@@ -60,7 +60,7 @@ public static class FieldAccessDescriptors
                 ],
                 ReturnValue: null,
                 MethodEnterInterpretation: (ushort)RecordedEventType.InstanceFieldRead,
-                MethodExitInterpretation: null));
+                MethodExitInterpretation: (ushort)RecordedEventType.InstanceFieldRead));
 
         WriteStaticField = new MethodDescriptor(
             MethodName: "WriteStaticField",
@@ -80,7 +80,7 @@ public static class FieldAccessDescriptors
                 ],
                 ReturnValue: null,
                 MethodEnterInterpretation: (ushort)RecordedEventType.StaticFieldWrite,
-                MethodExitInterpretation: null));
+                MethodExitInterpretation: (ushort)RecordedEventType.StaticFieldWrite));
         
         WriteInstanceField = new MethodDescriptor(
             MethodName: "WriteInstanceField",
@@ -105,7 +105,7 @@ public static class FieldAccessDescriptors
                 ],
                 ReturnValue: null,
                 MethodEnterInterpretation: (ushort)RecordedEventType.InstanceFieldWrite,
-                MethodExitInterpretation: null));
+                MethodExitInterpretation: (ushort)RecordedEventType.InstanceFieldWrite));
     }
 
     public static IEnumerable<MethodDescriptor> GetAllMethods()

--- a/src/Extensibility/SharpDetect.Plugins.Descriptors/Methods/SemaphoreSlimMethodDescriptors.cs
+++ b/src/Extensibility/SharpDetect.Plugins.Descriptors/Methods/SemaphoreSlimMethodDescriptors.cs
@@ -18,13 +18,18 @@ public static class SemaphoreSlimMethodDescriptors
     private static readonly CapturedArgumentDescriptor ObjectRefArg =
         new(0, new((byte)nint.Size, CapturedValue.CaptureAsReference));
 
+    private static readonly CapturedArgumentDescriptor ReleaseCountArg =
+        new(1, new(sizeof(int), CapturedValue.CaptureAsValue));
+    
     private static readonly CapturedArgumentDescriptor InitialCountArg =
-        new(1, new((byte)sizeof(int), CapturedValue.CaptureAsValue));
+        new(1, new(sizeof(int), CapturedValue.CaptureAsValue));
+    
+    private static readonly CapturedArgumentDescriptor MaximumCountArg =
+        new(2, new(sizeof(int), CapturedValue.CaptureAsValue));
 
     private static readonly MethodDescriptor CtorWithMaxCount;
     private static readonly MethodDescriptor WaitV8;
     private static readonly MethodDescriptor WaitCoreV10;
-    private static readonly MethodDescriptor ReleaseNoArgs;
     private static readonly MethodDescriptor ReleaseWithCount;
 
     static SemaphoreSlimMethodDescriptors()
@@ -45,7 +50,7 @@ public static class SemaphoreSlimMethodDescriptors
             RewritingDescriptor: new MethodRewritingDescriptor(
                 InjectHooks: true,
                 InjectManagedWrapper: false,
-                Arguments: [ObjectRefArg, InitialCountArg],
+                Arguments: [ObjectRefArg, InitialCountArg, MaximumCountArg],
                 ReturnValue: null,
                 MethodEnterInterpretation: (ushort)RecordedEventType.SemaphoreCreate,
                 MethodExitInterpretation: null));
@@ -92,23 +97,6 @@ public static class SemaphoreSlimMethodDescriptors
                 MethodEnterInterpretation: (ushort)RecordedEventType.SemaphoreTryAcquire,
                 MethodExitInterpretation: (ushort)RecordedEventType.SemaphoreAcquireResult));
 
-        ReleaseNoArgs = new MethodDescriptor(
-            MethodName: "Release",
-            DeclaringTypeFullName: SemaphoreSlimTypeName,
-            VersionDescriptor: null,
-            SignatureDescriptor: new MethodSignatureDescriptor(
-                CallingConvention: CorCallingConvention.IMAGE_CEE_CS_CALLCONV_HASTHIS,
-                ParametersCount: 0,
-                ReturnType: ArgumentTypeDescriptor.CreateSimple(CorElementType.ELEMENT_TYPE_I4),
-                ArgumentTypeElements: []),
-            RewritingDescriptor: new MethodRewritingDescriptor(
-                InjectHooks: true,
-                InjectManagedWrapper: false,
-                Arguments: [ObjectRefArg],
-                ReturnValue: null,
-                MethodEnterInterpretation: (ushort)RecordedEventType.SemaphoreRelease,
-                MethodExitInterpretation: (ushort)RecordedEventType.SemaphoreReleaseResult));
-
         ReleaseWithCount = new MethodDescriptor(
             MethodName: "Release",
             DeclaringTypeFullName: SemaphoreSlimTypeName,
@@ -121,7 +109,7 @@ public static class SemaphoreSlimMethodDescriptors
             RewritingDescriptor: new MethodRewritingDescriptor(
                 InjectHooks: true,
                 InjectManagedWrapper: false,
-                Arguments: [ObjectRefArg],
+                Arguments: [ ObjectRefArg, ReleaseCountArg ],
                 ReturnValue: null,
                 MethodEnterInterpretation: (ushort)RecordedEventType.SemaphoreRelease,
                 MethodExitInterpretation: (ushort)RecordedEventType.SemaphoreReleaseResult));
@@ -131,7 +119,6 @@ public static class SemaphoreSlimMethodDescriptors
     {
         // Public API
         yield return CtorWithMaxCount;
-        yield return ReleaseNoArgs;
         yield return ReleaseWithCount;
 
         // Internal API

--- a/src/Extensibility/SharpDetect.Plugins.Descriptors/Methods/SemaphoreSlimMethodDescriptors.cs
+++ b/src/Extensibility/SharpDetect.Plugins.Descriptors/Methods/SemaphoreSlimMethodDescriptors.cs
@@ -17,7 +17,11 @@ public static class SemaphoreSlimMethodDescriptors
     
     private static readonly CapturedArgumentDescriptor ObjectRefArg =
         new(0, new((byte)nint.Size, CapturedValue.CaptureAsReference));
-    
+
+    private static readonly CapturedArgumentDescriptor InitialCountArg =
+        new(1, new((byte)sizeof(int), CapturedValue.CaptureAsValue));
+
+    private static readonly MethodDescriptor CtorWithMaxCount;
     private static readonly MethodDescriptor WaitV8;
     private static readonly MethodDescriptor WaitCoreV10;
     private static readonly MethodDescriptor ReleaseNoArgs;
@@ -25,6 +29,27 @@ public static class SemaphoreSlimMethodDescriptors
 
     static SemaphoreSlimMethodDescriptors()
     {
+        CtorWithMaxCount = new MethodDescriptor(
+            MethodName: ".ctor",
+            DeclaringTypeFullName: SemaphoreSlimTypeName,
+            VersionDescriptor: null,
+            SignatureDescriptor: new MethodSignatureDescriptor(
+                CallingConvention: CorCallingConvention.IMAGE_CEE_CS_CALLCONV_HASTHIS,
+                ParametersCount: 2,
+                ReturnType: ArgumentTypeDescriptor.CreateSimple(CorElementType.ELEMENT_TYPE_VOID),
+                ArgumentTypeElements:
+                [
+                    ArgumentTypeDescriptor.CreateSimple(CorElementType.ELEMENT_TYPE_I4),
+                    ArgumentTypeDescriptor.CreateSimple(CorElementType.ELEMENT_TYPE_I4)
+                ]),
+            RewritingDescriptor: new MethodRewritingDescriptor(
+                InjectHooks: true,
+                InjectManagedWrapper: false,
+                Arguments: [ObjectRefArg, InitialCountArg],
+                ReturnValue: null,
+                MethodEnterInterpretation: (ushort)RecordedEventType.SemaphoreCreate,
+                MethodExitInterpretation: null));
+
         WaitV8 = new MethodDescriptor(
             MethodName: "Wait",
             DeclaringTypeFullName: SemaphoreSlimTypeName,
@@ -104,13 +129,14 @@ public static class SemaphoreSlimMethodDescriptors
 
     public static IEnumerable<MethodDescriptor> GetAllMethods()
     {
+        // Public API
+        yield return CtorWithMaxCount;
+        yield return ReleaseNoArgs;
+        yield return ReleaseWithCount;
+
         // Internal API
         yield return WaitV8;
         yield return WaitCoreV10;
-        
-        // Public API
-        yield return ReleaseNoArgs;
-        yield return ReleaseWithCount;
     }
 }
 

--- a/src/Extensibility/SharpDetect.Plugins.Descriptors/Methods/TaskMethodDescriptors.cs
+++ b/src/Extensibility/SharpDetect.Plugins.Descriptors/Methods/TaskMethodDescriptors.cs
@@ -15,9 +15,7 @@ public static class TaskMethodDescriptors
     private const string ContinuationResultTaskFromTaskTypeName = "System.Threading.Tasks.ContinuationResultTaskFromTask`1";
     private const string ContinuationTaskFromResultTaskTypeName = "System.Threading.Tasks.ContinuationTaskFromResultTask`1";
     private const string ContinuationResultTaskFromResultTaskTypeName = "System.Threading.Tasks.ContinuationResultTaskFromResultTask`2";
-    private const string ActionTypeName = "System.Action";
     private const string TaskAwaiterTypeName = "System.Runtime.CompilerServices.TaskAwaiter";
-    private const string IAsyncStateMachineBoxTypeName = "System.Runtime.CompilerServices.IAsyncStateMachineBox";
     private const string ConfigureAwaitOptionsTypeName = "System.Threading.Tasks.ConfigureAwaitOptions";
 
     private static readonly CapturedArgumentDescriptor ObjectRefArg =
@@ -33,8 +31,6 @@ public static class TaskMethodDescriptors
     private static readonly MethodDescriptor TaskWait;
     private static readonly MethodDescriptor TaskResult;
     private static readonly MethodDescriptor TaskAwaiterValidateEnd;
-    private static readonly MethodDescriptor TaskAwaiterOnCompleted;
-    private static readonly MethodDescriptor TaskAwaiterUnsafeOnCompleted;
 
     static TaskMethodDescriptors()
     {
@@ -125,51 +121,6 @@ public static class TaskMethodDescriptors
                 ReturnValue: null,
                 MethodEnterInterpretation: (ushort)RecordedEventType.TaskJoinStart,
                 MethodExitInterpretation: (ushort)RecordedEventType.TaskJoinFinish));
-        
-        TaskAwaiterOnCompleted= new MethodDescriptor(
-            MethodName: "OnCompletedInternal",
-            DeclaringTypeFullName: TaskAwaiterTypeName,
-            VersionDescriptor: null,
-            SignatureDescriptor: new MethodSignatureDescriptor(
-                CallingConvention: CorCallingConvention.IMAGE_CEE_CS_CALLCONV_DEFAULT,
-                ParametersCount: 4,
-                ReturnType: ArgumentTypeDescriptor.CreateSimple(CorElementType.ELEMENT_TYPE_VOID),
-                ArgumentTypeElements:
-                [
-                    ArgumentTypeDescriptor.CreateClass(TaskTypeName),
-                    ArgumentTypeDescriptor.CreateClass(ActionTypeName),
-                    ArgumentTypeDescriptor.CreateSimple(CorElementType.ELEMENT_TYPE_BOOLEAN),
-                    ArgumentTypeDescriptor.CreateSimple(CorElementType.ELEMENT_TYPE_BOOLEAN)
-                ]),
-            RewritingDescriptor: new MethodRewritingDescriptor(
-                InjectHooks: true,
-                InjectManagedWrapper: false,
-                Arguments: [ new(0, new((byte)nint.Size, CapturedValue.CaptureAsReference)) ],
-                ReturnValue: null,
-                MethodEnterInterpretation: (ushort)RecordedEventType.TaskJoinStart,
-                MethodExitInterpretation: (ushort)RecordedEventType.TaskJoinFinish));
-        
-        TaskAwaiterUnsafeOnCompleted= new MethodDescriptor(
-            MethodName: "UnsafeOnCompletedInternal",
-            DeclaringTypeFullName: TaskAwaiterTypeName,
-            VersionDescriptor: null,
-            SignatureDescriptor: new MethodSignatureDescriptor(
-                CallingConvention: CorCallingConvention.IMAGE_CEE_CS_CALLCONV_DEFAULT,
-                ParametersCount: 3,
-                ReturnType: ArgumentTypeDescriptor.CreateSimple(CorElementType.ELEMENT_TYPE_VOID),
-                ArgumentTypeElements:
-                [
-                    ArgumentTypeDescriptor.CreateClass(TaskTypeName),
-                    ArgumentTypeDescriptor.CreateClass(IAsyncStateMachineBoxTypeName),
-                    ArgumentTypeDescriptor.CreateSimple(CorElementType.ELEMENT_TYPE_BOOLEAN)
-                ]),
-            RewritingDescriptor: new MethodRewritingDescriptor(
-                InjectHooks: true,
-                InjectManagedWrapper: false,
-                Arguments: [ new(0, new((byte)nint.Size, CapturedValue.CaptureAsReference)) ],
-                ReturnValue: null,
-                MethodEnterInterpretation: (ushort)RecordedEventType.TaskJoinStart,
-                MethodExitInterpretation: (ushort)RecordedEventType.TaskJoinFinish));
     }
 
     private static MethodDescriptor CreateInnerInvokeMethodDescriptorForType(string typeName)
@@ -203,8 +154,6 @@ public static class TaskMethodDescriptors
         yield return ContinuationTaskFromResultTaskInnerInvoke;
         yield return ContinuationResultTaskFromResultTaskInnerInvoke;
         yield return TaskAwaiterValidateEnd;
-        yield return TaskAwaiterOnCompleted;
-        yield return TaskAwaiterUnsafeOnCompleted;
 
         // Common public API
         yield return TaskWait;

--- a/src/Extensibility/SharpDetect.Plugins.PerThreadOrdering/PerThreadOrderingPluginBase.cs
+++ b/src/Extensibility/SharpDetect.Plugins.PerThreadOrdering/PerThreadOrderingPluginBase.cs
@@ -40,6 +40,7 @@ public abstract class PerThreadOrderingPluginBase : PluginBase
     public event Action<StaticFieldWriteArgs>? StaticFieldWritten;
     public event Action<InstanceFieldReadArgs>? InstanceFieldRead;
     public event Action<InstanceFieldWriteArgs>? InstanceFieldWritten;
+    public event Action<SemaphoreCreatedArgs>? SemaphoreCreated;
     public event Action<SemaphoreAcquireAttemptArgs>? SemaphoreAcquireAttempted;
     public event Action<SemaphoreAcquireResultArgs>? SemaphoreAcquireReturned;
     public event Action<SemaphoreReleaseArgs>? SemaphoreReleased;
@@ -76,6 +77,7 @@ public abstract class PerThreadOrderingPluginBase : PluginBase
     protected void RaiseStaticFieldWritten(StaticFieldWriteArgs args) => StaticFieldWritten?.Invoke(args);
     protected void RaiseInstanceFieldRead(InstanceFieldReadArgs args) => InstanceFieldRead?.Invoke(args);
     protected void RaiseInstanceFieldWritten(InstanceFieldWriteArgs args) => InstanceFieldWritten?.Invoke(args);
+    protected void RaiseSemaphoreCreated(SemaphoreCreatedArgs args) => SemaphoreCreated?.Invoke(args);
     protected void RaiseSemaphoreAcquireAttempted(SemaphoreAcquireAttemptArgs args) => SemaphoreAcquireAttempted?.Invoke(args);
     protected void RaiseSemaphoreAcquireReturned(SemaphoreAcquireResultArgs args) => SemaphoreAcquireReturned?.Invoke(args);
     protected void RaiseSemaphoreReleased(SemaphoreReleaseArgs args) => SemaphoreReleased?.Invoke(args);
@@ -166,6 +168,14 @@ public abstract class PerThreadOrderingPluginBase : PluginBase
         var lockId = ExtractSynchronizationObjectIdFromFrame(id, frame);
         var success = MemoryMarshal.Read<bool>(args.ReturnValue);
         ProcessWaitReturn(id, args.ModuleId, args.MethodToken, lockId, success);
+    }
+
+    [RecordedEventBind((ushort)RecordedEventType.SemaphoreCreate)]
+    public void OnSemaphoreCreateEnter(RecordedEventMetadata metadata, MethodEnterWithArgumentsRecordedEvent args)
+    {
+        var (id, arguments, semaphoreId) = ExtractSynchronizationContext(metadata, args);
+        var initialCount = (int)arguments[1].Value.AsT0;
+        SemaphoreCreated?.Invoke(new(id, args.ModuleId, args.MethodToken, semaphoreId, initialCount));
     }
 
     [RecordedEventBind((ushort)RecordedEventType.SemaphoreAcquire)]

--- a/src/Extensibility/SharpDetect.Plugins.PerThreadOrdering/PerThreadOrderingPluginBase.cs
+++ b/src/Extensibility/SharpDetect.Plugins.PerThreadOrdering/PerThreadOrderingPluginBase.cs
@@ -205,8 +205,12 @@ public abstract class PerThreadOrderingPluginBase : PluginBase
     [RecordedEventBind((ushort)RecordedEventType.SemaphoreReleaseResult)]
     public void OnSemaphoreReleaseExit(RecordedEventMetadata metadata, MethodExitRecordedEvent args)
     {
-        var (id, semaphoreId) = PopLockContext(metadata, args);
-        SemaphoreReleased?.Invoke(new(id, args.ModuleId, args.MethodToken, semaphoreId));
+        var id = new ProcessThreadId(metadata.Pid, metadata.Tid);
+        var frame = _callStackTracker.Pop(id);
+        EnsureCallStackIntegrity(frame, args.ModuleId, args.MethodToken);
+        var semaphoreId = ExtractSynchronizationObjectIdFromFrame(id, frame);
+        var releaseCount = (int)frame.Arguments!.Value[1].Value.AsT0;
+        SemaphoreReleased?.Invoke(new(id, args.ModuleId, args.MethodToken, semaphoreId, releaseCount));
     }
     
     [RecordedEventBind((ushort)RecordedEventType.ThreadStartCore)]

--- a/src/SharpDetect.Core/Events/RecordedEventType.cs
+++ b/src/SharpDetect.Core/Events/RecordedEventType.cs
@@ -87,6 +87,7 @@ public enum RecordedEventType : ushort
     SemaphoreAcquireResult = 120,
     SemaphoreRelease = 121,
     SemaphoreReleaseResult = 122,
+    SemaphoreCreate = 123,
 
     /* Task synchronization */
     TaskSchedule = 200,

--- a/src/SharpDetect.Core/Plugins/PluginEventArgs.cs
+++ b/src/SharpDetect.Core/Plugins/PluginEventArgs.cs
@@ -28,3 +28,4 @@ public readonly record struct TaskJoinFinishArgs(ProcessThreadId ProcessThreadId
 public readonly record struct SemaphoreAcquireAttemptArgs(ProcessThreadId ProcessThreadId, ModuleId ModuleId, MdMethodDef MethodToken, ProcessTrackedObjectId SemaphoreId);
 public readonly record struct SemaphoreAcquireResultArgs(ProcessThreadId ProcessThreadId, ModuleId ModuleId, MdMethodDef MethodToken, ProcessTrackedObjectId SemaphoreId, bool IsSuccess);
 public readonly record struct SemaphoreReleaseArgs(ProcessThreadId ProcessThreadId, ModuleId ModuleId, MdMethodDef MethodToken, ProcessTrackedObjectId SemaphoreId);
+public readonly record struct SemaphoreCreatedArgs(ProcessThreadId ProcessThreadId, ModuleId ModuleId, MdMethodDef MethodToken, ProcessTrackedObjectId SemaphoreId, int InitialCount);

--- a/src/SharpDetect.Core/Plugins/PluginEventArgs.cs
+++ b/src/SharpDetect.Core/Plugins/PluginEventArgs.cs
@@ -27,5 +27,5 @@ public readonly record struct TaskCompleteArgs(ProcessThreadId ProcessThreadId, 
 public readonly record struct TaskJoinFinishArgs(ProcessThreadId ProcessThreadId, ProcessTrackedObjectId TaskObjectId, bool IsSuccess);
 public readonly record struct SemaphoreAcquireAttemptArgs(ProcessThreadId ProcessThreadId, ModuleId ModuleId, MdMethodDef MethodToken, ProcessTrackedObjectId SemaphoreId);
 public readonly record struct SemaphoreAcquireResultArgs(ProcessThreadId ProcessThreadId, ModuleId ModuleId, MdMethodDef MethodToken, ProcessTrackedObjectId SemaphoreId, bool IsSuccess);
-public readonly record struct SemaphoreReleaseArgs(ProcessThreadId ProcessThreadId, ModuleId ModuleId, MdMethodDef MethodToken, ProcessTrackedObjectId SemaphoreId);
+public readonly record struct SemaphoreReleaseArgs(ProcessThreadId ProcessThreadId, ModuleId ModuleId, MdMethodDef MethodToken, ProcessTrackedObjectId SemaphoreId, int ReleaseCount);
 public readonly record struct SemaphoreCreatedArgs(ProcessThreadId ProcessThreadId, ModuleId ModuleId, MdMethodDef MethodToken, ProcessTrackedObjectId SemaphoreId, int InitialCount);

--- a/src/SharpDetect.Core/Plugins/RecordedEventState.cs
+++ b/src/SharpDetect.Core/Plugins/RecordedEventState.cs
@@ -7,7 +7,7 @@ public enum RecordedEventState
 {
     Unavailable = 0,
     Executed = 1,
-    Defered = 2,
+    Deferred = 2,
     Discarded = 3,
     Failed = 4
 }

--- a/src/SharpDetect.Worker/Services/AnalysisWorker.cs
+++ b/src/SharpDetect.Worker/Services/AnalysisWorker.cs
@@ -125,16 +125,24 @@ public sealed class AnalysisWorker : IAnalysisWorker
     
     private void ExecuteAnalysis(Task targetProcessTask, uint rootPid, CancellationToken cancellationToken)
     {
-        foreach (var currentEvent in ReceiveEvents(targetProcessTask, rootPid, cancellationToken))
+        try
         {
-            if (currentEvent.EventArgs is ProfilerDestroyRecordedEvent && currentEvent.Metadata.Pid == rootPid)
-                return;
-
-            if (_pluginHost.ProcessEvent(currentEvent) == RecordedEventState.Failed)
+            foreach (var currentEvent in ReceiveEvents(targetProcessTask, rootPid, cancellationToken))
             {
-                LogFailureAndTerminateAnalysis();
-                return;
+                if (currentEvent.EventArgs is ProfilerDestroyRecordedEvent && currentEvent.Metadata.Pid == rootPid)
+                    return;
+
+                if (_pluginHost.ProcessEvent(currentEvent) == RecordedEventState.Failed)
+                {
+                    LogFailureAndTerminateAnalysis();
+                    return;
+                }
             }
+        }
+        finally
+        {
+            if (_pluginHost is IDisposable disposable)
+                disposable.Dispose();
         }
     }
 

--- a/src/SharpDetect.slnx
+++ b/src/SharpDetect.slnx
@@ -33,6 +33,7 @@
     <Project Path="Tests/SharpDetect.E2ETests.Subject/SharpDetect.E2ETests.Subject.csproj" />
     <Project Path="Tests/SharpDetect.E2ETests/SharpDetect.E2ETests.csproj" />
     <Project Path="Tests/SharpDetect.InterProcessQueue.Tests/SharpDetect.InterProcessQueue.Tests.csproj" />
+    <Project Path="Tests/SharpDetect.PluginHost.Tests/SharpDetect.PluginHost.Tests.csproj" />
     <Project Path="Tests/SharpDetect.Reporting.Tests/SharpDetect.Reporting.Tests.csproj" />
     <Project Path="Tests/SharpDetect.TemporalAsserts/SharpDetect.TemporalAsserts.csproj" />
   </Folder>

--- a/src/Tests/SharpDetect.E2ETests.Subject/Entrypoint.cs
+++ b/src/Tests/SharpDetect.E2ETests.Subject/Entrypoint.cs
@@ -494,6 +494,9 @@ namespace SharpDetect.E2ETests.Subject
                 case nameof(Test_NoDataRace_Semaphore_HighContention_WriteRead):
                     Test_NoDataRace_Semaphore_HighContention_WriteRead();
                     break;
+                case nameof(Test_NoDataRace_Semaphore_BatchRelease_WriteRead):
+                    Test_NoDataRace_Semaphore_BatchRelease_WriteRead();
+                    break;
             }
 
             // Disposables

--- a/src/Tests/SharpDetect.E2ETests.Subject/Entrypoint.cs
+++ b/src/Tests/SharpDetect.E2ETests.Subject/Entrypoint.cs
@@ -488,6 +488,9 @@ namespace SharpDetect.E2ETests.Subject
                 case nameof(Test_NoDataRace_SemaphoreSlim_ProtectedWriteRead):
                     Test_NoDataRace_SemaphoreSlim_ProtectedWriteRead();
                     break;
+                case nameof(Test_NoDataRace_Monitor_HighContention_WriteRead):
+                    Test_NoDataRace_Monitor_HighContention_WriteRead();
+                    break;
             }
 
             // Disposables

--- a/src/Tests/SharpDetect.E2ETests.Subject/Entrypoint.cs
+++ b/src/Tests/SharpDetect.E2ETests.Subject/Entrypoint.cs
@@ -491,6 +491,9 @@ namespace SharpDetect.E2ETests.Subject
                 case nameof(Test_NoDataRace_Monitor_HighContention_WriteRead):
                     Test_NoDataRace_Monitor_HighContention_WriteRead();
                     break;
+                case nameof(Test_NoDataRace_Semaphore_HighContention_WriteRead):
+                    Test_NoDataRace_Semaphore_HighContention_WriteRead();
+                    break;
             }
 
             // Disposables

--- a/src/Tests/SharpDetect.E2ETests.Subject/SimpleTests.cs
+++ b/src/Tests/SharpDetect.E2ETests.Subject/SimpleTests.cs
@@ -1279,6 +1279,31 @@ namespace SharpDetect.E2ETests.Subject
                 });
         }
 
+        public static void Test_NoDataRace_Semaphore_HighContention_WriteRead()
+        {
+            const int iterations = 5000;
+            var semaphore = new SemaphoreSlim(1, 1);
+            RunConcurrently(
+                () =>
+                {
+                    for (var i = 0; i < iterations; i++)
+                    {
+                        semaphore.Wait();
+                        DataRace.Test_DataRace_ValueType_Static = i;
+                        semaphore.Release();
+                    }
+                },
+                () =>
+                {
+                    for (var i = 0; i < iterations; i++)
+                    {
+                        semaphore.Wait();
+                        _ = DataRace.Test_DataRace_ValueType_Static;
+                        semaphore.Release();
+                    }
+                });
+        }
+
         public static void Test_SingleGarbageCollection_ObjectTracking_Simple()
         {
             // Generate garbage

--- a/src/Tests/SharpDetect.E2ETests.Subject/SimpleTests.cs
+++ b/src/Tests/SharpDetect.E2ETests.Subject/SimpleTests.cs
@@ -1304,6 +1304,15 @@ namespace SharpDetect.E2ETests.Subject
                 });
         }
 
+        public static void Test_NoDataRace_Semaphore_BatchRelease_WriteRead()
+        {
+            const int permits = 4;
+            var semaphore = new SemaphoreSlim(0, permits);
+            semaphore.Release(permits);
+            for (var i = 0; i < permits; i++)
+                semaphore.Wait();
+        }
+
         public static void Test_SingleGarbageCollection_ObjectTracking_Simple()
         {
             // Generate garbage

--- a/src/Tests/SharpDetect.E2ETests.Subject/SimpleTests.cs
+++ b/src/Tests/SharpDetect.E2ETests.Subject/SimpleTests.cs
@@ -1256,6 +1256,29 @@ namespace SharpDetect.E2ETests.Subject
             Task.WaitAll(task1, task2);
         }
 
+        public static void Test_NoDataRace_Monitor_HighContention_WriteRead()
+        {
+            const int iterations = 5000;
+            var lockObj = new object();
+            RunConcurrently(
+                () =>
+                {
+                    for (var i = 0; i < iterations; i++)
+                    {
+                        lock (lockObj)
+                            DataRace.Test_DataRace_ValueType_Static = i;
+                    }
+                },
+                () =>
+                {
+                    for (var i = 0; i < iterations; i++)
+                    {
+                        lock (lockObj)
+                            _ = DataRace.Test_DataRace_ValueType_Static;
+                    }
+                });
+        }
+
         public static void Test_SingleGarbageCollection_ObjectTracking_Simple()
         {
             // Generate garbage

--- a/src/Tests/SharpDetect.E2ETests/DataRacePluginTests.cs
+++ b/src/Tests/SharpDetect.E2ETests/DataRacePluginTests.cs
@@ -145,6 +145,11 @@ public class DataRacePluginTests(ITestOutputHelper testOutput)
         => AssertDoesNotDetectDataRace("Test_NoDataRace_Semaphore_HighContention_WriteRead", sdk, plugin);
 
     [Theory]
+    [MemberData(nameof(SdkVersions.AllWithFastTrackOnly), MemberType = typeof(SdkVersions))]
+    public Task NoDataRace_SemaphoreSlim_BatchRelease_WriteRead(string sdk, string plugin)
+        => AssertDoesNotDetectDataRace("Test_NoDataRace_Semaphore_BatchRelease_WriteRead", sdk, plugin);
+
+    [Theory]
     [MemberData(nameof(SdkVersions.AllWithBothDataRacePlugins), MemberType = typeof(SdkVersions))]
     public Task NoDataRace_GenericType_Static_DifferentInstantiations_WriteWrite_NoRace(string sdk, string plugin)
         => AssertDoesNotDetectDataRace("Test_NoDataRace_GenericType_Static_DifferentInstantiations_WriteWrite_NoRace", sdk, plugin);

--- a/src/Tests/SharpDetect.E2ETests/DataRacePluginTests.cs
+++ b/src/Tests/SharpDetect.E2ETests/DataRacePluginTests.cs
@@ -136,6 +136,11 @@ public class DataRacePluginTests(ITestOutputHelper testOutput)
 
     [Theory]
     [MemberData(nameof(SdkVersions.AllWithBothDataRacePlugins), MemberType = typeof(SdkVersions))]
+    public Task NoDataRace_Monitor_HighContention_WriteRead(string sdk, string plugin)
+        => AssertDoesNotDetectDataRace("Test_NoDataRace_Monitor_HighContention_WriteRead", sdk, plugin);
+
+    [Theory]
+    [MemberData(nameof(SdkVersions.AllWithBothDataRacePlugins), MemberType = typeof(SdkVersions))]
     public Task NoDataRace_GenericType_Static_DifferentInstantiations_WriteWrite_NoRace(string sdk, string plugin)
         => AssertDoesNotDetectDataRace("Test_NoDataRace_GenericType_Static_DifferentInstantiations_WriteWrite_NoRace", sdk, plugin);
 

--- a/src/Tests/SharpDetect.E2ETests/DataRacePluginTests.cs
+++ b/src/Tests/SharpDetect.E2ETests/DataRacePluginTests.cs
@@ -138,6 +138,11 @@ public class DataRacePluginTests(ITestOutputHelper testOutput)
     [MemberData(nameof(SdkVersions.AllWithBothDataRacePlugins), MemberType = typeof(SdkVersions))]
     public Task NoDataRace_Monitor_HighContention_WriteRead(string sdk, string plugin)
         => AssertDoesNotDetectDataRace("Test_NoDataRace_Monitor_HighContention_WriteRead", sdk, plugin);
+    
+    [Theory]
+    [MemberData(nameof(SdkVersions.AllWithFastTrackOnly), MemberType = typeof(SdkVersions))]
+    public Task NoDataRace_SemaphoreSlim_HighContention_WriteRead(string sdk, string plugin)
+        => AssertDoesNotDetectDataRace("Test_NoDataRace_Semaphore_HighContention_WriteRead", sdk, plugin);
 
     [Theory]
     [MemberData(nameof(SdkVersions.AllWithBothDataRacePlugins), MemberType = typeof(SdkVersions))]

--- a/src/Tests/SharpDetect.PluginHost.Tests/CapturingLogger.cs
+++ b/src/Tests/SharpDetect.PluginHost.Tests/CapturingLogger.cs
@@ -1,0 +1,31 @@
+// Copyright 2026 Andrej Čižmárik and Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+using Microsoft.Extensions.Logging;
+
+namespace SharpDetect.PluginHost.Tests;
+
+internal sealed class CapturingLogger<T> : ILogger<T>
+{
+    public List<(LogLevel Level, string Message)> Entries { get; } = [];
+
+    public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
+
+    public bool IsEnabled(LogLevel logLevel) => true;
+
+    public void Log<TState>(
+        LogLevel logLevel,
+        EventId eventId,
+        TState state,
+        Exception? exception,
+        Func<TState, Exception?, string> formatter)
+    {
+        Entries.Add((logLevel, formatter(state, exception)));
+    }
+
+    private sealed class NullScope : IDisposable
+    {
+        public static readonly NullScope Instance = new();
+        public void Dispose() { }
+    }
+}

--- a/src/Tests/SharpDetect.PluginHost.Tests/RecordingPluginHost.cs
+++ b/src/Tests/SharpDetect.PluginHost.Tests/RecordingPluginHost.cs
@@ -1,0 +1,18 @@
+// Copyright 2026 Andrej Čižmárik and Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+using SharpDetect.Core.Events;
+using SharpDetect.Core.Plugins;
+
+namespace SharpDetect.PluginHost.Tests;
+
+internal sealed class RecordingPluginHost : IPluginHost
+{
+    public List<RecordedEvent> Dispatched { get; } = [];
+
+    public RecordedEventState ProcessEvent(RecordedEvent recordedEvent)
+    {
+        Dispatched.Add(recordedEvent);
+        return RecordedEventState.Executed;
+    }
+}

--- a/src/Tests/SharpDetect.PluginHost.Tests/ReorderingPluginHostTests.cs
+++ b/src/Tests/SharpDetect.PluginHost.Tests/ReorderingPluginHostTests.cs
@@ -312,7 +312,7 @@ public class ReorderingPluginHostTests
         var host = Build(out var recorder);
 
         // Act
-        host.ProcessEvent(SyncEventBuilder.EnterWithTargetAndCount(T1, RecordedEventType.SemaphoreCreate, S1, 1));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTargetCountAndCapacity(T1, RecordedEventType.SemaphoreCreate, S1, 1, 1));
         host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.SemaphoreAcquire, S1));
         host.ProcessEvent(SyncEventBuilder.ExitWithSuccess(T1, RecordedEventType.SemaphoreAcquireResult, true));
         host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.SemaphoreRelease, S1));
@@ -330,7 +330,7 @@ public class ReorderingPluginHostTests
         var host = Build(out var recorder);
 
         // Act
-        host.ProcessEvent(SyncEventBuilder.EnterWithTargetAndCount(T1, RecordedEventType.SemaphoreCreate, S1, 1));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTargetCountAndCapacity(T1, RecordedEventType.SemaphoreCreate, S1, 1, 1));
         host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.SemaphoreAcquire, S1));
         host.ProcessEvent(SyncEventBuilder.ExitWithSuccess(T1, RecordedEventType.SemaphoreAcquireResult, true));
         host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T2, RecordedEventType.SemaphoreAcquire, S1));
@@ -361,7 +361,7 @@ public class ReorderingPluginHostTests
         var host = Build(out var recorder);
 
         // Act & Assert
-        host.ProcessEvent(SyncEventBuilder.EnterWithTargetAndCount(T1, RecordedEventType.SemaphoreCreate, S1, 1));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTargetCountAndCapacity(T1, RecordedEventType.SemaphoreCreate, S1, 1, 1));
         host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.SemaphoreAcquire, S1));
         host.ProcessEvent(SyncEventBuilder.ExitWithSuccess(T1, RecordedEventType.SemaphoreAcquireResult, true));
         host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T2, RecordedEventType.SemaphoreAcquire, S1));
@@ -386,7 +386,7 @@ public class ReorderingPluginHostTests
         var host = Build(out var recorder);
 
         // Act
-        host.ProcessEvent(SyncEventBuilder.EnterWithTargetAndCount(T1, RecordedEventType.SemaphoreCreate, S1, 1));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTargetCountAndCapacity(T1, RecordedEventType.SemaphoreCreate, S1, 1, 1));
         host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.SemaphoreAcquire, S1));
         host.ProcessEvent(SyncEventBuilder.ExitWithSuccess(T1, RecordedEventType.SemaphoreAcquireResult, true));
         host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T2, RecordedEventType.SemaphoreTryAcquire, S1));
@@ -404,7 +404,7 @@ public class ReorderingPluginHostTests
         var host = Build(out var recorder);
 
         // Act
-        host.ProcessEvent(SyncEventBuilder.EnterWithTargetAndCount(T1, RecordedEventType.SemaphoreCreate, S1, 2));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTargetCountAndCapacity(T1, RecordedEventType.SemaphoreCreate, S1, 2, 2));
         host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.SemaphoreAcquire, S1));
         host.ProcessEvent(SyncEventBuilder.ExitWithSuccess(T1, RecordedEventType.SemaphoreAcquireResult, true));
         host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T2, RecordedEventType.SemaphoreAcquire, S1));
@@ -570,7 +570,7 @@ public class ReorderingPluginHostTests
         var host = Build(out var recorder);
 
         // Act
-        host.ProcessEvent(SyncEventBuilder.EnterWithTargetAndCount(T1, RecordedEventType.SemaphoreCreate, S1, 1));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTargetCountAndCapacity(T1, RecordedEventType.SemaphoreCreate, S1, 1, 1));
         host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.SemaphoreAcquire, S1));
         host.ProcessEvent(SyncEventBuilder.ExitWithSuccess(T1, RecordedEventType.SemaphoreAcquireResult, true));
         host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T2, RecordedEventType.SemaphoreAcquire, S1));
@@ -593,7 +593,7 @@ public class ReorderingPluginHostTests
         var host = Build(out var recorder);
 
         // Act
-        host.ProcessEvent(SyncEventBuilder.EnterWithTargetAndCount(T1, RecordedEventType.SemaphoreCreate, S1, 1));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTargetCountAndCapacity(T1, RecordedEventType.SemaphoreCreate, S1, 1, 1));
         host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.SemaphoreAcquire, S1));
         host.ProcessEvent(SyncEventBuilder.ExitWithSuccess(T1, RecordedEventType.SemaphoreAcquireResult, true));
         host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T2, RecordedEventType.SemaphoreAcquire, S1));
@@ -679,7 +679,7 @@ public class ReorderingPluginHostTests
         var host = Build(out var recorder, out var logger);
 
         // Act
-        host.ProcessEvent(SyncEventBuilder.EnterWithTargetAndCount(T1, RecordedEventType.SemaphoreCreate, S1, 1));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTargetCountAndCapacity(T1, RecordedEventType.SemaphoreCreate, S1, 1, 1));
         host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.SemaphoreAcquire, S1));
         host.ProcessEvent(SyncEventBuilder.ExitWithSuccess(T1, RecordedEventType.SemaphoreAcquireResult, true));
         host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.SemaphoreRelease, S1));
@@ -722,7 +722,7 @@ public class ReorderingPluginHostTests
         host.ProcessEvent(SyncEventBuilder.Exit(T1, RecordedEventType.MonitorLockAcquireResult));
         host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.MonitorLockRelease, L1));
         host.ProcessEvent(SyncEventBuilder.Exit(T1, RecordedEventType.MonitorLockReleaseResult));
-        host.ProcessEvent(SyncEventBuilder.EnterWithTargetAndCount(T1, RecordedEventType.SemaphoreCreate, S1, 1));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTargetCountAndCapacity(T1, RecordedEventType.SemaphoreCreate, S1, 1, 1));
         host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T2, RecordedEventType.TaskStart, Task1));
         host.ProcessEvent(SyncEventBuilder.Exit(T2, RecordedEventType.TaskComplete));
         Assert.Equal(1, host.ShadowLockCount);
@@ -759,7 +759,7 @@ public class ReorderingPluginHostTests
         var host = Build(out _, out var logger);
 
         // Act
-        host.ProcessEvent(SyncEventBuilder.EnterWithTargetAndCount(T1, RecordedEventType.SemaphoreCreate, S1, 1));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTargetCountAndCapacity(T1, RecordedEventType.SemaphoreCreate, S1, 1, 1));
         host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.SemaphoreAcquire, S1));
         host.ProcessEvent(SyncEventBuilder.ExitWithSuccess(T1, RecordedEventType.SemaphoreAcquireResult, true));
         host.ProcessEvent(SyncEventBuilder.GarbageCollected(TReaper, S1));

--- a/src/Tests/SharpDetect.PluginHost.Tests/ReorderingPluginHostTests.cs
+++ b/src/Tests/SharpDetect.PluginHost.Tests/ReorderingPluginHostTests.cs
@@ -14,6 +14,7 @@ public class ReorderingPluginHostTests
     private const uint T1 = 1;
     private const uint T2 = 2;
     private const uint T3 = 3;
+    private const uint TReaper = 9;
     private const nuint L1 = 0x1000;
     private const nuint L2 = 0x1001;
     private const nuint S1 = 0x1800;
@@ -209,7 +210,7 @@ public class ReorderingPluginHostTests
     }
     
     [Fact]
-    public void ReorderingPluginHost_FailedMonitorWait_NotDeferred_NotReordered()
+    public void ReorderingPluginHost_FailedMonitorWait_IsDeferred_IsReordered()
     {
         // Arrange
         var host = Build(out var recorder);
@@ -221,12 +222,35 @@ public class ReorderingPluginHostTests
         host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T2, RecordedEventType.MonitorLockAcquire, L1));
         host.ProcessEvent(SyncEventBuilder.Exit(T2, RecordedEventType.MonitorLockAcquireResult));
         host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T2, RecordedEventType.MonitorLockRelease, L1));
-        host.ProcessEvent(SyncEventBuilder.ExitWithSuccess(T1, RecordedEventType.MonitorWaitResult, false));
-        host.ProcessEvent(SyncEventBuilder.Exit(T2, RecordedEventType.MonitorLockReleaseResult));
+        host.ProcessEvent(SyncEventBuilder.ExitWithSuccess(T1, RecordedEventType.MonitorWaitResult, false)); // deferred — wait timeout still reacquires
+        host.ProcessEvent(SyncEventBuilder.Exit(T2, RecordedEventType.MonitorLockReleaseResult)); // wakes T1
 
         // Assert
         Assert.Equal(8, recorder.Dispatched.Count);
-        Assert.Equal((T2, RecordedEventType.MonitorLockReleaseResult), ClassifyDispatched(recorder.Dispatched.Last()));
+        Assert.Equal((T1, RecordedEventType.MonitorWaitResult), ClassifyDispatched(recorder.Dispatched.Last()));
+    }
+
+    [Fact]
+    public void ReorderingPluginHost_FailedMonitorWait_ReacquiresShadowLockForOwner()
+    {
+        // Arrange
+        var host = Build(out var recorder);
+
+        // Act & Assert
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.MonitorLockAcquire, L1));
+        host.ProcessEvent(SyncEventBuilder.Exit(T1, RecordedEventType.MonitorLockAcquireResult));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.MonitorWaitAttempt, L1));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T2, RecordedEventType.MonitorLockAcquire, L1));
+        host.ProcessEvent(SyncEventBuilder.Exit(T2, RecordedEventType.MonitorLockAcquireResult));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T2, RecordedEventType.MonitorLockRelease, L1));
+        host.ProcessEvent(SyncEventBuilder.Exit(T2, RecordedEventType.MonitorLockReleaseResult));
+        host.ProcessEvent(SyncEventBuilder.ExitWithSuccess(T1, RecordedEventType.MonitorWaitResult, false));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T3, RecordedEventType.MonitorLockAcquire, L1));
+        host.ProcessEvent(SyncEventBuilder.Exit(T3, RecordedEventType.MonitorLockAcquireResult));
+        Assert.DoesNotContain(recorder.Dispatched, e => e.Metadata.Tid.Value == T3 && IsAcquireResult(e));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.MonitorLockRelease, L1));
+        host.ProcessEvent(SyncEventBuilder.Exit(T1, RecordedEventType.MonitorLockReleaseResult));
+        Assert.Contains(recorder.Dispatched, e => e.Metadata.Tid.Value == T3 && IsAcquireResult(e));
     }
 
     [Fact]
@@ -393,7 +417,7 @@ public class ReorderingPluginHostTests
     }
 
     [Fact]
-    public void ReorderingPluginHost_MonitorWaitWithoutOwnership_DispatchesWhenLockFree()
+    public void ReorderingPluginHost_MonitorWaitWithoutOwnership_DispatchesWithoutCorruptingShadow()
     {
         // Arrange
         var host = Build(out var recorder);
@@ -404,11 +428,16 @@ public class ReorderingPluginHostTests
         host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.MonitorWaitAttempt, L1));
         host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T2, RecordedEventType.MonitorLockRelease, L1));
         host.ProcessEvent(SyncEventBuilder.Exit(T2, RecordedEventType.MonitorLockReleaseResult));
-        host.ProcessEvent(SyncEventBuilder.ExitWithSuccess(T1, RecordedEventType.MonitorWaitResult, true));
-
-        // Assert
+        host.ProcessEvent(SyncEventBuilder.ExitWithSuccess(T1, RecordedEventType.MonitorWaitResult, false));
+        Assert.Contains(recorder.Dispatched, e =>
+            e.Metadata.Tid.Value == T1 && ClassifyDispatched(e) == (T1, RecordedEventType.MonitorWaitAttempt));
         Assert.Contains(recorder.Dispatched, e =>
             e.Metadata.Tid.Value == T1 && ClassifyDispatched(e) == (T1, RecordedEventType.MonitorWaitResult));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T3, RecordedEventType.MonitorLockAcquire, L1));
+        host.ProcessEvent(SyncEventBuilder.Exit(T3, RecordedEventType.MonitorLockAcquireResult));
+
+        // Assert
+        Assert.Contains(recorder.Dispatched, e => e.Metadata.Tid.Value == T3 && IsAcquireResult(e));
     }
 
     [Fact]
@@ -480,6 +509,90 @@ public class ReorderingPluginHostTests
     }
 
     [Fact]
+    public void ReorderingPluginHost_ThreadDestroy_PurgesDestroyedFromLockWaiterQueue()
+    {
+        // Arrange
+        var host = Build(out var recorder);
+
+        // Act
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.MonitorLockAcquire, L1));
+        host.ProcessEvent(SyncEventBuilder.Exit(T1, RecordedEventType.MonitorLockAcquireResult));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T2, RecordedEventType.MonitorLockAcquire, L1));
+        host.ProcessEvent(SyncEventBuilder.Exit(T2, RecordedEventType.MonitorLockAcquireResult)); // deferred [1st in wake queue]
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T3, RecordedEventType.MonitorLockAcquire, L1));
+        host.ProcessEvent(SyncEventBuilder.Exit(T3, RecordedEventType.MonitorLockAcquireResult)); // deferred [2nd in wake queue]
+        host.ProcessEvent(SyncEventBuilder.ThreadDestroy(T2, TReaper)); // dead before being woken; destroy fires from a different thread
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.MonitorLockRelease, L1));
+        host.ProcessEvent(SyncEventBuilder.Exit(T1, RecordedEventType.MonitorLockReleaseResult)); // would have woken T2 — must now wake T3
+
+        // Assert
+        Assert.Contains(recorder.Dispatched, e => e.Metadata.Tid.Value == T3 && IsAcquireResult(e));
+        Assert.DoesNotContain(recorder.Dispatched, e => e.Metadata.Tid.Value == T2 && IsAcquireResult(e));
+    }
+
+    [Fact]
+    public void ReorderingPluginHost_ThreadDestroy_PurgesDestroyedFromSemaphoreWaiterQueue()
+    {
+        // Arrange
+        var host = Build(out var recorder);
+
+        // Act
+        host.ProcessEvent(SyncEventBuilder.EnterWithTargetAndCount(T1, RecordedEventType.SemaphoreCreate, S1, 1));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.SemaphoreAcquire, S1));
+        host.ProcessEvent(SyncEventBuilder.ExitWithSuccess(T1, RecordedEventType.SemaphoreAcquireResult, true));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T2, RecordedEventType.SemaphoreAcquire, S1));
+        host.ProcessEvent(SyncEventBuilder.ExitWithSuccess(T2, RecordedEventType.SemaphoreAcquireResult, true)); // deferred
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T3, RecordedEventType.SemaphoreAcquire, S1));
+        host.ProcessEvent(SyncEventBuilder.ExitWithSuccess(T3, RecordedEventType.SemaphoreAcquireResult, true)); // deferred
+        host.ProcessEvent(SyncEventBuilder.ThreadDestroy(T2, TReaper));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.SemaphoreRelease, S1));
+        host.ProcessEvent(SyncEventBuilder.Exit(T1, RecordedEventType.SemaphoreReleaseResult));
+
+        // Assert
+        Assert.Contains(recorder.Dispatched, e => e.Metadata.Tid.Value == T3 && IsSemaphoreAcquireResult(e));
+        Assert.DoesNotContain(recorder.Dispatched, e => e.Metadata.Tid.Value == T2 && IsSemaphoreAcquireResult(e));
+    }
+
+    [Fact]
+    public void ReorderingPluginHost_ThreadDestroy_AbandonedSemaphorePermit_DoesNotAutoRelease()
+    {
+        // Arrange
+        var host = Build(out var recorder);
+
+        // Act
+        host.ProcessEvent(SyncEventBuilder.EnterWithTargetAndCount(T1, RecordedEventType.SemaphoreCreate, S1, 1));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.SemaphoreAcquire, S1));
+        host.ProcessEvent(SyncEventBuilder.ExitWithSuccess(T1, RecordedEventType.SemaphoreAcquireResult, true));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T2, RecordedEventType.SemaphoreAcquire, S1));
+        host.ProcessEvent(SyncEventBuilder.ExitWithSuccess(T2, RecordedEventType.SemaphoreAcquireResult, true)); // deferred
+        host.ProcessEvent(SyncEventBuilder.ThreadDestroy(T1));
+
+        // Assert
+        Assert.DoesNotContain(recorder.Dispatched, e => e.Metadata.Tid.Value == T2 && IsSemaphoreAcquireResult(e));
+    }
+
+    [Fact]
+    public void ReorderingPluginHost_ThreadDestroy_OwnedTask_CompletesAndDrainsJoiners()
+    {
+        // Arrange
+        var host = Build(out var recorder);
+
+        // Act
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T2, RecordedEventType.TaskStart, Task1));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.TaskJoinStart, Task1));
+        host.ProcessEvent(SyncEventBuilder.ExitWithSuccess(T1, RecordedEventType.TaskJoinFinish, true)); // deferred
+        Assert.DoesNotContain(recorder.Dispatched, e =>
+            e.Metadata.Tid.Value == T1 &&
+            (e.EventArgs as MethodExitWithArgumentsRecordedEvent)?.Interpretation == (ushort)RecordedEventType.TaskJoinFinish);
+        host.ProcessEvent(SyncEventBuilder.ThreadDestroy(T2));
+
+        // Assert
+        Assert.Contains(recorder.Dispatched, e =>
+            e.Metadata.Tid.Value == T1 &&
+            (e.EventArgs as MethodExitWithArgumentsRecordedEvent)?.Interpretation == (ushort)RecordedEventType.TaskJoinFinish);
+    }
+
+    [Fact]
     public void ReorderingPluginHost_ThreadDestroy_DrainsAllPendingEventsOfWokenThread()
     {
         // Arrange
@@ -504,6 +617,45 @@ public class ReorderingPluginHostTests
             (T2, RecordedEventType.MonitorLockAcquireResult),
             (T2, RecordedEventType.InstanceFieldRead),
         }, t2Events);
+    }
+
+    [Fact]
+    public void ReorderingPluginHost_FieldAccessInstrumentation_FromBlockedThread_DispatchedImmediately()
+    {
+        // Arrage
+        var host = Build(out var recorder);
+
+        // Act
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.MonitorLockAcquire, L1));
+        host.ProcessEvent(SyncEventBuilder.Exit(T1, RecordedEventType.MonitorLockAcquireResult));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T2, RecordedEventType.MonitorLockAcquire, L1));
+        host.ProcessEvent(SyncEventBuilder.Exit(T2, RecordedEventType.MonitorLockAcquireResult)); // T2 deferred
+        host.ProcessEvent(SyncEventBuilder.FieldAccessInstrumentation(T2, instrumentationId: 42));
+        
+        // Assert
+        Assert.Contains(recorder.Dispatched, e =>
+            e.Metadata.Tid.Value == T2 && e.EventArgs is FieldAccessInstrumentationRecordedEvent reg
+            && reg.InstrumentationId == 42);
+    }
+
+    [Fact]
+    public void ReorderingPluginHost_ThreadStartCore_FromBlockedThread_DispatchedImmediately()
+    {
+        // Arrange
+        var host = Build(out var recorder);
+
+        // Act
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.MonitorLockAcquire, L1));
+        host.ProcessEvent(SyncEventBuilder.Exit(T1, RecordedEventType.MonitorLockAcquireResult));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T2, RecordedEventType.MonitorLockAcquire, L1));
+        host.ProcessEvent(SyncEventBuilder.Exit(T2, RecordedEventType.MonitorLockAcquireResult)); // T2 deferred
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T2, RecordedEventType.ThreadStartCore, 0x3000));
+
+        // Assert
+        Assert.Contains(recorder.Dispatched, e =>
+            e.Metadata.Tid.Value == T2 &&
+            e.EventArgs is MethodEnterWithArgumentsRecordedEvent enter &&
+            (RecordedEventType)enter.Interpretation == RecordedEventType.ThreadStartCore);
     }
 
     private static (uint Tid, RecordedEventType Type) ClassifyDispatched(RecordedEvent e)

--- a/src/Tests/SharpDetect.PluginHost.Tests/ReorderingPluginHostTests.cs
+++ b/src/Tests/SharpDetect.PluginHost.Tests/ReorderingPluginHostTests.cs
@@ -315,7 +315,7 @@ public class ReorderingPluginHostTests
         host.ProcessEvent(SyncEventBuilder.EnterWithTargetCountAndCapacity(T1, RecordedEventType.SemaphoreCreate, S1, 1, 1));
         host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.SemaphoreAcquire, S1));
         host.ProcessEvent(SyncEventBuilder.ExitWithSuccess(T1, RecordedEventType.SemaphoreAcquireResult, true));
-        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.SemaphoreRelease, S1));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTargetAndCount(T1, RecordedEventType.SemaphoreRelease, S1, 1));
         host.ProcessEvent(SyncEventBuilder.Exit(T1, RecordedEventType.SemaphoreReleaseResult));
 
         // Assert
@@ -336,7 +336,7 @@ public class ReorderingPluginHostTests
         host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T2, RecordedEventType.SemaphoreAcquire, S1));
         host.ProcessEvent(SyncEventBuilder.ExitWithSuccess(T2, RecordedEventType.SemaphoreAcquireResult, true)); // deferred [no permits]
         host.ProcessEvent(SyncEventBuilder.FieldRead(T2)); // also deferred
-        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.SemaphoreRelease, S1));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTargetAndCount(T1, RecordedEventType.SemaphoreRelease, S1, 1));
         host.ProcessEvent(SyncEventBuilder.Exit(T1, RecordedEventType.SemaphoreReleaseResult)); // wakes T2
 
         // Assert
@@ -368,14 +368,36 @@ public class ReorderingPluginHostTests
         host.ProcessEvent(SyncEventBuilder.ExitWithSuccess(T2, RecordedEventType.SemaphoreAcquireResult, true)); // deferred [1st]
         host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T3, RecordedEventType.SemaphoreAcquire, S1));
         host.ProcessEvent(SyncEventBuilder.ExitWithSuccess(T3, RecordedEventType.SemaphoreAcquireResult, true)); // deferred [2nd]
-        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.SemaphoreRelease, S1));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTargetAndCount(T1, RecordedEventType.SemaphoreRelease, S1, 1));
         host.ProcessEvent(SyncEventBuilder.Exit(T1, RecordedEventType.SemaphoreReleaseResult)); // wakes T2
         var t2AcqIdx = recorder.Dispatched.FindIndex(e => e.Metadata.Tid.Value == T2 && IsSemaphoreAcquireResult(e));
         var t3AcqIdx = recorder.Dispatched.FindIndex(e => e.Metadata.Tid.Value == T3 && IsSemaphoreAcquireResult(e));
         Assert.True(t2AcqIdx >= 0, "T2 acquire result should have dispatched after T1 release");
         Assert.True(t3AcqIdx < 0, "T3 acquire result should still be deferred");
-        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T2, RecordedEventType.SemaphoreRelease, S1));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTargetAndCount(T2, RecordedEventType.SemaphoreRelease, S1, 1));
         host.ProcessEvent(SyncEventBuilder.Exit(T2, RecordedEventType.SemaphoreReleaseResult));
+        Assert.Contains(recorder.Dispatched, e => e.Metadata.Tid.Value == T3 && IsSemaphoreAcquireResult(e));
+    }
+
+    [Fact]
+    public void ReorderingPluginHost_SemaphoreReleaseWithCount_WakesMultipleWaiters()
+    {
+        // Arrange
+        var host = Build(out var recorder);
+
+        // Act
+        host.ProcessEvent(SyncEventBuilder.EnterWithTargetCountAndCapacity(T1, RecordedEventType.SemaphoreCreate, S1, 1, 10));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.SemaphoreAcquire, S1));
+        host.ProcessEvent(SyncEventBuilder.ExitWithSuccess(T1, RecordedEventType.SemaphoreAcquireResult, true));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T2, RecordedEventType.SemaphoreAcquire, S1));
+        host.ProcessEvent(SyncEventBuilder.ExitWithSuccess(T2, RecordedEventType.SemaphoreAcquireResult, true)); // deferred
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T3, RecordedEventType.SemaphoreAcquire, S1));
+        host.ProcessEvent(SyncEventBuilder.ExitWithSuccess(T3, RecordedEventType.SemaphoreAcquireResult, true)); // deferred
+        host.ProcessEvent(SyncEventBuilder.EnterWithTargetAndCount(T1, RecordedEventType.SemaphoreRelease, S1, 2));
+        host.ProcessEvent(SyncEventBuilder.Exit(T1, RecordedEventType.SemaphoreReleaseResult)); // wakes T2 and T3
+
+        // Assert
+        Assert.Contains(recorder.Dispatched, e => e.Metadata.Tid.Value == T2 && IsSemaphoreAcquireResult(e));
         Assert.Contains(recorder.Dispatched, e => e.Metadata.Tid.Value == T3 && IsSemaphoreAcquireResult(e));
     }
 
@@ -578,7 +600,7 @@ public class ReorderingPluginHostTests
         host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T3, RecordedEventType.SemaphoreAcquire, S1));
         host.ProcessEvent(SyncEventBuilder.ExitWithSuccess(T3, RecordedEventType.SemaphoreAcquireResult, true)); // deferred
         host.ProcessEvent(SyncEventBuilder.ThreadDestroy(T2, TReaper));
-        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.SemaphoreRelease, S1));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTargetAndCount(T1, RecordedEventType.SemaphoreRelease, S1, 1));
         host.ProcessEvent(SyncEventBuilder.Exit(T1, RecordedEventType.SemaphoreReleaseResult));
 
         // Assert
@@ -682,7 +704,7 @@ public class ReorderingPluginHostTests
         host.ProcessEvent(SyncEventBuilder.EnterWithTargetCountAndCapacity(T1, RecordedEventType.SemaphoreCreate, S1, 1, 1));
         host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.SemaphoreAcquire, S1));
         host.ProcessEvent(SyncEventBuilder.ExitWithSuccess(T1, RecordedEventType.SemaphoreAcquireResult, true));
-        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.SemaphoreRelease, S1));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTargetAndCount(T1, RecordedEventType.SemaphoreRelease, S1, 1));
         host.ProcessEvent(SyncEventBuilder.Exit(T1, RecordedEventType.SemaphoreReleaseResult));
         Assert.Equal(1, host.ShadowSemaphoreCount);
         host.ProcessEvent(SyncEventBuilder.GarbageCollected(TReaper, S1));

--- a/src/Tests/SharpDetect.PluginHost.Tests/ReorderingPluginHostTests.cs
+++ b/src/Tests/SharpDetect.PluginHost.Tests/ReorderingPluginHostTests.cs
@@ -1,6 +1,7 @@
 // Copyright 2026 Andrej Čižmárik and Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using SharpDetect.Core.Events;
 using SharpDetect.Core.Plugins;
@@ -25,6 +26,13 @@ public class ReorderingPluginHostTests
     {
         recorder = new RecordingPluginHost();
         return new ReorderingPluginHost(recorder, NullLogger<ReorderingPluginHost>.Instance);
+    }
+
+    private static ReorderingPluginHost Build(out RecordingPluginHost recorder, out CapturingLogger<ReorderingPluginHost> logger)
+    {
+        recorder = new RecordingPluginHost();
+        logger = new CapturingLogger<ReorderingPluginHost>();
+        return new ReorderingPluginHost(recorder, logger);
     }
 
     [Fact]
@@ -656,6 +664,155 @@ public class ReorderingPluginHostTests
             e.Metadata.Tid.Value == T2 &&
             e.EventArgs is MethodEnterWithArgumentsRecordedEvent enter &&
             (RecordedEventType)enter.Interpretation == RecordedEventType.ThreadStartCore);
+    }
+
+    [Fact]
+    public void ReorderingPluginHost_GarbageCollected_CleanLock_RemovesShadowAndForwardsEvent()
+    {
+        // Arrange
+        var host = Build(out var recorder, out var logger);
+
+        // Act
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.MonitorLockAcquire, L1));
+        host.ProcessEvent(SyncEventBuilder.Exit(T1, RecordedEventType.MonitorLockAcquireResult));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.MonitorLockRelease, L1));
+        host.ProcessEvent(SyncEventBuilder.Exit(T1, RecordedEventType.MonitorLockReleaseResult));
+        Assert.Equal(1, host.ShadowLockCount);
+        host.ProcessEvent(SyncEventBuilder.GarbageCollected(TReaper, L1));
+
+        // Assert
+        Assert.Equal(0, host.ShadowLockCount);
+        Assert.Contains(recorder.Dispatched, e => e.EventArgs is GarbageCollectedTrackedObjectsRecordedEvent);
+        Assert.DoesNotContain(logger.Entries, e => e.Level >= LogLevel.Warning);
+    }
+
+    [Fact]
+    public void ReorderingPluginHost_GarbageCollected_CleanSemaphore_RemovesShadowAndForwardsEvent()
+    {
+        // Arrange
+        var host = Build(out var recorder, out var logger);
+
+        // Act
+        host.ProcessEvent(SyncEventBuilder.EnterWithTargetAndCount(T1, RecordedEventType.SemaphoreCreate, S1, 1));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.SemaphoreAcquire, S1));
+        host.ProcessEvent(SyncEventBuilder.ExitWithSuccess(T1, RecordedEventType.SemaphoreAcquireResult, true));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.SemaphoreRelease, S1));
+        host.ProcessEvent(SyncEventBuilder.Exit(T1, RecordedEventType.SemaphoreReleaseResult));
+        Assert.Equal(1, host.ShadowSemaphoreCount);
+        host.ProcessEvent(SyncEventBuilder.GarbageCollected(TReaper, S1));
+
+        // Assert
+        Assert.Equal(0, host.ShadowSemaphoreCount);
+        Assert.Contains(recorder.Dispatched, e => e.EventArgs is GarbageCollectedTrackedObjectsRecordedEvent);
+        Assert.DoesNotContain(logger.Entries, e => e.Level >= LogLevel.Warning);
+    }
+
+    [Fact]
+    public void ReorderingPluginHost_GarbageCollected_CleanTask_RemovesShadowAndForwardsEvent()
+    {
+        // Arrange
+        var host = Build(out var recorder, out var logger);
+
+        // Act
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T2, RecordedEventType.TaskStart, Task1));
+        host.ProcessEvent(SyncEventBuilder.Exit(T2, RecordedEventType.TaskComplete));
+        Assert.Equal(1, host.ShadowTaskCount);
+        host.ProcessEvent(SyncEventBuilder.GarbageCollected(TReaper, Task1));
+
+        // Assert
+        Assert.Equal(0, host.ShadowTaskCount);
+        Assert.Contains(recorder.Dispatched, e => e.EventArgs is GarbageCollectedTrackedObjectsRecordedEvent);
+        Assert.DoesNotContain(logger.Entries, e => e.Level >= LogLevel.Warning);
+    }
+
+    [Fact]
+    public void ReorderingPluginHost_GarbageCollected_MixedObjects_RemovesAllMatchingShadows()
+    {
+        // Arrange
+        var host = Build(out _, out _);
+
+        // Act
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.MonitorLockAcquire, L1));
+        host.ProcessEvent(SyncEventBuilder.Exit(T1, RecordedEventType.MonitorLockAcquireResult));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.MonitorLockRelease, L1));
+        host.ProcessEvent(SyncEventBuilder.Exit(T1, RecordedEventType.MonitorLockReleaseResult));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTargetAndCount(T1, RecordedEventType.SemaphoreCreate, S1, 1));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T2, RecordedEventType.TaskStart, Task1));
+        host.ProcessEvent(SyncEventBuilder.Exit(T2, RecordedEventType.TaskComplete));
+        Assert.Equal(1, host.ShadowLockCount);
+        Assert.Equal(1, host.ShadowSemaphoreCount);
+        Assert.Equal(1, host.ShadowTaskCount);
+        host.ProcessEvent(SyncEventBuilder.GarbageCollected(TReaper, L1, S1, Task1));
+
+        // Assert
+        Assert.Equal(0, host.ShadowLockCount);
+        Assert.Equal(0, host.ShadowSemaphoreCount);
+        Assert.Equal(0, host.ShadowTaskCount);
+    }
+
+    [Fact]
+    public void ReorderingPluginHost_GarbageCollected_LockWithOwner_LogsWarning()
+    {
+        // Arrange
+        var host = Build(out _, out var logger);
+
+        // Act
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.MonitorLockAcquire, L1));
+        host.ProcessEvent(SyncEventBuilder.Exit(T1, RecordedEventType.MonitorLockAcquireResult));
+        host.ProcessEvent(SyncEventBuilder.GarbageCollected(TReaper, L1));
+
+        // Assert
+        Assert.Equal(0, host.ShadowLockCount);
+        Assert.Contains(logger.Entries, e => e.Level == LogLevel.Warning && e.Message.Contains("Lock"));
+    }
+
+    [Fact]
+    public void ReorderingPluginHost_GarbageCollected_SemaphoreWithOutstandingPermits_LogsWarning()
+    {
+        // Arrange
+        var host = Build(out _, out var logger);
+
+        // Act
+        host.ProcessEvent(SyncEventBuilder.EnterWithTargetAndCount(T1, RecordedEventType.SemaphoreCreate, S1, 1));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.SemaphoreAcquire, S1));
+        host.ProcessEvent(SyncEventBuilder.ExitWithSuccess(T1, RecordedEventType.SemaphoreAcquireResult, true));
+        host.ProcessEvent(SyncEventBuilder.GarbageCollected(TReaper, S1));
+
+        // Assert
+        Assert.Equal(0, host.ShadowSemaphoreCount);
+        Assert.Contains(logger.Entries, e => e.Level == LogLevel.Warning && e.Message.Contains("Semaphore"));
+    }
+
+    [Fact]
+    public void ReorderingPluginHost_GarbageCollected_TaskNotCompleted_LogsWarning()
+    {
+        // Arrange
+        var host = Build(out _, out var logger);
+
+        // Act
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T2, RecordedEventType.TaskStart, Task1));
+        host.ProcessEvent(SyncEventBuilder.GarbageCollected(TReaper, Task1));
+
+        // Assert
+        Assert.Equal(0, host.ShadowTaskCount);
+        Assert.Contains(logger.Entries, e => e.Level == LogLevel.Warning && e.Message.Contains("Task"));
+    }
+
+    [Fact]
+    public void ReorderingPluginHost_GarbageCollected_UnknownObject_NoOp()
+    {
+        // Arrange
+        var host = Build(out var recorder, out var logger);
+
+        // Act
+        host.ProcessEvent(SyncEventBuilder.GarbageCollected(TReaper, L1, S1, Task1));
+
+        // Assert
+        Assert.Equal(0, host.ShadowLockCount);
+        Assert.Equal(0, host.ShadowSemaphoreCount);
+        Assert.Equal(0, host.ShadowTaskCount);
+        Assert.DoesNotContain(logger.Entries, e => e.Level >= LogLevel.Warning);
+        Assert.Contains(recorder.Dispatched, e => e.EventArgs is GarbageCollectedTrackedObjectsRecordedEvent);
     }
 
     private static (uint Tid, RecordedEventType Type) ClassifyDispatched(RecordedEvent e)

--- a/src/Tests/SharpDetect.PluginHost.Tests/ReorderingPluginHostTests.cs
+++ b/src/Tests/SharpDetect.PluginHost.Tests/ReorderingPluginHostTests.cs
@@ -173,7 +173,32 @@ public class ReorderingPluginHostTests
             e.Metadata.Tid.Value == T1 &&
             (e.EventArgs as MethodExitRecordedEvent)?.Interpretation == (ushort)RecordedEventType.TaskJoinFinish);
     }
-    
+
+    [Fact]
+    public void ReorderingPluginHost_TaskJoin_QueuesSubsequentPlainMethodExitOnSameThread()
+    {
+        // Arrange
+        var host = Build(out var recorder);
+
+        // Act
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T2, RecordedEventType.TaskStart, Task1));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.TaskJoinStart, Task1));
+        host.ProcessEvent(SyncEventBuilder.Exit(T1, RecordedEventType.TaskJoinFinish)); // deferred
+        host.ProcessEvent(SyncEventBuilder.Exit(T1, RecordedEventType.MethodExit)); // must also defer
+        host.ProcessEvent(SyncEventBuilder.Exit(T2, RecordedEventType.TaskComplete)); // wake T1
+
+        // Assert
+        var t1Exits = recorder.Dispatched
+            .Where(e => e.Metadata.Tid.Value == T1 && e.EventArgs is MethodExitRecordedEvent)
+            .Select(e => (RecordedEventType)((MethodExitRecordedEvent)e.EventArgs).Interpretation)
+            .ToArray();
+        Assert.Equal(new[]
+        {
+            RecordedEventType.TaskJoinFinish,
+            RecordedEventType.MethodExit,
+        }, t1Exits);
+    }
+
     [Fact]
     public void ReorderingPluginHost_MonitorWait_ReleasesAndReacquires()
     {
@@ -625,45 +650,6 @@ public class ReorderingPluginHostTests
             (T2, RecordedEventType.MonitorLockAcquireResult),
             (T2, RecordedEventType.InstanceFieldRead),
         }, t2Events);
-    }
-
-    [Fact]
-    public void ReorderingPluginHost_FieldAccessInstrumentation_FromBlockedThread_DispatchedImmediately()
-    {
-        // Arrage
-        var host = Build(out var recorder);
-
-        // Act
-        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.MonitorLockAcquire, L1));
-        host.ProcessEvent(SyncEventBuilder.Exit(T1, RecordedEventType.MonitorLockAcquireResult));
-        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T2, RecordedEventType.MonitorLockAcquire, L1));
-        host.ProcessEvent(SyncEventBuilder.Exit(T2, RecordedEventType.MonitorLockAcquireResult)); // T2 deferred
-        host.ProcessEvent(SyncEventBuilder.FieldAccessInstrumentation(T2, instrumentationId: 42));
-        
-        // Assert
-        Assert.Contains(recorder.Dispatched, e =>
-            e.Metadata.Tid.Value == T2 && e.EventArgs is FieldAccessInstrumentationRecordedEvent reg
-            && reg.InstrumentationId == 42);
-    }
-
-    [Fact]
-    public void ReorderingPluginHost_ThreadStartCore_FromBlockedThread_DispatchedImmediately()
-    {
-        // Arrange
-        var host = Build(out var recorder);
-
-        // Act
-        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.MonitorLockAcquire, L1));
-        host.ProcessEvent(SyncEventBuilder.Exit(T1, RecordedEventType.MonitorLockAcquireResult));
-        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T2, RecordedEventType.MonitorLockAcquire, L1));
-        host.ProcessEvent(SyncEventBuilder.Exit(T2, RecordedEventType.MonitorLockAcquireResult)); // T2 deferred
-        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T2, RecordedEventType.ThreadStartCore, 0x3000));
-
-        // Assert
-        Assert.Contains(recorder.Dispatched, e =>
-            e.Metadata.Tid.Value == T2 &&
-            e.EventArgs is MethodEnterWithArgumentsRecordedEvent enter &&
-            (RecordedEventType)enter.Interpretation == RecordedEventType.ThreadStartCore);
     }
 
     [Fact]

--- a/src/Tests/SharpDetect.PluginHost.Tests/ReorderingPluginHostTests.cs
+++ b/src/Tests/SharpDetect.PluginHost.Tests/ReorderingPluginHostTests.cs
@@ -823,6 +823,55 @@ public class ReorderingPluginHostTests
         Assert.Contains(recorder.Dispatched, e => e.EventArgs is GarbageCollectedTrackedObjectsRecordedEvent);
     }
 
+    [Fact]
+    public void ReorderingPluginHost_ThreadStartCore_NotBlocked_ThreadStartCallback_ProcessedImmediately()
+    {
+        // Arrange
+        var host = Build(out var recorder);
+
+        // Act & Assert
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.MonitorLockAcquire, L1));
+        host.ProcessEvent(SyncEventBuilder.Exit(T1, RecordedEventType.MonitorLockAcquireResult));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T2, RecordedEventType.MonitorLockAcquire, L1));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.ThreadStartCore, T3));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T3, RecordedEventType.ThreadStartCallback, T3));
+        Assert.Contains(recorder.Dispatched, e =>
+            ClassifyDispatched(e) == (T1, RecordedEventType.ThreadStartCore));
+        Assert.Contains(recorder.Dispatched, e =>
+            ClassifyDispatched(e) == (T3, RecordedEventType.ThreadStartCallback));
+        var coreIdx = recorder.Dispatched.FindIndex(e => ClassifyDispatched(e) == (T1, RecordedEventType.ThreadStartCore));
+        var callbackIdx = recorder.Dispatched.FindIndex(e => ClassifyDispatched(e) == (T3, RecordedEventType.ThreadStartCallback));
+        Assert.True(coreIdx < callbackIdx);
+    }
+
+    [Fact]
+    public void ReorderingPluginHost_ThreadStartCallback_DeferredUntilParentThreadStartCoreProcessed()
+    {
+        // Arrange
+        var host = Build(out var recorder);
+
+        // Act & Assert
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.MonitorLockAcquire, L1));
+        host.ProcessEvent(SyncEventBuilder.Exit(T1, RecordedEventType.MonitorLockAcquireResult));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T2, RecordedEventType.MonitorLockAcquire, L1));
+        host.ProcessEvent(SyncEventBuilder.Exit(T2, RecordedEventType.MonitorLockAcquireResult));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T2, RecordedEventType.ThreadStartCore, T3));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T3, RecordedEventType.ThreadStartCallback, T3));
+        Assert.DoesNotContain(recorder.Dispatched, e =>
+            ClassifyDispatched(e) == (T2, RecordedEventType.ThreadStartCore));
+        Assert.DoesNotContain(recorder.Dispatched, e =>
+            ClassifyDispatched(e) == (T3, RecordedEventType.ThreadStartCallback));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.MonitorLockRelease, L1));
+        host.ProcessEvent(SyncEventBuilder.Exit(T1, RecordedEventType.MonitorLockReleaseResult));
+        Assert.Contains(recorder.Dispatched, e =>
+            ClassifyDispatched(e) == (T2, RecordedEventType.ThreadStartCore));
+        Assert.Contains(recorder.Dispatched, e =>
+            ClassifyDispatched(e) == (T3, RecordedEventType.ThreadStartCallback));
+        var coreIdx = recorder.Dispatched.FindIndex(e => ClassifyDispatched(e) == (T2, RecordedEventType.ThreadStartCore));
+        var callbackIdx = recorder.Dispatched.FindIndex(e => ClassifyDispatched(e) == (T3, RecordedEventType.ThreadStartCallback));
+        Assert.True(coreIdx < callbackIdx);
+    }
+
     private static (uint Tid, RecordedEventType Type) ClassifyDispatched(RecordedEvent e)
     {
         var tid = e.Metadata.Tid.Value;

--- a/src/Tests/SharpDetect.PluginHost.Tests/ReorderingPluginHostTests.cs
+++ b/src/Tests/SharpDetect.PluginHost.Tests/ReorderingPluginHostTests.cs
@@ -255,13 +255,14 @@ public class ReorderingPluginHostTests
         var host = Build(out var recorder);
 
         // Act
+        host.ProcessEvent(SyncEventBuilder.EnterWithTargetAndCount(T1, RecordedEventType.SemaphoreCreate, S1, 1));
         host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.SemaphoreAcquire, S1));
         host.ProcessEvent(SyncEventBuilder.ExitWithSuccess(T1, RecordedEventType.SemaphoreAcquireResult, true));
         host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.SemaphoreRelease, S1));
         host.ProcessEvent(SyncEventBuilder.Exit(T1, RecordedEventType.SemaphoreReleaseResult));
 
         // Assert
-        Assert.Equal(4, recorder.Dispatched.Count);
+        Assert.Equal(5, recorder.Dispatched.Count);
         Assert.All(recorder.Dispatched, e => Assert.Equal(T1, e.Metadata.Tid.Value));
     }
 
@@ -272,6 +273,7 @@ public class ReorderingPluginHostTests
         var host = Build(out var recorder);
 
         // Act
+        host.ProcessEvent(SyncEventBuilder.EnterWithTargetAndCount(T1, RecordedEventType.SemaphoreCreate, S1, 1));
         host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.SemaphoreAcquire, S1));
         host.ProcessEvent(SyncEventBuilder.ExitWithSuccess(T1, RecordedEventType.SemaphoreAcquireResult, true));
         host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T2, RecordedEventType.SemaphoreAcquire, S1));
@@ -284,6 +286,7 @@ public class ReorderingPluginHostTests
         var kinds = recorder.Dispatched.Select(ClassifyDispatched).ToArray();
         Assert.Equal(new[]
         {
+            (T1, RecordedEventType.SemaphoreCreate),
             (T1, RecordedEventType.SemaphoreAcquire),
             (T1, RecordedEventType.SemaphoreAcquireResult),
             (T2, RecordedEventType.SemaphoreAcquire),
@@ -301,6 +304,7 @@ public class ReorderingPluginHostTests
         var host = Build(out var recorder);
 
         // Act & Assert
+        host.ProcessEvent(SyncEventBuilder.EnterWithTargetAndCount(T1, RecordedEventType.SemaphoreCreate, S1, 1));
         host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.SemaphoreAcquire, S1));
         host.ProcessEvent(SyncEventBuilder.ExitWithSuccess(T1, RecordedEventType.SemaphoreAcquireResult, true));
         host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T2, RecordedEventType.SemaphoreAcquire, S1));
@@ -325,14 +329,40 @@ public class ReorderingPluginHostTests
         var host = Build(out var recorder);
 
         // Act
+        host.ProcessEvent(SyncEventBuilder.EnterWithTargetAndCount(T1, RecordedEventType.SemaphoreCreate, S1, 1));
         host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.SemaphoreAcquire, S1));
         host.ProcessEvent(SyncEventBuilder.ExitWithSuccess(T1, RecordedEventType.SemaphoreAcquireResult, true));
         host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T2, RecordedEventType.SemaphoreTryAcquire, S1));
         host.ProcessEvent(SyncEventBuilder.ExitWithSuccess(T2, RecordedEventType.SemaphoreAcquireResult, false));
 
         // Assert
-        Assert.Equal(4, recorder.Dispatched.Count);
+        Assert.Equal(5, recorder.Dispatched.Count);
         Assert.Equal((T2, RecordedEventType.SemaphoreAcquireResult), ClassifyDispatched(recorder.Dispatched[^1]));
+    }
+
+    [Fact]
+    public void ReorderingPluginHost_Semaphore_InitialCountTwo_BothAcquiresSucceedWithoutRelease()
+    {
+        // Arrange
+        var host = Build(out var recorder);
+
+        // Act
+        host.ProcessEvent(SyncEventBuilder.EnterWithTargetAndCount(T1, RecordedEventType.SemaphoreCreate, S1, 2));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.SemaphoreAcquire, S1));
+        host.ProcessEvent(SyncEventBuilder.ExitWithSuccess(T1, RecordedEventType.SemaphoreAcquireResult, true));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T2, RecordedEventType.SemaphoreAcquire, S1));
+        host.ProcessEvent(SyncEventBuilder.ExitWithSuccess(T2, RecordedEventType.SemaphoreAcquireResult, true));
+        var kinds = recorder.Dispatched.Select(ClassifyDispatched).ToArray();
+        
+        // Assert
+        Assert.Equal(new[]
+        {
+            (T1, RecordedEventType.SemaphoreCreate),
+            (T1, RecordedEventType.SemaphoreAcquire),
+            (T1, RecordedEventType.SemaphoreAcquireResult),
+            (T2, RecordedEventType.SemaphoreAcquire),
+            (T2, RecordedEventType.SemaphoreAcquireResult),
+        }, kinds);
     }
 
     [Fact]

--- a/src/Tests/SharpDetect.PluginHost.Tests/ReorderingPluginHostTests.cs
+++ b/src/Tests/SharpDetect.PluginHost.Tests/ReorderingPluginHostTests.cs
@@ -1,0 +1,522 @@
+// Copyright 2026 Andrej Čižmárik and Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+using Microsoft.Extensions.Logging.Abstractions;
+using SharpDetect.Core.Events;
+using SharpDetect.Core.Plugins;
+using SharpDetect.PluginHost.Services.Strategies;
+using Xunit;
+
+namespace SharpDetect.PluginHost.Tests;
+
+public class ReorderingPluginHostTests
+{
+    private const uint T1 = 1;
+    private const uint T2 = 2;
+    private const uint T3 = 3;
+    private const nuint L1 = 0x1000;
+    private const nuint L2 = 0x1001;
+    private const nuint S1 = 0x1800;
+    private const nuint Task1 = 0x2000;
+    private const nuint Task2 = 0x2001;
+
+    private static ReorderingPluginHost Build(out RecordingPluginHost recorder)
+    {
+        recorder = new RecordingPluginHost();
+        return new ReorderingPluginHost(recorder, NullLogger<ReorderingPluginHost>.Instance);
+    }
+
+    [Fact]
+    public void ReorderingPluginHost_AcquireExitBeforeReleaseExit_IsDeferred_IsReordered()
+    {
+        // Arrange
+        var host = Build(out var recorder);
+
+        // Act
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.MonitorLockAcquire, L1));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T2, RecordedEventType.MonitorLockAcquire, L1));
+        host.ProcessEvent(SyncEventBuilder.Exit(T2, RecordedEventType.MonitorLockAcquireResult));
+        host.ProcessEvent(SyncEventBuilder.FieldRead(T2));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T2, RecordedEventType.MonitorLockRelease, L1));
+        host.ProcessEvent(SyncEventBuilder.Exit(T1, RecordedEventType.MonitorLockAcquireResult)); // arrives too early
+        host.ProcessEvent(SyncEventBuilder.FieldRead(T1)); // arrives too early
+        host.ProcessEvent(SyncEventBuilder.Exit(T2, RecordedEventType.MonitorLockReleaseResult)); // unblocks
+        var kinds = recorder.Dispatched.Select(ClassifyDispatched).ToArray();
+        
+        // Assert
+        Assert.Equal(new[]
+        {
+            (T1, RecordedEventType.MonitorLockAcquire),
+            (T2, RecordedEventType.MonitorLockAcquire),
+            (T2, RecordedEventType.MonitorLockAcquireResult),
+            (T2, RecordedEventType.InstanceFieldRead),
+            (T2, RecordedEventType.MonitorLockRelease),
+            (T2, RecordedEventType.MonitorLockReleaseResult),
+            (T1, RecordedEventType.MonitorLockAcquireResult),
+            (T1, RecordedEventType.InstanceFieldRead),
+        }, kinds);
+    }
+
+    [Fact]
+    public void ReorderingPluginHost_ReentrantLocking_NotDeferred_NotReordered()
+    {
+        // Arrange
+        var host = Build(out var recorder);
+
+        // Act
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.MonitorLockAcquire, L1));
+        host.ProcessEvent(SyncEventBuilder.Exit(T1, RecordedEventType.MonitorLockAcquireResult));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.MonitorLockAcquire, L1));
+        host.ProcessEvent(SyncEventBuilder.Exit(T1, RecordedEventType.MonitorLockAcquireResult));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.MonitorLockRelease, L1));
+        host.ProcessEvent(SyncEventBuilder.Exit(T1, RecordedEventType.MonitorLockReleaseResult));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.MonitorLockRelease, L1));
+        host.ProcessEvent(SyncEventBuilder.Exit(T1, RecordedEventType.MonitorLockReleaseResult));
+
+        // Assert
+        Assert.Equal(8, recorder.Dispatched.Count);
+        Assert.All(recorder.Dispatched, e => Assert.Equal(T1, e.Metadata.Tid.Value));
+    }
+
+    [Fact]
+    public void ReorderingPluginHost_FailedTryEnter_NotDeferred_NotReordered()
+    {
+        // Arrange
+        var host = Build(out var recorder);
+
+        // Act
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.MonitorLockAcquire, L1));
+        host.ProcessEvent(SyncEventBuilder.Exit(T1, RecordedEventType.MonitorLockAcquireResult));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T2, RecordedEventType.MonitorLockTryAcquire, L1));
+        host.ProcessEvent(SyncEventBuilder.ExitWithSuccess(T2, RecordedEventType.MonitorLockAcquireResult, success: false));
+
+        // Assert
+        Assert.Equal(4, recorder.Dispatched.Count);
+        Assert.Equal((T2, RecordedEventType.MonitorLockAcquireResult), ClassifyDispatched(recorder.Dispatched[^1]));
+    }
+
+    [Fact]
+    public void ReorderingPluginHost_MultipleWaiters_DrainInFifoOrder()
+    {
+        // Arrange
+        var host = Build(out var recorder);
+
+        // Act
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.MonitorLockAcquire, L1));
+        host.ProcessEvent(SyncEventBuilder.Exit(T1, RecordedEventType.MonitorLockAcquireResult));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T2, RecordedEventType.MonitorLockAcquire, L1));
+        host.ProcessEvent(SyncEventBuilder.Exit(T2, RecordedEventType.MonitorLockAcquireResult)); // deferred [1st in wake queue]
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T3, RecordedEventType.MonitorLockAcquire, L1));
+        host.ProcessEvent(SyncEventBuilder.Exit(T3, RecordedEventType.MonitorLockAcquireResult)); // deferred [2nd in wake queue]
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.MonitorLockRelease, L1));
+        host.ProcessEvent(SyncEventBuilder.Exit(T1, RecordedEventType.MonitorLockReleaseResult)); // wakes T2
+        var lastT1 = recorder.Dispatched.FindLastIndex(e => e.Metadata.Tid.Value == T1);
+        var firstT2Acq = recorder.Dispatched.FindIndex(e => e.Metadata.Tid.Value == T2 && IsAcquireResult(e));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T2, RecordedEventType.MonitorLockRelease, L1));
+        host.ProcessEvent(SyncEventBuilder.Exit(T2, RecordedEventType.MonitorLockReleaseResult));
+        
+        // Assert
+        Assert.True(firstT2Acq > lastT1, "T2's acquire result should dispatch after T1's release");
+        Assert.Contains(recorder.Dispatched, e => e.Metadata.Tid.Value == T3 && IsAcquireResult(e));
+    }
+
+    [Fact]
+    public void ReorderingPluginHost_CascadingDefer_DrainedAcquireDefersAgainOnAnotherLock()
+    {
+        // Arrange
+        var host = Build(out var recorder);
+
+        // Act & Assert
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.MonitorLockAcquire, L1));
+        host.ProcessEvent(SyncEventBuilder.Exit(T1, RecordedEventType.MonitorLockAcquireResult));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T3, RecordedEventType.MonitorLockAcquire, L2));
+        host.ProcessEvent(SyncEventBuilder.Exit(T3, RecordedEventType.MonitorLockAcquireResult));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T2, RecordedEventType.MonitorLockAcquire, L1));
+        host.ProcessEvent(SyncEventBuilder.Exit(T2, RecordedEventType.MonitorLockAcquireResult)); // deferred [waiting on T1 to release L1]
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T2, RecordedEventType.MonitorLockAcquire, L2));
+        host.ProcessEvent(SyncEventBuilder.Exit(T2, RecordedEventType.MonitorLockAcquireResult)); // deferred [waiting on T3 to release L2]
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.MonitorLockRelease, L1));
+        host.ProcessEvent(SyncEventBuilder.Exit(T1, RecordedEventType.MonitorLockReleaseResult)); // wakes T2 to acquire L1
+        var t2Acquires = recorder.Dispatched.Where(e => e.Metadata.Tid.Value == T2 && IsAcquireResult(e)).ToList();
+        Assert.Single(t2Acquires);
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T3, RecordedEventType.MonitorLockRelease, L2));
+        host.ProcessEvent(SyncEventBuilder.Exit(T3, RecordedEventType.MonitorLockReleaseResult)); // wakes T2 to acquire L2
+        t2Acquires = recorder.Dispatched.Where(e => e.Metadata.Tid.Value == T2 && IsAcquireResult(e)).ToList();
+        Assert.Equal(2, t2Acquires.Count);
+    }
+
+    [Fact]
+    public void ReorderingPluginHost_TaskJoin_DeferredUntilTaskComplete()
+    {
+        // Arrange
+        var host = Build(out var recorder);
+
+        // Act & Assert
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T2, RecordedEventType.TaskStart, Task1));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.TaskJoinStart, Task1));
+        host.ProcessEvent(SyncEventBuilder.Exit(T1, RecordedEventType.TaskJoinFinish)); // deferred [wait on task complete]
+        host.ProcessEvent(SyncEventBuilder.FieldRead(T1)); // also deferred
+        Assert.DoesNotContain(recorder.Dispatched, e =>
+            e.Metadata.Tid.Value == T1 &&
+            (e.EventArgs as MethodExitRecordedEvent)?.Interpretation == (ushort)RecordedEventType.TaskJoinFinish);
+        host.ProcessEvent(SyncEventBuilder.Exit(T2, RecordedEventType.TaskComplete)); // wake up
+        Assert.Contains(recorder.Dispatched, e =>
+            e.Metadata.Tid.Value == T1 &&
+            (e.EventArgs as MethodExitRecordedEvent)?.Interpretation == (ushort)RecordedEventType.TaskJoinFinish);
+    }
+    
+    [Fact]
+    public void ReorderingPluginHost_MonitorWait_ReleasesAndReacquires()
+    {
+        // Arrange
+        var host = Build(out var recorder);
+
+        // Act
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.MonitorLockAcquire, L1));
+        host.ProcessEvent(SyncEventBuilder.Exit(T1, RecordedEventType.MonitorLockAcquireResult));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.MonitorWaitAttempt, L1));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T2, RecordedEventType.MonitorLockAcquire, L1));
+        host.ProcessEvent(SyncEventBuilder.Exit(T2, RecordedEventType.MonitorLockAcquireResult));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T2, RecordedEventType.MonitorLockRelease, L1));
+        host.ProcessEvent(SyncEventBuilder.Exit(T2, RecordedEventType.MonitorLockReleaseResult));
+        host.ProcessEvent(SyncEventBuilder.ExitWithSuccess(T1, RecordedEventType.MonitorWaitResult, true));
+
+        // Assert
+        Assert.Contains(recorder.Dispatched, e =>
+            e.Metadata.Tid.Value == T1 &&
+            ClassifyDispatched(e) == (T1, RecordedEventType.MonitorWaitResult));
+    }
+    
+    [Fact]
+    public void ReorderingPluginHost_MonitorWaitExitBeforeReleaseExit_IsDeferred_IsReordered()
+    {
+        // Arrange
+        var host = Build(out var recorder);
+
+        // Act
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.MonitorLockAcquire, L1));
+        host.ProcessEvent(SyncEventBuilder.Exit(T1, RecordedEventType.MonitorLockAcquireResult));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.MonitorWaitAttempt, L1));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T2, RecordedEventType.MonitorLockAcquire, L1));
+        host.ProcessEvent(SyncEventBuilder.Exit(T2, RecordedEventType.MonitorLockAcquireResult));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T2, RecordedEventType.MonitorLockRelease, L1));
+        host.ProcessEvent(SyncEventBuilder.ExitWithSuccess(T1, RecordedEventType.MonitorWaitResult, true)); // deferred
+        host.ProcessEvent(SyncEventBuilder.Exit(T2, RecordedEventType.MonitorLockReleaseResult)); // wake up
+
+        // Assert
+        Assert.Equal(8, recorder.Dispatched.Count);
+        Assert.Equal((T1, RecordedEventType.MonitorWaitResult), ClassifyDispatched(recorder.Dispatched.Last()));
+    }
+    
+    [Fact]
+    public void ReorderingPluginHost_FailedMonitorWait_NotDeferred_NotReordered()
+    {
+        // Arrange
+        var host = Build(out var recorder);
+
+        // Act
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.MonitorLockAcquire, L1));
+        host.ProcessEvent(SyncEventBuilder.Exit(T1, RecordedEventType.MonitorLockAcquireResult));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.MonitorWaitAttempt, L1));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T2, RecordedEventType.MonitorLockAcquire, L1));
+        host.ProcessEvent(SyncEventBuilder.Exit(T2, RecordedEventType.MonitorLockAcquireResult));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T2, RecordedEventType.MonitorLockRelease, L1));
+        host.ProcessEvent(SyncEventBuilder.ExitWithSuccess(T1, RecordedEventType.MonitorWaitResult, false));
+        host.ProcessEvent(SyncEventBuilder.Exit(T2, RecordedEventType.MonitorLockReleaseResult));
+
+        // Assert
+        Assert.Equal(8, recorder.Dispatched.Count);
+        Assert.Equal((T2, RecordedEventType.MonitorLockReleaseResult), ClassifyDispatched(recorder.Dispatched.Last()));
+    }
+
+    [Fact]
+    public void ReorderingPluginHost_ThreadDestroy_AbandonedLock_ReleasesAndWakesWaiters()
+    {
+        // Arrange
+        var host = Build(out var recorder);
+
+        // Act
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.MonitorLockAcquire, L1));
+        host.ProcessEvent(SyncEventBuilder.Exit(T1, RecordedEventType.MonitorLockAcquireResult));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T2, RecordedEventType.MonitorLockAcquire, L1));
+        host.ProcessEvent(SyncEventBuilder.Exit(T2, RecordedEventType.MonitorLockAcquireResult)); // deferred
+        host.ProcessEvent(SyncEventBuilder.ThreadDestroy(T1));
+
+        // Assert
+        Assert.Contains(recorder.Dispatched, e =>
+            e.Metadata.Tid.Value == T2 &&
+            (e.EventArgs as MethodExitRecordedEvent)?.Interpretation == (ushort)RecordedEventType.MonitorLockAcquireResult);
+    }
+
+    [Fact]
+    public void ReorderingPluginHost_SemaphoreHappyPath_NotDeferred_NotReordered()
+    {
+        // Arrange
+        var host = Build(out var recorder);
+
+        // Act
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.SemaphoreAcquire, S1));
+        host.ProcessEvent(SyncEventBuilder.ExitWithSuccess(T1, RecordedEventType.SemaphoreAcquireResult, true));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.SemaphoreRelease, S1));
+        host.ProcessEvent(SyncEventBuilder.Exit(T1, RecordedEventType.SemaphoreReleaseResult));
+
+        // Assert
+        Assert.Equal(4, recorder.Dispatched.Count);
+        Assert.All(recorder.Dispatched, e => Assert.Equal(T1, e.Metadata.Tid.Value));
+    }
+
+    [Fact]
+    public void ReorderingPluginHost_SemaphoreAcquireExitBeforeReleaseExit_IsDeferred_IsReordered()
+    {
+        // Arrange
+        var host = Build(out var recorder);
+
+        // Act
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.SemaphoreAcquire, S1));
+        host.ProcessEvent(SyncEventBuilder.ExitWithSuccess(T1, RecordedEventType.SemaphoreAcquireResult, true));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T2, RecordedEventType.SemaphoreAcquire, S1));
+        host.ProcessEvent(SyncEventBuilder.ExitWithSuccess(T2, RecordedEventType.SemaphoreAcquireResult, true)); // deferred [no permits]
+        host.ProcessEvent(SyncEventBuilder.FieldRead(T2)); // also deferred
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.SemaphoreRelease, S1));
+        host.ProcessEvent(SyncEventBuilder.Exit(T1, RecordedEventType.SemaphoreReleaseResult)); // wakes T2
+
+        // Assert
+        var kinds = recorder.Dispatched.Select(ClassifyDispatched).ToArray();
+        Assert.Equal(new[]
+        {
+            (T1, RecordedEventType.SemaphoreAcquire),
+            (T1, RecordedEventType.SemaphoreAcquireResult),
+            (T2, RecordedEventType.SemaphoreAcquire),
+            (T1, RecordedEventType.SemaphoreRelease),
+            (T1, RecordedEventType.SemaphoreReleaseResult),
+            (T2, RecordedEventType.SemaphoreAcquireResult),
+            (T2, RecordedEventType.InstanceFieldRead),
+        }, kinds);
+    }
+
+    [Fact]
+    public void ReorderingPluginHost_SemaphoreMultipleWaiters_DrainInFifoOrder()
+    {
+        // Arrange
+        var host = Build(out var recorder);
+
+        // Act & Assert
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.SemaphoreAcquire, S1));
+        host.ProcessEvent(SyncEventBuilder.ExitWithSuccess(T1, RecordedEventType.SemaphoreAcquireResult, true));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T2, RecordedEventType.SemaphoreAcquire, S1));
+        host.ProcessEvent(SyncEventBuilder.ExitWithSuccess(T2, RecordedEventType.SemaphoreAcquireResult, true)); // deferred [1st]
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T3, RecordedEventType.SemaphoreAcquire, S1));
+        host.ProcessEvent(SyncEventBuilder.ExitWithSuccess(T3, RecordedEventType.SemaphoreAcquireResult, true)); // deferred [2nd]
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.SemaphoreRelease, S1));
+        host.ProcessEvent(SyncEventBuilder.Exit(T1, RecordedEventType.SemaphoreReleaseResult)); // wakes T2
+        var t2AcqIdx = recorder.Dispatched.FindIndex(e => e.Metadata.Tid.Value == T2 && IsSemaphoreAcquireResult(e));
+        var t3AcqIdx = recorder.Dispatched.FindIndex(e => e.Metadata.Tid.Value == T3 && IsSemaphoreAcquireResult(e));
+        Assert.True(t2AcqIdx >= 0, "T2 acquire result should have dispatched after T1 release");
+        Assert.True(t3AcqIdx < 0, "T3 acquire result should still be deferred");
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T2, RecordedEventType.SemaphoreRelease, S1));
+        host.ProcessEvent(SyncEventBuilder.Exit(T2, RecordedEventType.SemaphoreReleaseResult));
+        Assert.Contains(recorder.Dispatched, e => e.Metadata.Tid.Value == T3 && IsSemaphoreAcquireResult(e));
+    }
+
+    [Fact]
+    public void ReorderingPluginHost_FailedSemaphoreTryAcquire_NotDeferred_NotReordered()
+    {
+        // Arrange
+        var host = Build(out var recorder);
+
+        // Act
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.SemaphoreAcquire, S1));
+        host.ProcessEvent(SyncEventBuilder.ExitWithSuccess(T1, RecordedEventType.SemaphoreAcquireResult, true));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T2, RecordedEventType.SemaphoreTryAcquire, S1));
+        host.ProcessEvent(SyncEventBuilder.ExitWithSuccess(T2, RecordedEventType.SemaphoreAcquireResult, false));
+
+        // Assert
+        Assert.Equal(4, recorder.Dispatched.Count);
+        Assert.Equal((T2, RecordedEventType.SemaphoreAcquireResult), ClassifyDispatched(recorder.Dispatched[^1]));
+    }
+
+    [Fact]
+    public void ReorderingPluginHost_MonitorWaitReentrancy_RestoresOwnedDepth()
+    {
+        // Arrange
+        var host = Build(out var recorder);
+
+        // Act & Assert
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.MonitorLockAcquire, L1));
+        host.ProcessEvent(SyncEventBuilder.Exit(T1, RecordedEventType.MonitorLockAcquireResult));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.MonitorLockAcquire, L1));
+        host.ProcessEvent(SyncEventBuilder.Exit(T1, RecordedEventType.MonitorLockAcquireResult));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.MonitorWaitAttempt, L1));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T2, RecordedEventType.MonitorLockAcquire, L1));
+        host.ProcessEvent(SyncEventBuilder.Exit(T2, RecordedEventType.MonitorLockAcquireResult));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T2, RecordedEventType.MonitorLockRelease, L1));
+        host.ProcessEvent(SyncEventBuilder.Exit(T2, RecordedEventType.MonitorLockReleaseResult));
+        host.ProcessEvent(SyncEventBuilder.ExitWithSuccess(T1, RecordedEventType.MonitorWaitResult, true));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.MonitorLockRelease, L1));
+        host.ProcessEvent(SyncEventBuilder.Exit(T1, RecordedEventType.MonitorLockReleaseResult));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T3, RecordedEventType.MonitorLockAcquire, L1));
+        host.ProcessEvent(SyncEventBuilder.Exit(T3, RecordedEventType.MonitorLockAcquireResult));
+        Assert.DoesNotContain(recorder.Dispatched, e => e.Metadata.Tid.Value == T3 && IsAcquireResult(e));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.MonitorLockRelease, L1));
+        host.ProcessEvent(SyncEventBuilder.Exit(T1, RecordedEventType.MonitorLockReleaseResult));
+        Assert.Contains(recorder.Dispatched, e => e.Metadata.Tid.Value == T3 && IsAcquireResult(e));
+    }
+
+    [Fact]
+    public void ReorderingPluginHost_MonitorWaitWithoutOwnership_DispatchesWhenLockFree()
+    {
+        // Arrange
+        var host = Build(out var recorder);
+
+        // Act
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T2, RecordedEventType.MonitorLockAcquire, L1));
+        host.ProcessEvent(SyncEventBuilder.Exit(T2, RecordedEventType.MonitorLockAcquireResult));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.MonitorWaitAttempt, L1));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T2, RecordedEventType.MonitorLockRelease, L1));
+        host.ProcessEvent(SyncEventBuilder.Exit(T2, RecordedEventType.MonitorLockReleaseResult));
+        host.ProcessEvent(SyncEventBuilder.ExitWithSuccess(T1, RecordedEventType.MonitorWaitResult, true));
+
+        // Assert
+        Assert.Contains(recorder.Dispatched, e =>
+            e.Metadata.Tid.Value == T1 && ClassifyDispatched(e) == (T1, RecordedEventType.MonitorWaitResult));
+    }
+
+    [Fact]
+    public void ReorderingPluginHost_PulseOne_PassThrough()
+    {
+        // Arrange
+        var host = Build(out var recorder);
+
+        // Act
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.MonitorLockAcquire, L1));
+        host.ProcessEvent(SyncEventBuilder.Exit(T1, RecordedEventType.MonitorLockAcquireResult));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.MonitorPulseOneAttempt, L1));
+        host.ProcessEvent(SyncEventBuilder.Exit(T1, RecordedEventType.MonitorPulseOneResult));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.MonitorLockRelease, L1));
+        host.ProcessEvent(SyncEventBuilder.Exit(T1, RecordedEventType.MonitorLockReleaseResult));
+
+        // Assert
+        Assert.Equal(6, recorder.Dispatched.Count);
+        Assert.Equal((T1, RecordedEventType.MonitorPulseOneAttempt), ClassifyDispatched(recorder.Dispatched[2]));
+        Assert.Equal((T1, RecordedEventType.MonitorPulseOneResult), ClassifyDispatched(recorder.Dispatched[3]));
+    }
+
+    [Fact]
+    public void ReorderingPluginHost_ThreadJoin_PassThrough()
+    {
+        // Arrange
+        var host = Build(out var recorder);
+
+        // Act
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.ThreadJoinAttempt, L1));
+        host.ProcessEvent(SyncEventBuilder.ExitWithSuccess(T1, RecordedEventType.ThreadJoinResult, true));
+
+        // Assert
+        Assert.Equal(2, recorder.Dispatched.Count);
+        Assert.Equal((T1, RecordedEventType.ThreadJoinAttempt), ClassifyDispatched(recorder.Dispatched[0]));
+        Assert.Equal((T1, RecordedEventType.ThreadJoinResult), ClassifyDispatched(recorder.Dispatched[1]));
+    }
+
+    [Fact]
+    public void ReorderingPluginHost_UnobservedTaskJoin_PassThrough()
+    {
+        // Arrange
+        var host = Build(out var recorder);
+
+        // Act
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.TaskJoinStart, Task2));
+        host.ProcessEvent(SyncEventBuilder.ExitWithSuccess(T1, RecordedEventType.TaskJoinFinish, true));
+
+        // Assert
+        Assert.Equal(2, recorder.Dispatched.Count);
+        Assert.Equal((T1, RecordedEventType.TaskJoinFinish), ClassifyDispatched(recorder.Dispatched[1]));
+    }
+
+    [Fact]
+    public void ReorderingPluginHost_FailedTaskJoin_NotDeferred()
+    {
+        // Arrange
+        var host = Build(out var recorder);
+
+        // Act
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T2, RecordedEventType.TaskStart, Task1));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.TaskJoinStart, Task1));
+        host.ProcessEvent(SyncEventBuilder.ExitWithSuccess(T1, RecordedEventType.TaskJoinFinish, false));
+
+        // Assert
+        Assert.Contains(recorder.Dispatched, e =>
+            e.Metadata.Tid.Value == T1 &&
+            (e.EventArgs as MethodExitWithArgumentsRecordedEvent)?.Interpretation == (ushort)RecordedEventType.TaskJoinFinish);
+    }
+
+    [Fact]
+    public void ReorderingPluginHost_ThreadDestroy_DrainsAllPendingEventsOfWokenThread()
+    {
+        // Arrange
+        var host = Build(out var recorder);
+
+        // Act
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.MonitorLockAcquire, L1));
+        host.ProcessEvent(SyncEventBuilder.Exit(T1, RecordedEventType.MonitorLockAcquireResult));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T2, RecordedEventType.MonitorLockAcquire, L1));
+        host.ProcessEvent(SyncEventBuilder.Exit(T2, RecordedEventType.MonitorLockAcquireResult)); // deferred
+        host.ProcessEvent(SyncEventBuilder.FieldRead(T2)); // also deferred behind T2's BlockedOn
+        host.ProcessEvent(SyncEventBuilder.ThreadDestroy(T1));
+
+        // Assert
+        var t2Events = recorder.Dispatched
+            .Where(e => e.Metadata.Tid.Value == T2)
+            .Select(ClassifyDispatched)
+            .ToArray();
+        Assert.Equal(new[]
+        {
+            (T2, RecordedEventType.MonitorLockAcquire),
+            (T2, RecordedEventType.MonitorLockAcquireResult),
+            (T2, RecordedEventType.InstanceFieldRead),
+        }, t2Events);
+    }
+
+    private static (uint Tid, RecordedEventType Type) ClassifyDispatched(RecordedEvent e)
+    {
+        var tid = e.Metadata.Tid.Value;
+        var type = e.EventArgs switch
+        {
+            MethodEnterWithArgumentsRecordedEvent enter => (RecordedEventType)enter.Interpretation,
+            MethodExitRecordedEvent exit => (RecordedEventType)exit.Interpretation,
+            MethodExitWithArgumentsRecordedEvent exit => (RecordedEventType)exit.Interpretation,
+            ProfilerDestroyRecordedEvent => RecordedEventType.ProfilerDestroy,
+            ThreadDestroyRecordedEvent => RecordedEventType.ThreadDestroy,
+            _ => RecordedEventType.NotSpecified
+        };
+        return ((uint)tid, type);
+    }
+
+    private static bool IsAcquireResult(RecordedEvent e)
+    {
+        switch (e.EventArgs)
+        {
+            case MethodExitRecordedEvent exit:
+            {
+                var t = (RecordedEventType)exit.Interpretation;
+                return t is RecordedEventType.MonitorLockAcquireResult or RecordedEventType.LockAcquireResult;
+            }
+            case MethodExitWithArgumentsRecordedEvent exitArg:
+            {
+                var t = (RecordedEventType)exitArg.Interpretation;
+                return t is RecordedEventType.MonitorLockAcquireResult or RecordedEventType.LockAcquireResult;
+            }
+            default:
+                return false;
+        }
+    }
+
+    private static bool IsSemaphoreAcquireResult(RecordedEvent e)
+        => e.EventArgs switch
+        {
+            MethodExitRecordedEvent exit =>
+                (RecordedEventType)exit.Interpretation == RecordedEventType.SemaphoreAcquireResult,
+            MethodExitWithArgumentsRecordedEvent exit =>
+                (RecordedEventType)exit.Interpretation == RecordedEventType.SemaphoreAcquireResult,
+            _ => false,
+        };
+}

--- a/src/Tests/SharpDetect.PluginHost.Tests/SharpDetect.PluginHost.Tests.csproj
+++ b/src/Tests/SharpDetect.PluginHost.Tests/SharpDetect.PluginHost.Tests.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <IsPackable>false</IsPackable>
+        <IsTestProject>true</IsTestProject>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="coverlet.collector">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="xunit" />
+        <PackageReference Include="xunit.runner.visualstudio">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\Extensibility\SharpDetect.PluginHost\SharpDetect.PluginHost.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/src/Tests/SharpDetect.PluginHost.Tests/SyncEventBuilder.cs
+++ b/src/Tests/SharpDetect.PluginHost.Tests/SyncEventBuilder.cs
@@ -29,11 +29,17 @@ internal static class SyncEventBuilder
             ArgumentInfos: []));
     }
 
-    public static RecordedEvent EnterWithTargetAndCount(uint tid, RecordedEventType type, nuint targetObjectId, int count)
+    public static RecordedEvent EnterWithTargetCountAndCapacity(
+        uint tid,
+        RecordedEventType type,
+        nuint targetObjectId,
+        int count,
+        int capacity)
     {
-        var args = new byte[Unsafe.SizeOf<nuint>() + sizeof(int)];
+        var args = new byte[Unsafe.SizeOf<nuint>() + sizeof(int) + sizeof(int)];
         MemoryMarshal.Write(args, in targetObjectId);
         MemoryMarshal.Write(args.AsSpan()[Unsafe.SizeOf<nuint>()..], in count);
+        MemoryMarshal.Write(args.AsSpan()[(Unsafe.SizeOf<nuint>() + sizeof(int))..], in capacity);
         return new RecordedEvent(Meta(tid), new MethodEnterWithArgumentsRecordedEvent(
             ModuleId: Module,
             MethodToken: Method,

--- a/src/Tests/SharpDetect.PluginHost.Tests/SyncEventBuilder.cs
+++ b/src/Tests/SharpDetect.PluginHost.Tests/SyncEventBuilder.cs
@@ -86,4 +86,13 @@ internal static class SyncEventBuilder
 
     public static RecordedEvent ThreadDestroy(uint destroyedTid, uint emitterTid)
         => new(Meta(emitterTid), new ThreadDestroyRecordedEvent(new ThreadId(destroyedTid)));
+
+    public static RecordedEvent GarbageCollected(uint emitterTid, params nuint[] removedObjects)
+    {
+        var ids = new TrackedObjectId[removedObjects.Length];
+        for (var i = 0; i < removedObjects.Length; i++)
+            ids[i] = new TrackedObjectId(removedObjects[i]);
+
+        return new RecordedEvent(Meta(emitterTid), new GarbageCollectedTrackedObjectsRecordedEvent(ids));
+    }
 }

--- a/src/Tests/SharpDetect.PluginHost.Tests/SyncEventBuilder.cs
+++ b/src/Tests/SharpDetect.PluginHost.Tests/SyncEventBuilder.cs
@@ -69,9 +69,21 @@ internal static class SyncEventBuilder
             ArgumentValues: [],
             ArgumentInfos: []));
 
+    public static RecordedEvent FieldAccessInstrumentation(uint tid, ulong instrumentationId)
+        => new(Meta(tid), new FieldAccessInstrumentationRecordedEvent(
+            ModuleId: Module,
+            MethodToken: Method,
+            MethodOffset: 0,
+            FieldToken: new MdToken(0x04000001),
+            InstrumentationId: instrumentationId,
+            IsVolatile: false));
+
     public static RecordedEvent ProfilerDestroy(uint tid)
         => new(Meta(tid), new ProfilerDestroyRecordedEvent());
 
     public static RecordedEvent ThreadDestroy(uint tid)
         => new(Meta(tid), new ThreadDestroyRecordedEvent(new ThreadId(tid)));
+
+    public static RecordedEvent ThreadDestroy(uint destroyedTid, uint emitterTid)
+        => new(Meta(emitterTid), new ThreadDestroyRecordedEvent(new ThreadId(destroyedTid)));
 }

--- a/src/Tests/SharpDetect.PluginHost.Tests/SyncEventBuilder.cs
+++ b/src/Tests/SharpDetect.PluginHost.Tests/SyncEventBuilder.cs
@@ -29,6 +29,23 @@ internal static class SyncEventBuilder
             ArgumentInfos: []));
     }
 
+    public static RecordedEvent EnterWithTargetAndCount(
+        uint tid,
+        RecordedEventType type,
+        nuint targetObjectId,
+        int count)
+    {
+        var args = new byte[Unsafe.SizeOf<nuint>() + sizeof(int)];
+        MemoryMarshal.Write(args, in targetObjectId);
+        MemoryMarshal.Write(args.AsSpan()[Unsafe.SizeOf<nuint>()..], in count);
+        return new RecordedEvent(Meta(tid), new MethodEnterWithArgumentsRecordedEvent(
+            ModuleId: Module,
+            MethodToken: Method,
+            Interpretation: (ushort)type,
+            ArgumentValues: args,
+            ArgumentInfos: []));
+    }
+
     public static RecordedEvent EnterWithTargetCountAndCapacity(
         uint tid,
         RecordedEventType type,

--- a/src/Tests/SharpDetect.PluginHost.Tests/SyncEventBuilder.cs
+++ b/src/Tests/SharpDetect.PluginHost.Tests/SyncEventBuilder.cs
@@ -29,6 +29,19 @@ internal static class SyncEventBuilder
             ArgumentInfos: []));
     }
 
+    public static RecordedEvent EnterWithTargetAndCount(uint tid, RecordedEventType type, nuint targetObjectId, int count)
+    {
+        var args = new byte[Unsafe.SizeOf<nuint>() + sizeof(int)];
+        MemoryMarshal.Write(args, in targetObjectId);
+        MemoryMarshal.Write(args.AsSpan()[Unsafe.SizeOf<nuint>()..], in count);
+        return new RecordedEvent(Meta(tid), new MethodEnterWithArgumentsRecordedEvent(
+            ModuleId: Module,
+            MethodToken: Method,
+            Interpretation: (ushort)type,
+            ArgumentValues: args,
+            ArgumentInfos: []));
+    }
+
     public static RecordedEvent Exit(uint tid, RecordedEventType type)
         => new(Meta(tid), new MethodExitRecordedEvent(
             ModuleId: Module,

--- a/src/Tests/SharpDetect.PluginHost.Tests/SyncEventBuilder.cs
+++ b/src/Tests/SharpDetect.PluginHost.Tests/SyncEventBuilder.cs
@@ -1,0 +1,64 @@
+// Copyright 2026 Andrej Čižmárik and Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using SharpDetect.Core.Events;
+using SharpDetect.Core.Events.Profiler;
+
+namespace SharpDetect.PluginHost.Tests;
+
+internal static class SyncEventBuilder
+{
+    public const uint Pid = 42;
+    private static readonly ModuleId Module = new(1);
+    private static readonly MdMethodDef Method = new(0x06000001);
+
+    public static RecordedEventMetadata Meta(uint tid)
+        => new(Pid, new ThreadId(tid));
+
+    public static RecordedEvent EnterWithTarget(uint tid, RecordedEventType type, nuint targetObjectId)
+    {
+        var args = new byte[Unsafe.SizeOf<nuint>()];
+        MemoryMarshal.Write(args, in targetObjectId);
+        return new RecordedEvent(Meta(tid), new MethodEnterWithArgumentsRecordedEvent(
+            ModuleId: Module,
+            MethodToken: Method,
+            Interpretation: (ushort)type,
+            ArgumentValues: args,
+            ArgumentInfos: []));
+    }
+
+    public static RecordedEvent Exit(uint tid, RecordedEventType type)
+        => new(Meta(tid), new MethodExitRecordedEvent(
+            ModuleId: Module,
+            MethodToken: Method,
+            Interpretation: (ushort)type));
+
+    public static RecordedEvent ExitWithSuccess(uint tid, RecordedEventType type, bool success)
+    {
+        var ret = new byte[1];
+        MemoryMarshal.Write(ret, in success);
+        return new RecordedEvent(Meta(tid), new MethodExitWithArgumentsRecordedEvent(
+            ModuleId: Module,
+            MethodToken: Method,
+            Interpretation: (ushort)type,
+            ReturnValue: ret,
+            ByRefArgumentValues: [],
+            ByRefArgumentInfos: []));
+    }
+
+    public static RecordedEvent FieldRead(uint tid)
+        => new(Meta(tid), new MethodEnterWithArgumentsRecordedEvent(
+            ModuleId: Module,
+            MethodToken: Method,
+            Interpretation: (ushort)RecordedEventType.InstanceFieldRead,
+            ArgumentValues: [],
+            ArgumentInfos: []));
+
+    public static RecordedEvent ProfilerDestroy(uint tid)
+        => new(Meta(tid), new ProfilerDestroyRecordedEvent());
+
+    public static RecordedEvent ThreadDestroy(uint tid)
+        => new(Meta(tid), new ThreadDestroyRecordedEvent(new ThreadId(tid)));
+}


### PR DESCRIPTION
This PR attempts to resolve most issues that were previously responsible for delivering events to plugins in incorrect order. Profiler already guarantees the following:

- Events for a specific thread are always received in a correct order

The issue is that it does not guarantee ordering between different threads. This mostly stems from the fact that we are hooking managed methods for synchronization operations. However, these methods wrap OS-level synchronization primitives. Therefore it is possible that method `Monitor.Enter` finishes technically before `Monitor.Exit` from a different thread.