### PR TITLE
Make it possible to run analysis against unit test

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -19,6 +19,7 @@
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0" />
     <PackageVersion Include="xunit" Version="2.9.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.0" />
+    <PackageVersion Include="TUnit" Version="1.45.8" />
     <PackageVersion Include="coverlet.collector" Version="6.0.2" />
     <PackageVersion Include="Handlebars.Net" Version="2.1.6" />
   </ItemGroup>

--- a/src/Extensibility/SharpDetect.Plugins.DataRace.Common/IDataRacePluginConfiguration.cs
+++ b/src/Extensibility/SharpDetect.Plugins.DataRace.Common/IDataRacePluginConfiguration.cs
@@ -1,11 +1,13 @@
 // Copyright 2026 Andrej Čižmárik and Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+using System.Collections.Immutable;
+
 namespace SharpDetect.Plugins.DataRace.Common;
 
 public interface IDataRacePluginConfiguration
 {
     bool EnableFieldsAccessInstrumentation { get; }
-    string[] SkipInstrumentationForAssemblies { get; }
+    ImmutableArray<string> SkipInstrumentationForAssemblies { get; }
 }
 

--- a/src/Extensibility/SharpDetect.Plugins.DataRace.Common/WellKnownModules.cs
+++ b/src/Extensibility/SharpDetect.Plugins.DataRace.Common/WellKnownModules.cs
@@ -1,0 +1,19 @@
+// Copyright 2026 Andrej Čižmárik and Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Collections.Immutable;
+
+namespace SharpDetect.Plugins.DataRace.Common;
+
+public static class WellKnownModules
+{
+    public static readonly ImmutableArray<string> SystemModulePrefixes = [ "System.", "Microsoft." ];
+    public static readonly ImmutableArray<string> SystemAndTestFrameworksModulePrefixes =
+    [ 
+        "System.",
+        "Microsoft.",
+        "xunit.",
+        "nunit.",
+        "TUnit."
+    ];
+}

--- a/src/Extensibility/SharpDetect.Plugins.DataRace.Eraser/EraserPluginConfiguration.cs
+++ b/src/Extensibility/SharpDetect.Plugins.DataRace.Eraser/EraserPluginConfiguration.cs
@@ -1,6 +1,7 @@
 // Copyright 2026 Andrej Čižmárik and Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+using System.Collections.Immutable;
 using SharpDetect.Core.Configuration;
 using SharpDetect.Plugins.DataRace.Common;
 
@@ -9,6 +10,6 @@ namespace SharpDetect.Plugins.DataRace.Eraser;
 public sealed class EraserPluginConfiguration : PluginOptionsConfiguration, IPluginOptionsConfig<EraserPluginConfiguration>, IDataRacePluginConfiguration
 {
     public bool EnableFieldsAccessInstrumentation { get; init; } = true;
-    public string[] SkipInstrumentationForAssemblies { get; init; } = [];
+    public ImmutableArray<string> SkipInstrumentationForAssemblies { get; init; } = WellKnownModules.SystemModulePrefixes;
     public static EraserPluginConfiguration Default => new();
 }

--- a/src/Extensibility/SharpDetect.Plugins.DataRace.FastTrack/FastTrackPluginConfiguration.cs
+++ b/src/Extensibility/SharpDetect.Plugins.DataRace.FastTrack/FastTrackPluginConfiguration.cs
@@ -1,6 +1,7 @@
 // Copyright 2026 Andrej Čižmárik and Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+using System.Collections.Immutable;
 using SharpDetect.Core.Configuration;
 using SharpDetect.Plugins.DataRace.Common;
 
@@ -9,7 +10,7 @@ namespace SharpDetect.Plugins.DataRace.FastTrack;
 public sealed class FastTrackPluginConfiguration : PluginOptionsConfiguration, IPluginOptionsConfig<FastTrackPluginConfiguration>, IDataRacePluginConfiguration
 {
     public bool EnableFieldsAccessInstrumentation { get; init; } = true;
-    public string[] SkipInstrumentationForAssemblies { get; init; } = [];
+    public ImmutableArray<string> SkipInstrumentationForAssemblies { get; init; } = WellKnownModules.SystemModulePrefixes;
     public static FastTrackPluginConfiguration Default => new();
 }
 

--- a/src/Samples/Shared/DataRaceWorkloads.cs
+++ b/src/Samples/Shared/DataRaceWorkloads.cs
@@ -1,0 +1,49 @@
+// Copyright 2026 Andrej Čižmárik and Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+namespace Shared;
+
+public static class DataRaceWorkloads
+{
+    public static int Field;
+
+    public static void RaceFact()
+    {
+        Field = 0;
+        RunConcurrently(
+            () => Field = 1,
+            () => Field = 2);
+    }
+
+    public static void CleanFact()
+    {
+        Field = 0;
+        var t1 = new Thread(() => Field = 1);
+        t1.Start();
+        t1.Join();
+        var t2 = new Thread(() => Field = 2);
+        t2.Start();
+        t2.Join();
+    }
+
+    private static void RunConcurrently(params Action[] actions)
+    {
+        using var start = new ManualResetEventSlim(initialState: false);
+        using var ready = new CountdownEvent(initialCount: actions.Length);
+        var threads = actions
+            .Select(action => new Thread(() =>
+            {
+                ready.Signal();
+                start.Wait();
+                action();
+            }))
+            .ToArray();
+
+        foreach (var thread in threads)
+            thread.Start();
+        ready.Wait();
+        start.Set();
+        foreach (var thread in threads)
+            thread.Join();
+    }
+}

--- a/src/Samples/SimpleDataRaceTestsMtp/AnalysisDescriptor.json
+++ b/src/Samples/SimpleDataRaceTestsMtp/AnalysisDescriptor.json
@@ -1,0 +1,21 @@
+{
+    "Target":
+    {
+        "Path": "../../Samples/SimpleDataRaceTestsMtp/bin/Debug/net10.0/SimpleDataRaceTestsMtp.dll",
+        "Kind": "TestAssembly",
+        "Test":
+        {
+            "Runner": "Mtp",
+            "Filter": "/*/*/*/RaceFact"
+        }
+    },
+    "Analysis":
+    {
+        "PluginName": "FastTrack",
+        "RenderReport": true,
+        "Configuration":
+        {
+            "SkipInstrumentationForAssemblies": [ "System.", "Microsoft.", "TUnit." ]
+        }
+    }
+}

--- a/src/Samples/SimpleDataRaceTestsMtp/DataRaceTests.cs
+++ b/src/Samples/SimpleDataRaceTestsMtp/DataRaceTests.cs
@@ -1,0 +1,16 @@
+// Copyright 2026 Andrej Čižmárik and Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+using Shared;
+using TUnit.Core;
+
+namespace SimpleDataRaceTestsMtp;
+
+public class DataRaceTests
+{
+    [Test]
+    public void RaceFact() => DataRaceWorkloads.RaceFact();
+
+    [Test]
+    public void CleanFact() => DataRaceWorkloads.CleanFact();
+}

--- a/src/Samples/SimpleDataRaceTestsMtp/SimpleDataRaceTestsMtp.csproj
+++ b/src/Samples/SimpleDataRaceTestsMtp/SimpleDataRaceTestsMtp.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net10.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <IsTestProject>false</IsTestProject>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="TUnit" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <Compile Include="..\Shared\DataRaceWorkloads.cs" Link="DataRaceWorkloads.cs" />
+        <None Update="AnalysisDescriptor.json">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </None>
+    </ItemGroup>
+
+</Project>

--- a/src/Samples/SimpleDataRaceTestsVSTest/AnalysisDescriptor.json
+++ b/src/Samples/SimpleDataRaceTestsVSTest/AnalysisDescriptor.json
@@ -1,0 +1,21 @@
+{
+    "Target":
+    {
+        "Path": "../../Samples/SimpleDataRaceTestsVSTest/bin/Debug/net10.0/SimpleDataRaceTestsVSTest.dll",
+        "Kind": "TestAssembly",
+        "Test":
+        {
+            "Runner": "VsTest",
+            "Filter": "FullyQualifiedName~RaceFact"
+        }
+    },
+    "Analysis":
+    {
+        "PluginName": "FastTrack",
+        "RenderReport": true,
+        "Configuration":
+        {
+            "SkipInstrumentationForAssemblies": [ "System.", "Microsoft." ]
+        }
+    }
+}

--- a/src/Samples/SimpleDataRaceTestsVSTest/DataRaceTests.cs
+++ b/src/Samples/SimpleDataRaceTestsVSTest/DataRaceTests.cs
@@ -1,0 +1,16 @@
+// Copyright 2026 Andrej Čižmárik and Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+using Shared;
+using Xunit;
+
+namespace SimpleDataRaceTestsVSTest;
+
+public class DataRaceTests
+{
+    [Fact]
+    public void RaceFact() => DataRaceWorkloads.RaceFact();
+
+    [Fact]
+    public void CleanFact() => DataRaceWorkloads.CleanFact();
+}

