### PR TITLE
Improve performance for method enter & leave hooks

### DIFF
--- a/src/SharpDetect.Profiler/LibIPC/Client.h
+++ b/src/SharpDetect.Profiler/LibIPC/Client.h
@@ -43,7 +43,8 @@ namespace LibIPC
 		template<class... Types>
 		void Send(msgpack::type::tuple<Types...>&& data)
 		{
-			msgpack::sbuffer buffer;
+			thread_local msgpack::sbuffer buffer;
+			buffer.clear();
 			msgpack::pack(buffer, data);
 			const auto bufferSize = buffer.size();
 			std::vector<char> compact(buffer.data(), buffer.data() + bufferSize);
@@ -64,7 +65,8 @@ namespace LibIPC
 		template<class... Types>
 		void SendPriority(msgpack::type::tuple<Types...>&& data)
 		{
-			msgpack::sbuffer buffer;
+			thread_local msgpack::sbuffer buffer;
+			buffer.clear();
 			msgpack::pack(buffer, data);
 			std::vector<char> compact(buffer.data(), buffer.data() + buffer.size());
 			{

--- a/src/SharpDetect.Profiler/SharpDetect.Concurrency.Profiler/CorProfiler.cpp
+++ b/src/SharpDetect.Profiler/SharpDetect.Concurrency.Profiler/CorProfiler.cpp
@@ -910,13 +910,36 @@ BOOL Profiler::CorProfiler::FindCustomEventMapping(
     USHORT original,
     USHORT& mapping)
 {
-    auto guard = std::unique_lock(_customEventLookupsMutex);
+    auto guard = std::shared_lock(_customEventLookupsMutex);
     const auto mappingIt = lookup.find(std::make_tuple(moduleId, methodDef, original));
     if (mappingIt == lookup.cend())
         return false;
 
     mapping = mappingIt->second;
     return true;
+}
+
+Profiler::CorProfiler::CustomEventMappingResult Profiler::CorProfiler::FindCustomEventMappings(
+    const CustomEventsLookup& lookup,
+    ModuleID moduleId,
+    mdMethodDef methodDef,
+    USHORT originalEvent,
+    USHORT originalWithArgsEvent)
+{
+    CustomEventMappingResult result { };
+    auto guard = std::shared_lock(_customEventLookupsMutex);
+
+    auto it = lookup.find(std::make_tuple(moduleId, methodDef, originalEvent));
+    result.hasEvent = (it != lookup.cend());
+    if (result.hasEvent)
+        result.eventMapping = it->second;
+
+    it = lookup.find(std::make_tuple(moduleId, methodDef, originalWithArgsEvent));
+    result.hasWithArgsEvent = (it != lookup.cend());
+    if (result.hasWithArgsEvent)
+        result.withArgsEventMapping = it->second;
+
+    return result;
 }
 
 HRESULT Profiler::CorProfiler::PatchMethodBody(const LibProfiler::ModuleDef& moduleDef, mdTypeDef mdTypeDef, mdMethodDef mdMethodDef)
@@ -996,25 +1019,19 @@ HRESULT Profiler::CorProfiler::EnterMethod(const FunctionIDOrClientID functionOr
     }
 
     // Check if event mapping is available
-    USHORT customMethodEnterEvent;
-    USHORT customMethodEnterWithArgumentsEvent;
     constexpr auto originalMethodEnterEvent = static_cast<USHORT>(LibIPC::RecordedEventType::MethodEnter);
     constexpr auto originalMethodEnterWithArgumentsEvent = static_cast<USHORT>(LibIPC::RecordedEventType::MethodEnterWithArguments);
-    auto const hasCustomMethodEnterEvent = FindCustomEventMapping(
-        _customEventOnMethodEntryLookup,
-        moduleId,
-        methodDef,
-        originalMethodEnterEvent,
-        customMethodEnterEvent);
-    auto const hasCustomMethodEnterWithArgumentsEvent = FindCustomEventMapping(
-        _customEventOnMethodEntryLookup,
-        moduleId,
-        methodDef,
-        originalMethodEnterWithArgumentsEvent,
-        customMethodEnterWithArgumentsEvent);
+    auto const [hasCustomMethodEnterEvent, customMethodEnterEvent,
+                hasCustomMethodEnterWithArgumentsEvent, customMethodEnterWithArgumentsEvent] =
+        FindCustomEventMappings(
+            _customEventOnMethodEntryLookup,
+            moduleId,
+            methodDef,
+            originalMethodEnterEvent,
+            originalMethodEnterWithArgumentsEvent);
 
-    auto const hasDescriptor = HasMethodDescriptor(moduleId, methodDef);
-    if (!hasDescriptor)
+    const auto descriptorPointer = TryGetMethodDescriptor(moduleId, methodDef);
+    if (!descriptorPointer)
     {
         // Notify about method enter without arguments
         _client.Send(LibIPC::Helpers::CreateMethodEnterMsg(
@@ -1026,7 +1043,6 @@ HRESULT Profiler::CorProfiler::EnterMethod(const FunctionIDOrClientID functionOr
     }
 
     // Retrieve information about arguments
-    const auto descriptorPointer = GetMethodDescriptor(moduleId, methodDef);
     const auto& descriptor = *descriptorPointer.get();
     if (descriptor.rewritingDescriptor.arguments.empty())
     {
@@ -1115,25 +1131,19 @@ HRESULT Profiler::CorProfiler::LeaveMethod(const FunctionIDOrClientID functionOr
     }
 
     // Check if event mapping is available
-    USHORT customMethodExitEvent;
-    USHORT customMethodExitWithArgumentsEvent;
     constexpr auto originalMethodExitEvent = static_cast<USHORT>(LibIPC::RecordedEventType::MethodExit);
     constexpr auto originalMethodExitWithArgumentsEvent = static_cast<USHORT>(LibIPC::RecordedEventType::MethodExitWithArguments);
-    auto const hasCustomMethodExitEvent = FindCustomEventMapping(
-        _customEventOnMethodExitLookup,
-        moduleId,
-        methodDef,
-        originalMethodExitEvent,
-        customMethodExitEvent);
-    auto const hasCustomMethodExitWithArgumentsEvent = FindCustomEventMapping(
-        _customEventOnMethodExitLookup,
-        moduleId,
-        methodDef,
-        originalMethodExitWithArgumentsEvent,
-        customMethodExitWithArgumentsEvent);
+    auto const [hasCustomMethodExitEvent, customMethodExitEvent,
+                hasCustomMethodExitWithArgumentsEvent, customMethodExitWithArgumentsEvent] =
+        FindCustomEventMappings(
+            _customEventOnMethodExitLookup,
+            moduleId,
+            methodDef,
+            originalMethodExitEvent,
+            originalMethodExitWithArgumentsEvent);
 
-    auto const hasDescriptor = HasMethodDescriptor(moduleId, methodDef);
-    if (!hasDescriptor)
+    const auto descriptorPointer = TryGetMethodDescriptor(moduleId, methodDef);
+    if (!descriptorPointer)
     {
         // Notify about method leave without arguments
         _client.Send(LibIPC::Helpers::CreateMethodExitMsg(
@@ -1145,8 +1155,7 @@ HRESULT Profiler::CorProfiler::LeaveMethod(const FunctionIDOrClientID functionOr
     }
 
     // Retrieve information about arguments
-    const auto descriptorPtr = GetMethodDescriptor(moduleId, methodDef);
-    const auto& descriptor = *descriptorPtr.get();
+    const auto& descriptor = *descriptorPointer.get();
     auto const hasIndirects = HasIndirects(descriptor);
     auto const hasReturnValue = descriptor.rewritingDescriptor.returnValue.has_value();
     if (!hasReturnValue && !hasIndirects)
@@ -1461,8 +1470,15 @@ std::shared_ptr<LibProfiler::AssemblyDef> Profiler::CorProfiler::GetAssemblyDef(
 
 std::shared_ptr<Profiler::MethodDescriptor> Profiler::CorProfiler::GetMethodDescriptor(ModuleID moduleId, mdMethodDef methodDef)
 {
-    auto guard = std::unique_lock(_methodDescriptorsMutex);
+    auto guard = std::shared_lock(_methodDescriptorsMutex);
     return _methodDescriptorsLookup.find(std::make_pair(moduleId, methodDef))->second;
+}
+
+std::shared_ptr<Profiler::MethodDescriptor> Profiler::CorProfiler::TryGetMethodDescriptor(ModuleID moduleId, mdMethodDef methodDef)
+{
+    auto guard = std::shared_lock(_methodDescriptorsMutex);
+    const auto it = _methodDescriptorsLookup.find(std::make_pair(moduleId, methodDef));
+    return (it != _methodDescriptorsLookup.cend()) ? it->second : nullptr;
 }
 
 BOOL Profiler::CorProfiler::HasModuleDef(const ModuleID moduleId)
@@ -1479,7 +1495,7 @@ BOOL Profiler::CorProfiler::HasAssemblyDef(const AssemblyID assemblyId)
 
 BOOL Profiler::CorProfiler::HasMethodDescriptor(ModuleID moduleId, mdMethodDef methodDef)
 {
-    auto guard = std::unique_lock(_methodDescriptorsMutex);
+    auto guard = std::shared_lock(_methodDescriptorsMutex);
     return _methodDescriptorsLookup.contains(std::make_pair(moduleId, methodDef));
 }
 
@@ -1494,7 +1510,7 @@ std::shared_ptr<Profiler::MethodDescriptor> Profiler::CorProfiler::FindMethodDes
         return { };
     }
 
-    auto guard = std::unique_lock(_methodDescriptorsMutex);
+    auto guard = std::shared_lock(_methodDescriptorsMutex);
     const auto it = _methodDescriptorsLookup.find(std::make_pair(moduleId, mdMethodDef));
     return (it != _methodDescriptorsLookup.cend()) ? it->second : nullptr;
 }

--- a/src/SharpDetect.Profiler/SharpDetect.Concurrency.Profiler/CorProfiler.h
+++ b/src/SharpDetect.Profiler/SharpDetect.Concurrency.Profiler/CorProfiler.h
@@ -9,6 +9,7 @@
 #include <utility>
 #include <vector>
 #include <mutex>
+#include <shared_mutex>
 
 #include "cor.h"
 
@@ -58,6 +59,7 @@ namespace Profiler
 		[[nodiscard]] BOOL HasModuleDef(ModuleID moduleId);
 		[[nodiscard]] BOOL HasAssemblyDef(AssemblyID assemblyId);
 		[[nodiscard]] BOOL HasMethodDescriptor(ModuleID moduleId, mdMethodDef methodDef);
+		[[nodiscard]] std::shared_ptr<MethodDescriptor> TryGetMethodDescriptor(ModuleID moduleId, mdMethodDef methodDef);
 		[[nodiscard]] std::shared_ptr<LibProfiler::ModuleDef> GetModuleDef(ModuleID moduleId);
 		[[nodiscard]] std::shared_ptr<LibProfiler::AssemblyDef> GetAssemblyDef(AssemblyID assemblyID);
 		[[nodiscard]] std::shared_ptr<MethodDescriptor> GetMethodDescriptor(ModuleID moduleId, mdMethodDef methodDef);
@@ -128,13 +130,13 @@ namespace Profiler
 		LibProfiler::ObjectsTracker _objectsTracker;
 		std::vector< std::shared_ptr<MethodDescriptor>> _methodDescriptors;
 		std::unordered_map<MethodId, std::shared_ptr<MethodDescriptor>, MethodIdHasher> _methodDescriptorsLookup;
-		std::mutex _methodDescriptorsMutex;
+		std::shared_mutex _methodDescriptorsMutex;
 
 		using MethodInvocationId = std::tuple<ModuleID, mdMethodDef, USHORT>;
 		using MethodInvocationIdHasher = tuple_hash<ModuleID, mdMethodDef, USHORT>;
 		std::unordered_map<MethodInvocationId, USHORT, MethodInvocationIdHasher> _customEventOnMethodEntryLookup;
 		std::unordered_map<MethodInvocationId, USHORT, MethodInvocationIdHasher> _customEventOnMethodExitLookup;
-		std::mutex _customEventLookupsMutex;
+		std::shared_mutex _customEventLookupsMutex;
 
 		using CustomEventsLookup = std::unordered_map<MethodInvocationId, USHORT, MethodInvocationIdHasher>;
 		void AddCustomEventMapping(
@@ -149,5 +151,20 @@ namespace Profiler
 			mdMethodDef methodDef,
 			USHORT original,
 			USHORT& mapping);
+
+		struct CustomEventMappingResult
+		{
+			BOOL hasEvent;
+			USHORT eventMapping;
+			BOOL hasWithArgsEvent;
+			USHORT withArgsEventMapping;
+		};
+		
+		CustomEventMappingResult FindCustomEventMappings(
+			const CustomEventsLookup& lookup,
+			ModuleID moduleId,
+			mdMethodDef methodDef,
+			USHORT originalEvent,
+			USHORT originalWithArgsEvent);
 	};
 }


### PR DESCRIPTION
This PR introduces the following changes:

- `shared_lock` is used for readers when accessing event mappings
- Event mappings are fetched only once per hook
- Reduce allocations when enqueuing to event IPQ