### PR TITLE
Fix issue with unbounded event queue memory growth when consumer is slow

### DIFF
--- a/src/SharpDetect.Profiler/LibIPC/Client.cpp
+++ b/src/SharpDetect.Profiler/LibIPC/Client.cpp
@@ -35,6 +35,8 @@ LibIPC::Client::Client(std::string commandQueueName, std::string commandQueueFil
 	_eventQueueSize(eventQueueSize),
 	_commandQueueSize(commandQueueSize),
 	_terminating(false),
+	_eventQueueBytes(0),
+	_eventQueueMaxBytes(64 * 1024 * 1024),
 	_commandReceivingEnabled(true),
 	_commandHandler(nullptr),
 	_ipqProducerCreateSymbolAddress(nullptr),
@@ -53,6 +55,21 @@ LibIPC::Client::Client(std::string commandQueueName, std::string commandQueueFil
 		throw std::runtime_error("Error while configuring memory mapped file.");
 	}
 	auto const ipqPath = std::string(ipqPathStringPointer);
+
+	if (auto const eventBufferMaxStringPointer = std::getenv("SharpDetect_EVENT_BUFFER_MAX_BYTES"))
+	{
+		try
+		{
+			auto const parsed = std::stoull(eventBufferMaxStringPointer);
+			if (parsed > 0)
+				_eventQueueMaxBytes = static_cast<std::size_t>(parsed);
+		}
+		catch (const std::exception&)
+		{
+			LOG_F(WARNING, "Could not parse SharpDetect_EVENT_BUFFER_MAX_BYTES=%s; using default.", eventBufferMaxStringPointer);
+		}
+	}
+	LOG_F(INFO, "Event buffer cap: %zu bytes.", _eventQueueMaxBytes);
 
 	_ipqModuleHandle = LibProfiler::PAL_LoadLibrary(ipqPath);
 	if (_ipqModuleHandle == nullptr)
@@ -107,7 +124,7 @@ LibIPC::Client::Client(std::string commandQueueName, std::string commandQueueFil
 	_commandThread = std::thread(&LibIPC::Client::CommandThreadLoop, this);
 }
 
-void LibIPC::Client::SendDirect(const ipq_producer_enqueue enqueueFn, msgpack::sbuffer& buffer)
+void LibIPC::Client::SendDirect(const ipq_producer_enqueue enqueueFn, std::vector<char>& buffer)
 {
 	const auto byteStream = reinterpret_cast<BYTE*>(buffer.data());
 	INT result = 0;
@@ -116,18 +133,20 @@ void LibIPC::Client::SendDirect(const ipq_producer_enqueue enqueueFn, msgpack::s
 		if (result != 0)
 			std::this_thread::yield();
 
-		result = enqueueFn(_ffiProducer, byteStream, buffer.size());
+		result = enqueueFn(_ffiProducer, byteStream, static_cast<INT>(buffer.size()));
 	}
 	while (result != 0);
 }
 
-void LibIPC::Client::DrainEventQueue(const ipq_producer_enqueue enqueueFn)
+void LibIPC::Client::DrainQueues(const ipq_producer_enqueue enqueueFn)
 {
-	std::queue<msgpack::sbuffer> pending;
+	std::queue<std::vector<char>> pending;
 	{
 		auto lock = std::unique_lock(_eventMutex);
 		std::swap(pending, _eventQueue);
+		_eventQueueBytes = 0;
 	}
+	_eventQueueDrainedSignal.notify_all();
 
 	while (!pending.empty())
 	{
@@ -149,7 +168,7 @@ void LibIPC::Client::EventThreadLoop()
 				continue;
 		}
 
-		DrainEventQueue(enqueueFn);
+		DrainQueues(enqueueFn);
 
 		if (_terminating)
 			break;
@@ -275,9 +294,10 @@ LibIPC::Client::~Client()
 	// Terminate event worker and ensure internal queue is sent
 	const auto enqueueFn = reinterpret_cast<ipq_producer_enqueue>(_ipqProducerEnqueueSymbolAddress);
 	_eventQueueNonEmptySignal.notify_all();
+	_eventQueueDrainedSignal.notify_all();
 	if (_eventThread.joinable())
 		_eventThread.join();
-	DrainEventQueue(enqueueFn);
+	DrainQueues(enqueueFn);
 
 	// Terminate command worker
 	if (_commandReceivingEnabled && _commandThread.joinable())
@@ -286,8 +306,9 @@ LibIPC::Client::~Client()
 	// Notify managed that we are gracefully terminating
 	const auto destroyMsg = Helpers::CreateProfilerDestroyMsg(
 		Helpers::CreateMetadataMsg(LibProfiler::PAL_GetCurrentPid(), 0));
-	msgpack::sbuffer buffer;
-	msgpack::pack(buffer, destroyMsg);
+	msgpack::sbuffer sbuf;
+	msgpack::pack(sbuf, destroyMsg);
+	std::vector<char> buffer(sbuf.data(), sbuf.data() + sbuf.size());
 	SendDirect(enqueueFn, buffer);
 
 	reinterpret_cast<ipq_producer_destroy>(_ipqProducerDestroySymbolAddress)(_ffiProducer);

--- a/src/SharpDetect.Profiler/LibIPC/Client.h
+++ b/src/SharpDetect.Profiler/LibIPC/Client.h
@@ -9,6 +9,7 @@
 #include <string>
 #include <thread>
 #include <queue>
+#include <vector>
 
 #include "../lib/msgpack-c/include/msgpack.hpp"
 #include "cor.h"
@@ -44,9 +45,32 @@ namespace LibIPC
 		{
 			msgpack::sbuffer buffer;
 			msgpack::pack(buffer, data);
+			const auto bufferSize = buffer.size();
+			std::vector<char> compact(buffer.data(), buffer.data() + bufferSize);
+			{
+				std::unique_lock<std::mutex> lock(_eventMutex);
+				_eventQueueDrainedSignal.wait(lock, [this, bufferSize] {
+					return _terminating
+						|| _eventQueueBytes + bufferSize <= _eventQueueMaxBytes
+						|| _eventQueue.empty();
+				});
+				_eventQueueBytes += bufferSize;
+				_eventQueue.emplace(std::move(compact));
+			}
+
+			_eventQueueNonEmptySignal.notify_one();
+		}
+
+		template<class... Types>
+		void SendPriority(msgpack::type::tuple<Types...>&& data)
+		{
+			msgpack::sbuffer buffer;
+			msgpack::pack(buffer, data);
+			std::vector<char> compact(buffer.data(), buffer.data() + buffer.size());
 			{
 				std::lock_guard<std::mutex> guard(_eventMutex);
-				_eventQueue.emplace(std::move(buffer));
+				_eventQueueBytes += compact.size();
+				_eventQueue.emplace(std::move(compact));
 			}
 
 			_eventQueueNonEmptySignal.notify_one();
@@ -67,8 +91,8 @@ namespace LibIPC
 
 		void EventThreadLoop();
 		void CommandThreadLoop();
-		void SendDirect(ipq_producer_enqueue enqueueFn, msgpack::sbuffer& buffer);
-		void DrainEventQueue(ipq_producer_enqueue enqueueFn);
+		void SendDirect(ipq_producer_enqueue enqueueFn, std::vector<char>& buffer);
+		void DrainQueues(ipq_producer_enqueue enqueueFn);
 
 		static const std::string _ipqProducerCreateSymbolName;
 		static const std::string _ipqProducerDestroySymbolName;
@@ -95,7 +119,10 @@ namespace LibIPC
 		std::mutex _eventMutex;
 		std::atomic_bool _terminating;
 		std::condition_variable _eventQueueNonEmptySignal;
-		std::queue<msgpack::sbuffer> _eventQueue;
+		std::condition_variable _eventQueueDrainedSignal;
+		std::queue<std::vector<char>> _eventQueue;
+		std::size_t _eventQueueBytes;
+		std::size_t _eventQueueMaxBytes;
 		bool _commandReceivingEnabled;
 		ICommandHandler* _commandHandler;
 

--- a/src/SharpDetect.Profiler/SharpDetect.Concurrency.Profiler/CorProfiler.cpp
+++ b/src/SharpDetect.Profiler/SharpDetect.Concurrency.Profiler/CorProfiler.cpp
@@ -262,7 +262,7 @@ HRESULT STDMETHODCALLTYPE Profiler::CorProfiler::GarbageCollectionStarted(
 
     auto collectedGenerations = std::vector<BOOL>(generationCollected, generationCollected + cGenerations);
     _objectsTracker.ProcessGarbageCollectionStarted(std::move(collectedGenerations), std::move(ranges));
-    _client.Send(LibIPC::Helpers::CreateGarbageCollectionStartMsg(CreateMetadataMsg()));
+    _client.SendPriority(LibIPC::Helpers::CreateGarbageCollectionStartMsg(CreateMetadataMsg()));
     return S_OK;
 }
 
@@ -280,13 +280,13 @@ HRESULT STDMETHODCALLTYPE Profiler::CorProfiler::GarbageCollectionFinished()
     }
     if (!removedTrackedObjectIds.empty())
     {
-        _client.Send(LibIPC::Helpers::CreateGarbageCollectedTrackedObjectsMsg(
-            CreateMetadataMsg(), 
+        _client.SendPriority(LibIPC::Helpers::CreateGarbageCollectedTrackedObjectsMsg(
+            CreateMetadataMsg(),
             std::move(removedTrackedObjectIds)));
     }
 
     const auto newSize = _objectsTracker.GetTrackedObjectsCount();
-    _client.Send(LibIPC::Helpers::CreateGarbageCollectionFinishMsg(CreateMetadataMsg(), oldSize, newSize));
+    _client.SendPriority(LibIPC::Helpers::CreateGarbageCollectionFinishMsg(CreateMetadataMsg(), oldSize, newSize));
     return S_OK;
 }
 


### PR DESCRIPTION
This PR fixes an issue with memory consumption. Issue occurs when analyzing more demanding applications that uses many threads and consumer is slow (or interrupted due to debugging)