### PR TITLE
Fix issues with cannot get method body when unsafe accessor is used

### DIFF
--- a/src/SharpDetect.Profiler/LibProfiler/Instrumentation.cpp
+++ b/src/SharpDetect.Profiler/LibProfiler/Instrumentation.cpp
@@ -53,7 +53,9 @@ HRESULT LibProfiler::PatchMethodBody(
 	HRESULT hr = rewriter.Import();
 	if (FAILED(hr))
 	{
-		LOG_F(ERROR, "Could not import method body for %d from module %s. Error: 0x%x.", mdMethodDef, moduleDef.GetName().c_str(), hr);
+        if (hr != CORPROF_E_FUNCTION_NOT_IL)
+			LOG_F(ERROR, "Could not import method body for %d from module %s. Error: 0x%x.", mdMethodDef, moduleDef.GetName().c_str(), hr);
+		
 		return E_FAIL;
 	}
 


### PR DESCRIPTION
This PR resolves issues with failing to access IL of methods marked with `UnsafeAccessorAttribute`. These are not managed but for some reason still emit `JITCompilationStarted` in profiler. As a result, we are skipping all methods that return `CORPROF_E_FUNCTION_NOT_IL` when accessing their method body. Warnings are issued only for other errors