--- a/src/Samples/SimpleDataRaceTestsVSTest/SimpleDataRaceTestsVSTest.csproj
+++ b/src/Samples/SimpleDataRaceTestsVSTest/SimpleDataRaceTestsVSTest.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net10.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
+        <IsTestProject>false</IsTestProject>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="xunit" />
+        <PackageReference Include="xunit.runner.visualstudio">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+        <Compile Include="..\Shared\DataRaceWorkloads.cs" Link="DataRaceWorkloads.cs" />
+        <None Update="AnalysisDescriptor.json">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </None>
+    </ItemGroup>
+
+</Project>

--- a/src/SharpDetect.Cli/Commands/InitCommand.cs
+++ b/src/SharpDetect.Cli/Commands/InitCommand.cs
@@ -6,6 +6,7 @@ using CliFx.Attributes;
 using CliFx.Exceptions;
 using CliFx.Infrastructure;
 using SharpDetect.Cli.Handlers;
+using SharpDetect.Worker.Commands.Run;
 
 namespace SharpDetect.Cli.Commands;
 
@@ -21,11 +22,40 @@ public sealed class InitCommand : ICommand
     [CommandOption("target", 't', Description = "Target application path")]
     public required string TargetPath { get; init; }
 
+    [CommandOption("test", Description = "Treat the target as a test assembly")]
+    public bool IsTest { get; init; }
+
+    [CommandOption("filter", 'f', Description = "Test filter expression (requires --test)")]
+    public string? TestFilter { get; init; }
+
+    [CommandOption("runner", Description = "Test runner: Mtp (default) | VSTest (requires --test)")]
+    public TestRunner TestRunner { get; init; } = TestTargetConfigurationArgs.DefaultRunner;
+
     public async ValueTask ExecuteAsync(IConsole console)
     {
+        if (!IsTest && TestFilter is not null)
+        {
+            throw new CommandException(
+                "--filter requires --test.",
+                (int)ExitCode.ConfigurationError);
+        }
+
+        if (!IsTest && TestRunner != TestTargetConfigurationArgs.DefaultRunner)
+        {
+            throw new CommandException(
+                "--runner requires --test.",
+                (int)ExitCode.ConfigurationError);
+        }
+
         try
         {
-            var handler = new InitCommandHandler(OutputFile, PluginType, TargetPath);
+            var handler = new InitCommandHandler(
+                outputFile: OutputFile,
+                pluginNameOrTypeFullName: PluginType,
+                targetAssemblyPath: TargetPath,
+                isTest: IsTest,
+                testRunner: TestRunner,
+                testFilter: TestFilter);
             var cancellationToken = console.RegisterCancellationHandler();
             await handler.ExecuteAsync(console, cancellationToken);
         }
@@ -42,4 +72,3 @@ public sealed class InitCommand : ICommand
         }
     }
 }
-

--- a/src/SharpDetect.Cli/Commands/InitCommand.cs
+++ b/src/SharpDetect.Cli/Commands/InitCommand.cs
@@ -31,6 +31,9 @@ public sealed class InitCommand : ICommand
     [CommandOption("runner", Description = "Test runner: Mtp (default) | VSTest (requires --test)")]
     public TestRunner TestRunner { get; init; } = TestTargetConfigurationArgs.DefaultRunner;
 
+    [CommandOption("instrument-system-libraries", Description = "Instrument system assemblies (System, Microsoft, test frameworks..)")]
+    public bool InstrumentSystemLibraries { get; init; }
+
     public async ValueTask ExecuteAsync(IConsole console)
     {
         if (!IsTest && TestFilter is not null)
@@ -55,7 +58,8 @@ public sealed class InitCommand : ICommand
                 targetAssemblyPath: TargetPath,
                 isTest: IsTest,
                 testRunner: TestRunner,
-                testFilter: TestFilter);
+                testFilter: TestFilter,
+                instrumentSystemLibraries: InstrumentSystemLibraries);
             var cancellationToken = console.RegisterCancellationHandler();
             await handler.ExecuteAsync(console, cancellationToken);
         }

--- a/src/SharpDetect.Cli/Commands/RunCommand.cs
+++ b/src/SharpDetect.Cli/Commands/RunCommand.cs
@@ -31,9 +31,12 @@ public sealed class RunCommand : ICommand
     [CommandOption("runner", Description = "Test runner: Mtp (default) | VSTest (requires --test)")]
     public TestRunner TestRunner { get; init; } = TestTargetConfigurationArgs.DefaultRunner;
 
+    [CommandOption("instrument-system-libraries", Description = "Instrument system assemblies (System, Microsoft, test frameworks..)")]
+    public bool InstrumentSystemLibraries { get; init; }
+
     public async ValueTask ExecuteAsync(IConsole console)
     {
-        ValidateOptions(ArgumentsFile, PluginType, TargetPath, IsTest, TestFilter, TestRunner);
+        ValidateOptions(ArgumentsFile, PluginType, TargetPath, IsTest, TestFilter, TestRunner, InstrumentSystemLibraries);
 
         var useInlineForm = string.IsNullOrEmpty(ArgumentsFile);
         var previousDirectory = Directory.GetCurrentDirectory();
@@ -48,7 +51,8 @@ public sealed class RunCommand : ICommand
                     targetAssemblyPath: TargetPath!,
                     isTest: IsTest,
                     testRunner: TestRunner,
-                    testFilter: TestFilter);
+                    testFilter: TestFilter,
+                    instrumentSystemLibraries: InstrumentSystemLibraries);
                 var rawJson = InitCommandHandler.SerializeRunCommandArgs(arguments);
                 commandHandler = new RunCommandHandler(arguments, rawJson);
             }
@@ -94,7 +98,8 @@ public sealed class RunCommand : ICommand
         string? targetPath,
         bool isTest,
         string? testFilter,
-        TestRunner testRunner)
+        TestRunner testRunner,
+        bool instrumentSystemLibraries = false)
     {
         var hasConfigFile = !string.IsNullOrEmpty(argumentsFile);
         var hasPlugin = !string.IsNullOrEmpty(pluginType);
@@ -124,6 +129,11 @@ public sealed class RunCommand : ICommand
         if (!isTest && testRunner != TestTargetConfigurationArgs.DefaultRunner)
             throw new CommandException(
                 "--runner requires --test.",
+                (int)ExitCode.ConfigurationError);
+
+        if (hasConfigFile && instrumentSystemLibraries)
+            throw new CommandException(
+                "--instrument-system-libraries cannot be combined with a configuration file; set SkipInstrumentationForAssemblies in the file instead.",
                 (int)ExitCode.ConfigurationError);
     }
 }

--- a/src/SharpDetect.Cli/Commands/RunCommand.cs
+++ b/src/SharpDetect.Cli/Commands/RunCommand.cs
@@ -6,27 +6,61 @@ using CliFx.Attributes;
 using CliFx.Exceptions;
 using CliFx.Infrastructure;
 using SharpDetect.Cli.Handlers;
+using SharpDetect.Worker.Commands.Run;
 
 namespace SharpDetect.Cli.Commands;
 
-[Command("run", Description = "Executes analysis based on provided configuration file")]
+[Command("run", Description = "Executes analysis using inline options, or based on a provided configuration file")]
 public sealed class RunCommand : ICommand
 {
-    [CommandParameter(0, Description = "Arguments file")]
-    public required string ArgumentsFile { get; init; }
+    [CommandParameter(0, IsRequired = false, Description = "Configuration file (omit to use inline options)")]
+    public string? ArgumentsFile { get; init; }
+
+    [CommandOption("plugin", 'p', Description = "Plugin type full name")]
+    public string? PluginType { get; init; }
+
+    [CommandOption("target", 't', Description = "Target application path")]
+    public string? TargetPath { get; init; }
+
+    [CommandOption("test", Description = "Treat the target as a test assembly")]
+    public bool IsTest { get; init; }
+
+    [CommandOption("filter", 'f', Description = "Test filter expression (requires --test)")]
+    public string? TestFilter { get; init; }
+
+    [CommandOption("runner", Description = "Test runner: Mtp (default) | VSTest (requires --test)")]
+    public TestRunner TestRunner { get; init; } = TestTargetConfigurationArgs.DefaultRunner;
 
     public async ValueTask ExecuteAsync(IConsole console)
     {
+        ValidateOptions(ArgumentsFile, PluginType, TargetPath, IsTest, TestFilter, TestRunner);
+
+        var useInlineForm = string.IsNullOrEmpty(ArgumentsFile);
         var previousDirectory = Directory.GetCurrentDirectory();
-        var directoryName = Path.GetDirectoryName(ArgumentsFile);
-        var workingDirectory = string.IsNullOrEmpty(directoryName) ? previousDirectory : directoryName;
         RunCommandHandler? commandHandler = null;
 
         try
         {
-            Directory.SetCurrentDirectory(workingDirectory);
-            var fileName = Path.GetFileName(ArgumentsFile);
-            commandHandler = new RunCommandHandler(fileName);
+            if (useInlineForm)
+            {
+                var arguments = InitCommandHandler.BuildRunCommandArgs(
+                    pluginNameOrTypeFullName: PluginType!,
+                    targetAssemblyPath: TargetPath!,
+                    isTest: IsTest,
+                    testRunner: TestRunner,
+                    testFilter: TestFilter);
+                var rawJson = InitCommandHandler.SerializeRunCommandArgs(arguments);
+                commandHandler = new RunCommandHandler(arguments, rawJson);
+            }
+            else
+            {
+                var directoryName = Path.GetDirectoryName(ArgumentsFile);
+                var workingDirectory = string.IsNullOrEmpty(directoryName) ? previousDirectory : directoryName;
+                Directory.SetCurrentDirectory(workingDirectory);
+                var fileName = Path.GetFileName(ArgumentsFile!);
+                commandHandler = new RunCommandHandler(fileName);
+            }
+
             var cancellationToken = console.RegisterCancellationHandler();
             await commandHandler.ExecuteAsync(console, cancellationToken);
         }
@@ -52,5 +86,44 @@ public sealed class RunCommand : ICommand
             commandHandler?.Dispose();
             Directory.SetCurrentDirectory(previousDirectory);
         }
+    }
+
+    internal static void ValidateOptions(
+        string? argumentsFile,
+        string? pluginType,
+        string? targetPath,
+        bool isTest,
+        string? testFilter,
+        TestRunner testRunner)
+    {
+        var hasConfigFile = !string.IsNullOrEmpty(argumentsFile);
+        var hasPlugin = !string.IsNullOrEmpty(pluginType);
+        var hasTarget = !string.IsNullOrEmpty(targetPath);
+        var hasInline = hasPlugin || hasTarget;
+
+        if (hasConfigFile && hasInline)
+            throw new CommandException(
+                "Specify either a configuration file or inline options (--plugin and --target), not both.",
+                (int)ExitCode.ConfigurationError);
+
+        if (!hasConfigFile && !hasInline)
+            throw new CommandException(
+                "Either provide a configuration file or specify inline options (--plugin and --target).",
+                (int)ExitCode.ConfigurationError);
+
+        if (hasInline && (!hasPlugin || !hasTarget))
+            throw new CommandException(
+                "Both --plugin and --target are required when using inline options.",
+                (int)ExitCode.ConfigurationError);
+
+        if (!isTest && testFilter is not null)
+            throw new CommandException(
+                "--filter requires --test.",
+                (int)ExitCode.ConfigurationError);
+
+        if (!isTest && testRunner != TestTargetConfigurationArgs.DefaultRunner)
+            throw new CommandException(
+                "--runner requires --test.",
+                (int)ExitCode.ConfigurationError);
     }
 }

--- a/src/SharpDetect.Cli/Handlers/InitCommandHandler.cs
+++ b/src/SharpDetect.Cli/Handlers/InitCommandHandler.cs
@@ -11,7 +11,13 @@ using SharpDetect.Worker.Commands.Run;
 
 namespace SharpDetect.Cli.Handlers;
 
-internal sealed class InitCommandHandler(string outputFile, string pluginNameOrTypeFullName, string targetAssemblyPath)
+internal sealed class InitCommandHandler(
+    string outputFile,
+    string pluginNameOrTypeFullName,
+    string targetAssemblyPath,
+    bool isTest = false,
+    TestRunner testRunner = TestTargetConfigurationArgs.DefaultRunner,
+    string? testFilter = null)
 {
     private static readonly JsonSerializerOptions JsonSerializerOptions = new()
     {
@@ -39,15 +45,31 @@ internal sealed class InitCommandHandler(string outputFile, string pluginNameOrT
 
     internal string CreateTemplateConfigurationJson()
     {
-        var templateArgs = CreateTemplateConfiguration();
+        var templateArgs = BuildRunCommandArgs(
+            pluginNameOrTypeFullName: pluginNameOrTypeFullName,
+            targetAssemblyPath: targetAssemblyPath,
+            isTest: isTest,
+            testRunner: testRunner,
+            testFilter: testFilter);
         return JsonSerializer.Serialize(templateArgs, JsonSerializerOptions);
     }
 
-    private RunCommandArgs CreateTemplateConfiguration()
+    internal static RunCommandArgs BuildRunCommandArgs(
+        string pluginNameOrTypeFullName,
+        string targetAssemblyPath,
+        bool isTest = false,
+        TestRunner testRunner = TestTargetConfigurationArgs.DefaultRunner,
+        string? testFilter = null)
     {
-        var target = new TargetConfigurationArgs(
-            path: targetAssemblyPath,
-            redirectInputOutput: new RedirectInputOutputConfigurationArgs(singleConsoleMode: true));
+        var target = isTest
+            ? new TargetConfigurationArgs(
+                path: targetAssemblyPath,
+                kind: TargetKind.TestAssembly,
+                redirectInputOutput: new RedirectInputOutputConfigurationArgs(singleConsoleMode: true),
+                test: new TestTargetConfigurationArgs(runner: testRunner, filter: testFilter))
+            : new TargetConfigurationArgs(
+                path: targetAssemblyPath,
+                redirectInputOutput: new RedirectInputOutputConfigurationArgs(singleConsoleMode: true));
 
         var analysis = pluginNameOrTypeFullName.Contains('.')
             ? new AnalysisPluginConfigurationArgs(pluginFullTypeName: pluginNameOrTypeFullName, renderReport: true)
@@ -55,6 +77,9 @@ internal sealed class InitCommandHandler(string outputFile, string pluginNameOrT
 
         return new RunCommandArgs(Runtime: null, target, analysis);
     }
+
+    internal static string SerializeRunCommandArgs(RunCommandArgs args)
+        => JsonSerializer.Serialize(args, JsonSerializerOptions);
 
     private static bool IsValidDotNetAssembly(string filePath)
     {
@@ -74,4 +99,3 @@ internal sealed class InitCommandHandler(string outputFile, string pluginNameOrT
         }
     }
 }
-

--- a/src/SharpDetect.Cli/Handlers/InitCommandHandler.cs
+++ b/src/SharpDetect.Cli/Handlers/InitCommandHandler.cs
@@ -7,6 +7,7 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using CliFx.Exceptions;
 using CliFx.Infrastructure;
+using SharpDetect.Plugins.DataRace.Common;
 using SharpDetect.Worker.Commands.Run;
 
 namespace SharpDetect.Cli.Handlers;
@@ -15,9 +16,10 @@ internal sealed class InitCommandHandler(
     string outputFile,
     string pluginNameOrTypeFullName,
     string targetAssemblyPath,
-    bool isTest = false,
-    TestRunner testRunner = TestTargetConfigurationArgs.DefaultRunner,
-    string? testFilter = null)
+    bool instrumentSystemLibraries,
+    bool isTest,
+    TestRunner? testRunner,
+    string? testFilter)
 {
     private static readonly JsonSerializerOptions JsonSerializerOptions = new()
     {
@@ -46,36 +48,57 @@ internal sealed class InitCommandHandler(
     internal string CreateTemplateConfigurationJson()
     {
         var templateArgs = BuildRunCommandArgs(
-            pluginNameOrTypeFullName: pluginNameOrTypeFullName,
-            targetAssemblyPath: targetAssemblyPath,
-            isTest: isTest,
-            testRunner: testRunner,
-            testFilter: testFilter);
+            pluginNameOrTypeFullName,
+            targetAssemblyPath,
+            instrumentSystemLibraries,
+            isTest,
+            testRunner,
+            testFilter);
         return JsonSerializer.Serialize(templateArgs, JsonSerializerOptions);
     }
 
     internal static RunCommandArgs BuildRunCommandArgs(
         string pluginNameOrTypeFullName,
         string targetAssemblyPath,
-        bool isTest = false,
-        TestRunner testRunner = TestTargetConfigurationArgs.DefaultRunner,
-        string? testFilter = null)
+        bool instrumentSystemLibraries,
+        bool isTest,
+        TestRunner? testRunner,
+        string? testFilter)
     {
         var target = isTest
             ? new TargetConfigurationArgs(
                 path: targetAssemblyPath,
                 kind: TargetKind.TestAssembly,
-                redirectInputOutput: new RedirectInputOutputConfigurationArgs(singleConsoleMode: true),
-                test: new TestTargetConfigurationArgs(runner: testRunner, filter: testFilter))
+                test: new TestTargetConfigurationArgs(testRunner ?? TestTargetConfigurationArgs.DefaultRunner, testFilter))
             : new TargetConfigurationArgs(
                 path: targetAssemblyPath,
                 redirectInputOutput: new RedirectInputOutputConfigurationArgs(singleConsoleMode: true));
 
+        var pluginConfiguration = BuildPluginConfiguration(isTest, instrumentSystemLibraries);
         var analysis = pluginNameOrTypeFullName.Contains('.')
-            ? new AnalysisPluginConfigurationArgs(pluginFullTypeName: pluginNameOrTypeFullName, renderReport: true)
-            : new AnalysisPluginConfigurationArgs(pluginName: pluginNameOrTypeFullName, renderReport: true);
+            ? new AnalysisPluginConfigurationArgs(
+                configuration: pluginConfiguration,
+                pluginFullTypeName: pluginNameOrTypeFullName,
+                renderReport: true)
+            : new AnalysisPluginConfigurationArgs(
+                configuration: pluginConfiguration,
+                pluginName: pluginNameOrTypeFullName,
+                renderReport: true);
 
         return new RunCommandArgs(Runtime: null, target, analysis);
+    }
+
+    private static object BuildPluginConfiguration(
+        bool isTest,
+        bool instrumentSystemLibraries)
+    {
+        var instrumentationSkipList = instrumentSystemLibraries
+            ? []
+            : isTest
+                ? WellKnownModules.SystemAndTestFrameworksModulePrefixes
+                : WellKnownModules.SystemModulePrefixes;
+
+        return new { SkipInstrumentationForAssemblies = instrumentationSkipList };
     }
 
     internal static string SerializeRunCommandArgs(RunCommandArgs args)

--- a/src/SharpDetect.Cli/Handlers/RunCommandHandler.cs
+++ b/src/SharpDetect.Cli/Handlers/RunCommandHandler.cs
@@ -29,23 +29,42 @@ internal sealed class RunCommandHandler : IDisposable
         {
             _rawConfigurationJson = LoadConfigurationJson(configurationFilePath);
             _arguments = CommandDeserializer.DeserializeCommandArguments<RunCommandArgs>(_rawConfigurationJson);
-            CommandArgumentsValidator.ValidateRunCommandArguments(_arguments);
-
-            var pluginType = LoadPluginInfo();
-            _serviceProvider = new AnalysisServiceProviderBuilder(_arguments)
-                .WithTimeProvider(TimeProvider.System)
-                .ConfigureLogging(logging =>
-                {
-                    logging.AddConsole();
-                    logging.SetMinimumLevel(_arguments.Analysis.LogLevel);
-                })
-                .WithPlugin(pluginType)
-                .Build();
+            _serviceProvider = Initialize(_arguments);
         }
         catch (Exception ex) when (ex is not CommandException)
         {
             throw new CommandException(ex.Message, (int)ExitCode.ConfigurationError, innerException: ex);
         }
+    }
+
+    public RunCommandHandler(RunCommandArgs arguments, string rawConfigurationJson)
+    {
+        try
+        {
+            _arguments = arguments;
+            _rawConfigurationJson = rawConfigurationJson;
+            _serviceProvider = Initialize(_arguments);
+        }
+        catch (Exception ex) when (ex is not CommandException)
+        {
+            throw new CommandException(ex.Message, (int)ExitCode.ConfigurationError, innerException: ex);
+        }
+    }
+
+    private IServiceProvider Initialize(RunCommandArgs arguments)
+    {
+        CommandArgumentsValidator.ValidateRunCommandArguments(arguments);
+        var pluginType = LoadPluginInfo();
+        var provider = new AnalysisServiceProviderBuilder(arguments)
+            .WithTimeProvider(TimeProvider.System)
+            .ConfigureLogging(logging =>
+            {
+                logging.AddConsole();
+                logging.SetMinimumLevel(arguments.Analysis.LogLevel);
+            })
+            .WithPlugin(pluginType)
+            .Build();
+        return provider;
     }
 
     public async ValueTask ExecuteAsync(IConsole console, CancellationToken cancellationToken)
@@ -66,7 +85,7 @@ internal sealed class RunCommandHandler : IDisposable
         }
 
         if (reportSummary.GetAllReports().Any())
-            throw new CommandException("Analysis detected issue(s)", (int)ExitCode.IssuesFound);
+            throw new CommandException("Analysis detected issue(s)");
     }
 
     private Task<string> RenderAndWriteReport(IPlugin plugin, Summary reportSummary, CancellationToken cancellationToken)

--- a/src/SharpDetect.Worker/Commands/CommandArgumentsValidator.cs
+++ b/src/SharpDetect.Worker/Commands/CommandArgumentsValidator.cs
@@ -25,6 +25,15 @@ public static class CommandArgumentsValidator
 
         if (!IsX64CompatibleAssembly(target))
             throw new ArgumentException("Unsupported target architecture. Only x64 and AnyCPU assemblies are supported.");
+
+        switch (configArgs.Kind)
+        {
+            case TargetKind.Executable:
+            case TargetKind.TestAssembly:
+                break;
+            default:
+                throw new ArgumentException($"Unsupported target kind: \"{configArgs.Kind}\".");
+        }
     }
 
     private static bool IsX64CompatibleAssembly(string assemblyPath)

--- a/src/SharpDetect.Worker/Commands/Run/TargetConfigurationArgs.cs
+++ b/src/SharpDetect.Worker/Commands/Run/TargetConfigurationArgs.cs
@@ -9,11 +9,16 @@ namespace SharpDetect.Worker.Commands.Run;
 
 public sealed class TargetConfigurationArgs
 {
+    public const TargetKind DefaultKind = TargetKind.Executable;
+
     public string Path { get; }
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    public TargetKind Kind { get; }
     public string? Args { get; }
     public string? WorkingDirectory { get; }
     public KeyValuePair<string, string>[]? AdditionalEnvironmentVariables { get; }
     public RedirectInputOutputConfigurationArgs? RedirectInputOutput { get; }
+    public TestTargetConfigurationArgs? Test { get; }
 
     [JsonConstructor]
     public TargetConfigurationArgs(
@@ -21,13 +26,17 @@ public sealed class TargetConfigurationArgs
         string? args = null,
         string? workingDirectory = null,
         KeyValuePair<string, string>[]? additionalEnvironmentVariables = null,
-        RedirectInputOutputConfigurationArgs? redirectInputOutput = null)
+        RedirectInputOutputConfigurationArgs? redirectInputOutput = null,
+        TargetKind kind = DefaultKind,
+        TestTargetConfigurationArgs? test = null)
     {
         Guard.IsNotNullOrWhiteSpace(path);
         Path = EnvironmentUtils.ExpandEnvironmentVariablesForPath(path);
+        Kind = kind;
         Args = args;
         WorkingDirectory = workingDirectory == null ? null : EnvironmentUtils.ExpandEnvironmentVariablesForPath(workingDirectory);
         AdditionalEnvironmentVariables = additionalEnvironmentVariables;
         RedirectInputOutput = redirectInputOutput;
+        Test = test;
     }
 }

--- a/src/SharpDetect.Worker/Commands/Run/TargetKind.cs
+++ b/src/SharpDetect.Worker/Commands/Run/TargetKind.cs
@@ -1,0 +1,10 @@
+// Copyright 2026 Andrej Čižmárik and Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+namespace SharpDetect.Worker.Commands.Run;
+
+public enum TargetKind
+{
+    Executable = 0,
+    TestAssembly = 1
+}

--- a/src/SharpDetect.Worker/Commands/Run/TestRunner.cs
+++ b/src/SharpDetect.Worker/Commands/Run/TestRunner.cs
@@ -1,0 +1,10 @@
+// Copyright 2026 Andrej Čižmárik and Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+namespace SharpDetect.Worker.Commands.Run;
+
+public enum TestRunner
+{
+    Mtp = 0,
+    VsTest = 1
+}

--- a/src/SharpDetect.Worker/Commands/Run/TestTargetConfigurationArgs.cs
+++ b/src/SharpDetect.Worker/Commands/Run/TestTargetConfigurationArgs.cs
@@ -1,0 +1,26 @@
+// Copyright 2026 Andrej Čižmárik and Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Text.Json.Serialization;
+
+namespace SharpDetect.Worker.Commands.Run;
+
+public sealed class TestTargetConfigurationArgs
+{
+    public const TestRunner DefaultRunner = TestRunner.Mtp;
+
+    public TestRunner Runner { get; }
+    public string? Filter { get; }
+    public string? AdditionalRunnerArgs { get; }
+
+    [JsonConstructor]
+    public TestTargetConfigurationArgs(
+        TestRunner runner = DefaultRunner,
+        string? filter = null,
+        string? additionalRunnerArgs = null)
+    {
+        Runner = runner;
+        Filter = filter;
+        AdditionalRunnerArgs = additionalRunnerArgs;
+    }
+}

--- a/src/SharpDetect.Worker/Services/AnalysisWorker.cs
+++ b/src/SharpDetect.Worker/Services/AnalysisWorker.cs
@@ -55,7 +55,10 @@ public sealed class AnalysisWorker : IAnalysisWorker
 
             var commandResult = await targetApplicationProcess;
             if (commandResult.ExitCode != 0)
-                _logger.LogWarning("Target process exited with non-zero exit code: {ExitCode}.", commandResult.ExitCode);
+            {
+                var level = _arguments.Target.Kind == TargetKind.TestAssembly ? LogLevel.Information : LogLevel.Warning;
+                _logger.Log(level, "Target process exited with non-zero exit code: {ExitCode}.", commandResult.ExitCode);
+            }
         }
         finally
         {
@@ -66,37 +69,22 @@ public sealed class AnalysisWorker : IAnalysisWorker
     private Command BuildTargetApplicationCommand()
     {
         var host = _arguments.Runtime.Host?.Path ?? "dotnet";
-        var argsBuilder = new List<string>(capacity: 3);
-        if (_arguments.Runtime.Host?.Args is { } hostArgs)
-            argsBuilder.Add(hostArgs);
-        argsBuilder.Add(_arguments.Target.Path);
-        if (_arguments.Target.Args is { } targetArgs)
-            argsBuilder.Add(targetArgs);
-
-        var profilerPath = GetProfilerPath();
-        var extension = Path.GetExtension(profilerPath);
-        var profilerDirectory = Path.GetDirectoryName(profilerPath)!;
-        var ipqPath = $"{Path.Combine(profilerDirectory, "SharpDetect.InterProcessQueue")}{extension}";
+        var environmentVariables = BuildTargetEnvironmentVariables();
+        var argsBuilder = TargetArgumentsBuilder.Build(_arguments, environmentVariables);
 
         var command = Cli.Wrap(host)
             .WithArguments(argsBuilder)
-            .WithEnvironmentVariables(builder =>
-            {
-                builder.Set("CORECLR_ENABLE_PROFILING", "1");
-                builder.Set("CORECLR_PROFILER", _arguments.Runtime.Profiler.Clsid.ToString());
-                builder.Set("CORECLR_PROFILER_PATH", profilerPath);
-                builder.Set("SharpDetect_IPQ_PATH", ipqPath);
-                builder.Set("SharpDetect_CONFIGURATION_PATH", GetFullConfigurationPath());
-                builder.Set("SharpDetect_LOG_LEVEL", ((int)_arguments.Runtime.Profiler.LogLevel).ToString());
-
-                foreach (var (key, value) in _arguments.Runtime.Host?.AdditionalEnvironmentVariables ?? Enumerable.Empty<KeyValuePair<string, string>>())
-                    builder.Set(key, value);
-                
-                foreach (var (key, value) in _arguments.Target.AdditionalEnvironmentVariables ?? Enumerable.Empty<KeyValuePair<string, string>>())
-                    builder.Set(key, value);
-            })
             .WithValidation(CommandResultValidation.None);
-        
+
+        if (!TargetArgumentsBuilder.RequiresEnvironmentInjection(_arguments))
+        {
+            command = command.WithEnvironmentVariables(builder =>
+            {
+                foreach (var (key, value) in environmentVariables)
+                    builder.Set(key, value);
+            });
+        }
+
         if (_arguments.Target.WorkingDirectory is { } workingDirectory)
             command = command.WithWorkingDirectory(workingDirectory);
 
@@ -122,7 +110,33 @@ public sealed class AnalysisWorker : IAnalysisWorker
 
         return command;
     }
-    
+
+    private Dictionary<string, string> BuildTargetEnvironmentVariables()
+    {
+        var profilerPath = GetProfilerPath();
+        var extension = Path.GetExtension(profilerPath);
+        var profilerDirectory = Path.GetDirectoryName(profilerPath)!;
+        var ipqPath = $"{Path.Combine(profilerDirectory, "SharpDetect.InterProcessQueue")}{extension}";
+
+        var envVars = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["CORECLR_ENABLE_PROFILING"] = "1",
+            ["CORECLR_PROFILER"] = _arguments.Runtime.Profiler.Clsid.ToString(),
+            ["CORECLR_PROFILER_PATH"] = profilerPath,
+            ["SharpDetect_IPQ_PATH"] = ipqPath,
+            ["SharpDetect_CONFIGURATION_PATH"] = GetFullConfigurationPath(),
+            ["SharpDetect_LOG_LEVEL"] = ((int)_arguments.Runtime.Profiler.LogLevel).ToString()
+        };
+
+        foreach (var (key, value) in _arguments.Runtime.Host?.AdditionalEnvironmentVariables ?? Enumerable.Empty<KeyValuePair<string, string>>())
+            envVars[key] = value;
+
+        foreach (var (key, value) in _arguments.Target.AdditionalEnvironmentVariables ?? Enumerable.Empty<KeyValuePair<string, string>>())
+            envVars[key] = value;
+
+        return envVars;
+    }
+
     private void ExecuteAnalysis(Task targetProcessTask, uint rootPid, CancellationToken cancellationToken)
     {
         try

--- a/src/SharpDetect.Worker/Services/TargetArgumentsBuilder.cs
+++ b/src/SharpDetect.Worker/Services/TargetArgumentsBuilder.cs
@@ -1,0 +1,99 @@
+// Copyright 2026 Andrej Čižmárik and Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+using SharpDetect.Worker.Commands.Run;
+
+namespace SharpDetect.Worker.Services;
+
+public static class TargetArgumentsBuilder
+{
+    public static List<string> Build(
+        RunCommandArgs arguments,
+        IReadOnlyDictionary<string, string>? environmentVariables = null) => arguments.Target.Kind switch
+    {
+        TargetKind.Executable => BuildExecutableArguments(arguments),
+        TargetKind.TestAssembly => arguments.Target.Test?.Runner switch
+        {
+            TestRunner.Mtp => BuildMtpTestArguments(arguments),
+            TestRunner.VsTest => BuildVsTestArguments(arguments, environmentVariables ?? EmptyEnv),
+            _ => throw new ArgumentException($"Target.Test must be specified when Target.Kind is \"{TargetKind.TestAssembly}\".")
+        },
+        _ => throw new ArgumentOutOfRangeException(nameof(arguments))
+    };
+
+    private static readonly IReadOnlyDictionary<string, string> EmptyEnv =
+        new Dictionary<string, string>(StringComparer.Ordinal);
+
+    public static bool RequiresEnvironmentInjection(RunCommandArgs arguments) =>
+        arguments.Target is { Kind: TargetKind.TestAssembly, Test.Runner: TestRunner.VsTest };
+
+    private static List<string> BuildExecutableArguments(RunCommandArgs arguments)
+    {
+        var argsBuilder = new List<string>(capacity: 3);
+        if (arguments.Runtime.Host?.Args is { } hostArgs)
+            argsBuilder.Add(hostArgs);
+        
+        argsBuilder.Add(arguments.Target.Path);
+        if (arguments.Target.Args is { } targetArgs)
+            argsBuilder.Add(targetArgs);
+        
+        return argsBuilder;
+    }
+
+    private static List<string> BuildMtpTestArguments(RunCommandArgs arguments)
+    {
+        var test = arguments.Target.Test!;
+        var argsBuilder = new List<string>(capacity: 5);
+        if (arguments.Runtime.Host?.Args is { } hostArgs)
+            argsBuilder.Add(hostArgs);
+        
+        argsBuilder.Add(arguments.Target.Path);
+        
+        if (test.Filter is { } filter)
+        {
+            argsBuilder.Add("--treenode-filter");
+            argsBuilder.Add(filter);
+        }
+        
+        if (test.AdditionalRunnerArgs is { } extra)
+            argsBuilder.Add(extra);
+        
+        if (arguments.Target.Args is { } targetArgs)
+            argsBuilder.Add(targetArgs);
+        
+        return argsBuilder;
+    }
+
+    private static List<string> BuildVsTestArguments(
+        RunCommandArgs arguments,
+        IReadOnlyDictionary<string, string> environmentVariables)
+    {
+        var test = arguments.Target.Test!;
+        var argsBuilder = new List<string>(capacity: 8 + environmentVariables.Count * 2);
+        if (arguments.Runtime.Host?.Args is { } hostArgs)
+            argsBuilder.Add(hostArgs);
+        
+        argsBuilder.Add("test");
+        argsBuilder.Add(arguments.Target.Path);
+        
+        foreach (var (key, value) in environmentVariables)
+        {
+            argsBuilder.Add("-e");
+            argsBuilder.Add($"{key}={value}");
+        }
+        
+        if (test.Filter is { } filter)
+        {
+            argsBuilder.Add("--filter");
+            argsBuilder.Add(filter);
+        }
+        
+        if (test.AdditionalRunnerArgs is { } extra)
+            argsBuilder.Add(extra);
+        
+        if (arguments.Target.Args is { } targetArgs)
+            argsBuilder.Add(targetArgs);
+        
+        return argsBuilder;
+    }
+}

--- a/src/Tests/SharpDetect.Cli.Tests/SharpDetectInitCommandHandlerTests.cs
+++ b/src/Tests/SharpDetect.Cli.Tests/SharpDetectInitCommandHandlerTests.cs
@@ -22,6 +22,12 @@ public class SharpDetectInitCommandHandlerTests
                 }
               },
               "Analysis": {
+                "Configuration": {
+                  "SkipInstrumentationForAssemblies": [
+                    "System.",
+                    "Microsoft."
+                  ]
+                },
                 "PluginName": "TestPlugin",
                 "RenderReport": true,
                 "LogLevel": "Warning"
@@ -39,7 +45,11 @@ public class SharpDetectInitCommandHandlerTests
             new InitCommandHandler(
                 outputFile: "TestConfig.json", 
                 pluginNameOrTypeFullName: "TestPlugin", 
-                targetAssemblyPath: "TestTarget.dll")
+                targetAssemblyPath: "TestTarget.dll",
+                instrumentSystemLibraries: false,
+                isTest: false,
+                testRunner: null,
+                testFilter: null)
             .CreateTemplateConfigurationJson()
             .ReplaceLineEndings();
         
@@ -55,15 +65,21 @@ public class SharpDetectInitCommandHandlerTests
               "Target": {
                 "Path": "TestTarget.dll",
                 "Kind": "TestAssembly",
-                "RedirectInputOutput": {
-                  "SingleConsoleMode": true
-                },
                 "Test": {
                   "Runner": "Mtp",
                   "Filter": "FullyQualifiedName~MyNamespace.RaceFact"
                 }
               },
               "Analysis": {
+                "Configuration": {
+                  "SkipInstrumentationForAssemblies": [
+                    "System.",
+                    "Microsoft.",
+                    "xunit.",
+                    "nunit.",
+                    "TUnit."
+                  ]
+                },
                 "PluginName": "TestPlugin",
                 "RenderReport": true,
                 "LogLevel": "Warning"
@@ -82,6 +98,7 @@ public class SharpDetectInitCommandHandlerTests
                 outputFile: "TestConfig.json",
                 pluginNameOrTypeFullName: "TestPlugin",
                 targetAssemblyPath: "TestTarget.dll",
+                instrumentSystemLibraries: false,
                 isTest: true,
                 testRunner: TestRunner.Mtp,
                 testFilter: "FullyQualifiedName~MyNamespace.RaceFact")
@@ -89,5 +106,85 @@ public class SharpDetectInitCommandHandlerTests
             .ReplaceLineEndings();
 
         Assert.Equal(expectedTemplate, actualTemplate);
+    }
+
+    [Fact]
+    public void Init_FastTrackPlugin_EmitsBaseSkipList()
+    {
+        var actualTemplate =
+            new InitCommandHandler(
+                outputFile: "TestConfig.json",
+                pluginNameOrTypeFullName: "FastTrack",
+                targetAssemblyPath: "TestTarget.dll",
+                instrumentSystemLibraries: false,
+                isTest: false,
+                testRunner: null,
+                testFilter: null)
+            .CreateTemplateConfigurationJson();
+
+        Assert.Contains("\"System.\"", actualTemplate);
+        Assert.Contains("\"Microsoft.\"", actualTemplate);
+        Assert.DoesNotContain("xunit.", actualTemplate);
+        Assert.DoesNotContain("nunit.", actualTemplate);
+        Assert.DoesNotContain("TUnit.", actualTemplate);
+    }
+
+    [Fact]
+    public void Init_FastTrackPlugin_TestMode_EmitsExtendedSkipList()
+    {
+        var actualTemplate =
+            new InitCommandHandler(
+                outputFile: "TestConfig.json",
+                pluginNameOrTypeFullName: "FastTrack",
+                targetAssemblyPath: "TestTarget.dll",
+                instrumentSystemLibraries: false,
+                isTest: true,
+                testRunner: TestRunner.Mtp,
+                testFilter: "FullyQualifiedName~MyNamespace.RaceFact")
+            .CreateTemplateConfigurationJson();
+
+        Assert.Contains("\"System.\"", actualTemplate);
+        Assert.Contains("\"Microsoft.\"", actualTemplate);
+        Assert.Contains("\"xunit.\"", actualTemplate);
+        Assert.Contains("\"nunit.\"", actualTemplate);
+        Assert.Contains("\"TUnit.\"", actualTemplate);
+    }
+
+    [Fact]
+    public void Init_FastTrackPlugin_InstrumentSystemLibraries_EmitsEmptyList()
+    {
+        var actualTemplate =
+            new InitCommandHandler(
+                outputFile: "TestConfig.json",
+                pluginNameOrTypeFullName: "FastTrack",
+                targetAssemblyPath: "TestTarget.dll",
+                instrumentSystemLibraries: true,
+                isTest: false,
+                testRunner: null,
+                testFilter: null)
+            .CreateTemplateConfigurationJson();
+
+        Assert.Contains("\"SkipInstrumentationForAssemblies\": []", actualTemplate);
+        Assert.DoesNotContain("\"System.\"", actualTemplate);
+        Assert.DoesNotContain("\"Microsoft.\"", actualTemplate);
+    }
+
+    [Fact]
+    public void Init_EraserPlugin_EmitsBaseSkipList()
+    {
+        var actualTemplate =
+            new InitCommandHandler(
+                outputFile: "TestConfig.json",
+                pluginNameOrTypeFullName: "Eraser",
+                targetAssemblyPath: "TestTarget.dll",
+                instrumentSystemLibraries: false,
+                isTest: false,
+                testRunner: null,
+                testFilter: null)
+            .CreateTemplateConfigurationJson();
+
+        Assert.Contains("\"Configuration\": {", actualTemplate);
+        Assert.Contains("\"System.\"", actualTemplate);
+        Assert.Contains("\"Microsoft.\"", actualTemplate);
     }
 }

--- a/src/Tests/SharpDetect.Cli.Tests/SharpDetectInitCommandHandlerTests.cs
+++ b/src/Tests/SharpDetect.Cli.Tests/SharpDetectInitCommandHandlerTests.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using SharpDetect.Cli.Handlers;
+using SharpDetect.Worker.Commands.Run;
 using Xunit;
 
 namespace SharpDetect.Cli.Tests;
@@ -42,6 +43,51 @@ public class SharpDetectInitCommandHandlerTests
             .CreateTemplateConfigurationJson()
             .ReplaceLineEndings();
         
+        Assert.Equal(expectedTemplate, actualTemplate);
+    }
+
+    [Fact]
+    public void Init_WithTestFlag_Should_Create_TestTemplate()
+    {
+        var expectedTemplate =
+            """
+            {
+              "Target": {
+                "Path": "TestTarget.dll",
+                "Kind": "TestAssembly",
+                "RedirectInputOutput": {
+                  "SingleConsoleMode": true
+                },
+                "Test": {
+                  "Runner": "Mtp",
+                  "Filter": "FullyQualifiedName~MyNamespace.RaceFact"
+                }
+              },
+              "Analysis": {
+                "PluginName": "TestPlugin",
+                "RenderReport": true,
+                "LogLevel": "Warning"
+              },
+              "Runtime": {
+                "Profiler": {
+                  "LogLevel": "Warning"
+                }
+              }
+            }
+            """
+            .ReplaceLineEndings();
+
+        var actualTemplate =
+            new InitCommandHandler(
+                outputFile: "TestConfig.json",
+                pluginNameOrTypeFullName: "TestPlugin",
+                targetAssemblyPath: "TestTarget.dll",
+                isTest: true,
+                testRunner: TestRunner.Mtp,
+                testFilter: "FullyQualifiedName~MyNamespace.RaceFact")
+            .CreateTemplateConfigurationJson()
+            .ReplaceLineEndings();
+
         Assert.Equal(expectedTemplate, actualTemplate);
     }
 }

--- a/src/Tests/SharpDetect.Cli.Tests/SharpDetectRunCommandTests.cs
+++ b/src/Tests/SharpDetect.Cli.Tests/SharpDetectRunCommandTests.cs
@@ -1,0 +1,132 @@
+// Copyright 2026 Andrej Čižmárik and Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+using CliFx.Exceptions;
+using SharpDetect.Cli.Commands;
+using SharpDetect.Worker.Commands.Run;
+using Xunit;
+
+namespace SharpDetect.Cli.Tests;
+
+public class SharpDetectRunCommandTests
+{
+    [Fact]
+    public void Validate_ConfigFileOnly_DoesNotThrow()
+    {
+        var exception = Record.Exception(() =>
+            RunCommand.ValidateOptions(
+                argumentsFile: "config.json",
+                pluginType: null,
+                targetPath: null,
+                isTest: false,
+                testFilter: null,
+                testRunner: TestTargetConfigurationArgs.DefaultRunner));
+
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public void Validate_InlineForm_DoesNotThrow()
+    {
+        var exception = Record.Exception(() =>
+            RunCommand.ValidateOptions(
+                argumentsFile: null,
+                pluginType: "FastTrack",
+                targetPath: "app.dll",
+                isTest: false,
+                testFilter: null,
+                testRunner: TestTargetConfigurationArgs.DefaultRunner));
+
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public void Validate_InlineFormWithTest_DoesNotThrow()
+    {
+        var exception = Record.Exception(() =>
+            RunCommand.ValidateOptions(
+                argumentsFile: null,
+                pluginType: "FastTrack",
+                targetPath: "tests.dll",
+                isTest: true,
+                testFilter: "FullyQualifiedName~MyNamespace.RaceFact",
+                testRunner: TestRunner.Mtp));
+
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public void Validate_BothConfigFileAndInlineOptions_ThrowsConfigurationError()
+    {
+        var exception = Assert.Throws<CommandException>(() =>
+            RunCommand.ValidateOptions(
+                argumentsFile: "config.json",
+                pluginType: "FastTrack",
+                targetPath: "app.dll",
+                isTest: false,
+                testFilter: null,
+                testRunner: TestTargetConfigurationArgs.DefaultRunner));
+
+        Assert.Equal((int)ExitCode.ConfigurationError, exception.ExitCode);
+    }
+
+    [Fact]
+    public void Validate_NeitherConfigFileNorInlineOptions_ThrowsConfigurationError()
+    {
+        var exception = Assert.Throws<CommandException>(() =>
+            RunCommand.ValidateOptions(
+                argumentsFile: null,
+                pluginType: null,
+                targetPath: null,
+                isTest: false,
+                testFilter: null,
+                testRunner: TestTargetConfigurationArgs.DefaultRunner));
+
+        Assert.Equal((int)ExitCode.ConfigurationError, exception.ExitCode);
+    }
+
+    [Fact]
+    public void Validate_InlineFormMissingTarget_ThrowsConfigurationError()
+    {
+        var exception = Assert.Throws<CommandException>(() =>
+            RunCommand.ValidateOptions(
+                argumentsFile: null,
+                pluginType: "FastTrack",
+                targetPath: null,
+                isTest: false,
+                testFilter: null,
+                testRunner: TestTargetConfigurationArgs.DefaultRunner));
+
+        Assert.Equal((int)ExitCode.ConfigurationError, exception.ExitCode);
+    }
+
+    [Fact]
+    public void Validate_InlineFormMissingPlugin_ThrowsConfigurationError()
+    {
+        var exception = Assert.Throws<CommandException>(() =>
+            RunCommand.ValidateOptions(
+                argumentsFile: null,
+                pluginType: null,
+                targetPath: "app.dll",
+                isTest: false,
+                testFilter: null,
+                testRunner: TestTargetConfigurationArgs.DefaultRunner));
+
+        Assert.Equal((int)ExitCode.ConfigurationError, exception.ExitCode);
+    }
+
+    [Fact]
+    public void Validate_FilterWithoutTest_ThrowsConfigurationError()
+    {
+        var exception = Assert.Throws<CommandException>(() =>
+            RunCommand.ValidateOptions(
+                argumentsFile: null,
+                pluginType: "FastTrack",
+                targetPath: "app.dll",
+                isTest: false,
+                testFilter: "FullyQualifiedName~Something",
+                testRunner: TestTargetConfigurationArgs.DefaultRunner));
+
+        Assert.Equal((int)ExitCode.ConfigurationError, exception.ExitCode);
+    }
+}

--- a/src/Tests/SharpDetect.Cli.Tests/TargetArgumentsBuilderTests.cs
+++ b/src/Tests/SharpDetect.Cli.Tests/TargetArgumentsBuilderTests.cs
@@ -1,0 +1,151 @@
+// Copyright 2026 Andrej Čižmárik and Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+using SharpDetect.Worker.Commands.Run;
+using SharpDetect.Worker.Services;
+using Xunit;
+
+namespace SharpDetect.Cli.Tests;
+
+public class TargetArgumentsBuilderTests
+{
+    private static RunCommandArgs CreateArgs(TargetConfigurationArgs target)
+        => new(
+            Runtime: null,
+            Target: target,
+            Analysis: new AnalysisPluginConfigurationArgs(pluginName: "TestPlugin"));
+
+    [Fact]
+    public void Executable_Produces_Path_Only()
+    {
+        var args = CreateArgs(new TargetConfigurationArgs(path: "MyApp.dll"));
+
+        var result = TargetArgumentsBuilder.Build(args);
+
+        Assert.Equal(new[] { "MyApp.dll" }, result);
+    }
+
+    [Fact]
+    public void Executable_Includes_Args_When_Provided()
+    {
+        var args = CreateArgs(new TargetConfigurationArgs(path: "MyApp.dll", args: "--foo"));
+
+        var result = TargetArgumentsBuilder.Build(args);
+
+        Assert.Equal(new[] { "MyApp.dll", "--foo" }, result);
+    }
+
+    [Fact]
+    public void Mtp_TestAssembly_Without_Filter_Produces_Path_Only()
+    {
+        var args = CreateArgs(new TargetConfigurationArgs(
+            path: "MyTests.dll",
+            kind: TargetKind.TestAssembly,
+            test: new TestTargetConfigurationArgs(runner: TestRunner.Mtp)));
+
+        var result = TargetArgumentsBuilder.Build(args);
+
+        Assert.Equal(new[] { "MyTests.dll" }, result);
+    }
+
+    [Fact]
+    public void Mtp_TestAssembly_With_Filter_Emits_TreeNodeFilter()
+    {
+        var args = CreateArgs(new TargetConfigurationArgs(
+            path: "MyTests.dll",
+            kind: TargetKind.TestAssembly,
+            test: new TestTargetConfigurationArgs(runner: TestRunner.Mtp, filter: "/*/*/*/RaceFact")));
+
+        var result = TargetArgumentsBuilder.Build(args);
+
+        Assert.Equal(
+            new[] { "MyTests.dll", "--treenode-filter", "/*/*/*/RaceFact" },
+            result);
+    }
+
+    [Fact]
+    public void Mtp_TestAssembly_Appends_AdditionalRunnerArgs()
+    {
+        var args = CreateArgs(new TargetConfigurationArgs(
+            path: "MyTests.dll",
+            kind: TargetKind.TestAssembly,
+            test: new TestTargetConfigurationArgs(
+                runner: TestRunner.Mtp,
+                filter: "/*/*/*/RaceFact",
+                additionalRunnerArgs: "--report-trx")));
+
+        var result = TargetArgumentsBuilder.Build(args);
+
+        Assert.Equal(
+            new[] { "MyTests.dll", "--treenode-filter", "/*/*/*/RaceFact", "--report-trx" },
+            result);
+    }
+
+    [Fact]
+    public void VsTest_TestAssembly_Emits_DotnetTest_Invocation_With_EnvFlags()
+    {
+        var args = CreateArgs(new TargetConfigurationArgs(
+            path: "MyTests.dll",
+            kind: TargetKind.TestAssembly,
+            test: new TestTargetConfigurationArgs(runner: TestRunner.VsTest)));
+        var env = new Dictionary<string, string>
+        {
+            ["CORECLR_ENABLE_PROFILING"] = "1",
+            ["CORECLR_PROFILER"] = "{abc}"
+        };
+
+        var result = TargetArgumentsBuilder.Build(args, env);
+
+        Assert.Equal(
+            new[]
+            {
+                "test", "MyTests.dll",
+                "-e", "CORECLR_ENABLE_PROFILING=1",
+                "-e", "CORECLR_PROFILER={abc}"
+            },
+            result);
+    }
+
+    [Fact]
+    public void VsTest_TestAssembly_With_Filter_Emits_FilterFlag()
+    {
+        var args = CreateArgs(new TargetConfigurationArgs(
+            path: "MyTests.dll",
+            kind: TargetKind.TestAssembly,
+            test: new TestTargetConfigurationArgs(runner: TestRunner.VsTest, filter: "FullyQualifiedName~Foo")));
+
+        var result = TargetArgumentsBuilder.Build(args);
+
+        Assert.Equal(
+            new[] { "test", "MyTests.dll", "--filter", "FullyQualifiedName~Foo" },
+            result);
+    }
+
+    [Fact]
+    public void RequiresEnvironmentInjection_Is_True_Only_For_VSTest()
+    {
+        var executable = CreateArgs(new TargetConfigurationArgs(path: "MyApp.dll"));
+        var mtp = CreateArgs(new TargetConfigurationArgs(
+            path: "MyTests.dll",
+            kind: TargetKind.TestAssembly,
+            test: new TestTargetConfigurationArgs(runner: TestRunner.Mtp)));
+        var vstest = CreateArgs(new TargetConfigurationArgs(
+            path: "MyTests.dll",
+            kind: TargetKind.TestAssembly,
+            test: new TestTargetConfigurationArgs(runner: TestRunner.VsTest)));
+
+        Assert.False(TargetArgumentsBuilder.RequiresEnvironmentInjection(executable));
+        Assert.False(TargetArgumentsBuilder.RequiresEnvironmentInjection(mtp));
+        Assert.True(TargetArgumentsBuilder.RequiresEnvironmentInjection(vstest));
+    }
+
+    [Fact]
+    public void TestAssembly_Without_TestConfig_Throws()
+    {
+        var args = CreateArgs(new TargetConfigurationArgs(
+            path: "MyTests.dll",
+            kind: TargetKind.TestAssembly));
+
+        Assert.Throws<ArgumentException>(() => TargetArgumentsBuilder.Build(args));
+    }
+}

--- a/src/Tests/SharpDetect.E2ETests/EndToEndTestCollection.cs
+++ b/src/Tests/SharpDetect.E2ETests/EndToEndTestCollection.cs
@@ -24,6 +24,9 @@ public sealed class MultiProcessTestsCollection : ICollectionFixture<EndToEndCol
 [CollectionDefinition(ObjectTrackingTests.CollectionName)]
 public sealed class ObjectTrackingTestsCollection : ICollectionFixture<EndToEndCollectionFixture> { }
 
+[CollectionDefinition(TestProjectIntegrationTests.CollectionName)]
+public sealed class TestProjectIntegrationTestsCollection : ICollectionFixture<EndToEndCollectionFixture> { }
+
 public sealed class EndToEndCollectionFixture
 {
     public EndToEndCollectionFixture()

--- a/src/Tests/SharpDetect.E2ETests/TestContextFactory.cs
+++ b/src/Tests/SharpDetect.E2ETests/TestContextFactory.cs
@@ -79,13 +79,15 @@ internal static class TestContextFactory
         args = args with
         {
             Target = new TargetConfigurationArgs(
-                args.Target.Path
+                path: args.Target.Path
                     .Replace("%SDK%", sdk)
                     .Replace("%BUILD_CONFIGURATION%", buildConfiguration),
-                args.Target.Args,
-                args.Target.WorkingDirectory,
-                args.Target.AdditionalEnvironmentVariables,
-                args.Target.RedirectInputOutput),
+                args: args.Target.Args,
+                workingDirectory: args.Target.WorkingDirectory,
+                additionalEnvironmentVariables: args.Target.AdditionalEnvironmentVariables,
+                redirectInputOutput: args.Target.RedirectInputOutput,
+                kind: args.Target.Kind,
+                test: args.Target.Test),
             Analysis = new AnalysisPluginConfigurationArgs(
                 args.Analysis.Configuration,
                 overridePluginTypeFullName ?? args.Analysis.PluginFullTypeName,

--- a/src/Tests/SharpDetect.E2ETests/TestProjectIntegrationTests.cs
+++ b/src/Tests/SharpDetect.E2ETests/TestProjectIntegrationTests.cs
@@ -1,0 +1,76 @@
+// Copyright 2026 Andrej Čižmárik and Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+using Microsoft.Extensions.DependencyInjection;
+using SharpDetect.E2ETests.Utils;
+using SharpDetect.Worker;
+using SharpDetect.Worker.Commands.Run;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SharpDetect.E2ETests;
+
+[Collection(CollectionName)]
+public class TestProjectIntegrationTests(ITestOutputHelper testOutput)
+{
+    public const string CollectionName = "E2E_TestProjectIntegrationTests";
+
+    private const string MtpRelativePath =
+        "../../../../../Samples/SimpleDataRaceTestsMtp/bin/%BUILD_CONFIGURATION%/%SDK%/SimpleDataRaceTestsMtp.dll";
+
+    private const string VsTestRelativePath =
+        "../../../../../Samples/SimpleDataRaceTestsVSTest/bin/%BUILD_CONFIGURATION%/%SDK%/SimpleDataRaceTestsVSTest.dll";
+
+    private static readonly string[] SkipSystemAssemblies = [ "System.", "Microsoft.", "TUnit.", "xunit." ];
+
+    [Fact]
+    public Task Mtp_RaceFact_Detects_Race()
+        => AssertDetectsRace(MtpRelativePath, TestRunner.Mtp, "/*/*/*/RaceFact");
+
+    [Fact]
+    public Task Mtp_CleanFact_Detects_No_Race()
+        => AssertDoesNotDetectRace(MtpRelativePath, TestRunner.Mtp, "/*/*/*/CleanFact");
+
+    [Fact]
+    public Task VSTest_RaceFact_Detects_Race()
+        => AssertDetectsRace(VsTestRelativePath, TestRunner.VsTest, "FullyQualifiedName~RaceFact");
+
+    [Fact]
+    public Task VSTest_CleanFact_Detects_No_Race()
+        => AssertDoesNotDetectRace(VsTestRelativePath, TestRunner.VsTest, "FullyQualifiedName~CleanFact");
+
+    private Task AssertDetectsRace(string relativePath, TestRunner runner, string filter)
+        => RunAndAssert(relativePath, runner, filter, expectRace: true);
+
+    private Task AssertDoesNotDetectRace(string relativePath, TestRunner runner, string filter)
+        => RunAndAssert(relativePath, runner, filter, expectRace: false);
+
+    private async Task RunAndAssert(string relativePath, TestRunner runner, string filter, bool expectRace)
+    {
+        var additionalData = TestPluginAdditionalData.CreateWithFieldsAccessInstrumentationEnabled();
+        using var services = E2ETestBuilder
+            .ForSubject(subjectArgs: string.Empty)
+            .WithCustomTarget(
+                relativeAssemblyPath: relativePath,
+                kind: TargetKind.TestAssembly,
+                test: new TestTargetConfigurationArgs(runner: runner, filter: filter))
+            .WithTestPlugin(typeof(TestFastTrackPlugin).FullName!)
+            .WithPluginConfiguration(new { SkipInstrumentationForAssemblies = SkipSystemAssemblies })
+            .Build("net10.0", testOutput, additionalData);
+        var plugin = services.GetRequiredService<TestFastTrackPlugin>();
+        var analysisWorker = services.GetRequiredService<IAnalysisWorker>();
+
+        await analysisWorker.ExecuteAsync(CancellationToken.None);
+
+        var subjectReports = plugin.GetSubjectReports().ToList();
+        if (expectRace)
+        {
+            Assert.NotEmpty(subjectReports);
+            Assert.Equal(plugin.ReportCategory, subjectReports[0].Category);
+        }
+        else
+        {
+            Assert.Empty(subjectReports);
+        }
+    }
+}

--- a/src/Tests/SharpDetect.E2ETests/Utils/E2ETestBuilder.cs
+++ b/src/Tests/SharpDetect.E2ETests/Utils/E2ETestBuilder.cs
@@ -28,6 +28,9 @@ internal sealed class E2ETestBuilder
     private object? _pluginConfiguration;
     private bool _renderReport;
     private KeyValuePair<string, string>[]? _additionalTargetEnvironmentVariables;
+    private string? _customTargetRelativePath;
+    private TargetKind _targetKind = TargetKind.Executable;
+    private TestTargetConfigurationArgs? _testTargetConfiguration;
     private const ProfilerLogLevel ProfilerLogLevel = Worker.Commands.Run.ProfilerLogLevel.Information;
     private const LogLevel AnalysisLogLevel = LogLevel.Information;
 
@@ -39,6 +42,14 @@ internal sealed class E2ETestBuilder
     public static E2ETestBuilder ForSubject(string subjectArgs)
     {
         return new E2ETestBuilder(subjectArgs);
+    }
+
+    public E2ETestBuilder WithCustomTarget(string relativeAssemblyPath, TargetKind kind, TestTargetConfigurationArgs? test = null)
+    {
+        _customTargetRelativePath = relativeAssemblyPath;
+        _targetKind = kind;
+        _testTargetConfiguration = test;
+        return this;
     }
 
     public E2ETestBuilder WithPlugin<TPlugin>() where TPlugin : class
@@ -94,7 +105,7 @@ internal sealed class E2ETestBuilder
         var temporaryFilesFolder = Path.Combine(Path.GetTempPath(), sessionId);
         Directory.CreateDirectory(temporaryFilesFolder);
 
-        var resolvedSubjectPath = SubjectRelativePath
+        var resolvedSubjectPath = (_customTargetRelativePath ?? SubjectRelativePath)
             .Replace("%SDK%", sdk)
             .Replace("%BUILD_CONFIGURATION%", BuildConfiguration);
 
@@ -109,9 +120,11 @@ internal sealed class E2ETestBuilder
                     logLevel: ProfilerLogLevel)),
             Target: new TargetConfigurationArgs(
                 path: resolvedSubjectPath,
-                args: _subjectArgs,
+                args: _customTargetRelativePath is null ? _subjectArgs : null,
                 additionalEnvironmentVariables: _additionalTargetEnvironmentVariables,
-                redirectInputOutput: new RedirectInputOutputConfigurationArgs(singleConsoleMode: true)),
+                redirectInputOutput: new RedirectInputOutputConfigurationArgs(singleConsoleMode: true),
+                kind: _targetKind,
+                test: _testTargetConfiguration),
             Analysis: new AnalysisPluginConfigurationArgs(
                 configuration: _pluginConfiguration,
                 pluginFullTypeName: _pluginTypeName,

--- a/src/build.cake
+++ b/src/build.cake
@@ -73,6 +73,16 @@ Task("Build-Managed")
     {
         Configuration = configuration
     });
+
+    // Some samples are intentionally left out of solution (cannot mix VSTest and MTP projects in a single solution)
+    DotNetBuild("./Samples/SimpleDataRaceTestsMtp/SimpleDataRaceTestsMtp.csproj", new DotNetBuildSettings
+    {
+        Configuration = configuration
+    });
+    DotNetBuild("./Samples/SimpleDataRaceTestsVSTest/SimpleDataRaceTestsVSTest.csproj", new DotNetBuildSettings
+    {
+        Configuration = configuration
+    });
 });
 
 Task("Build-IPQ")


### PR DESCRIPTION
This PR adds the following features:

- Analysis target can be a unit test (MTP and VSTest protocol support)
- Analysis can be started without JSON configuration (all necessary arguments can be passed directly to `run` command)
- Instrumentation of system libraries is suppressed by default
   - Users can use `-instrument-system-libraries` option to change this behavior (or directly change the JSON)
   - Regular executables suppress `System.` and `Microsoft.` libraries by default
   - Tests suppress additionally `xunit`, `nunit` and `TUnit` by default