### PR TITLE
Fix incorrect lock acquire exit result interpretation

### DIFF
--- a/src/Extensibility/SharpDetect.PluginHost/Services/Strategies/ReorderingPluginHost.cs
+++ b/src/Extensibility/SharpDetect.PluginHost/Services/Strategies/ReorderingPluginHost.cs
@@ -58,8 +58,8 @@ internal sealed class ReorderingPluginHost(IPluginHost inner, ILogger<Reordering
         return recordedEvent.EventArgs switch
         {
             MethodEnterWithArgumentsRecordedEvent enter => HandleEnter(recordedEvent, enter, thread.Id, thread),
-            MethodExitRecordedEvent exit => HandleExit(recordedEvent, exit.Interpretation, thread.Id, thread, returnValue: null),
-            MethodExitWithArgumentsRecordedEvent exit => HandleExit(recordedEvent, exit.Interpretation, thread.Id, thread, exit.ReturnValue),
+            MethodExitRecordedEvent exit => HandleExit(recordedEvent, exit.Interpretation, thread.Id, thread, returnValue: null, byRefArgumentValues: null),
+            MethodExitWithArgumentsRecordedEvent exit => HandleExit(recordedEvent, exit.Interpretation, thread.Id, thread, exit.ReturnValue, exit.ByRefArgumentValues),
             ThreadDestroyRecordedEvent destroy => HandleThreadDestroy(recordedEvent, destroy),
             GarbageCollectedTrackedObjectsRecordedEvent gc => HandleGarbageCollectedTrackedObjects(recordedEvent, gc),
             _ => inner.ProcessEvent(recordedEvent)
@@ -158,14 +158,15 @@ internal sealed class ReorderingPluginHost(IPluginHost inner, ILogger<Reordering
         ushort interpretation,
         ProcessThreadId tid,
         ShadowThread thread,
-        byte[]? returnValue)
+        byte[]? returnValue,
+        byte[]? byRefArgumentValues)
     {
         var kind = (RecordedEventType)interpretation;
         switch (kind)
         {
             case RecordedEventType.MonitorLockAcquireResult:
             case RecordedEventType.LockAcquireResult:
-                return HandleAcquireResult(recordedEvent, tid, thread, ReadBoolOrDefault(returnValue, true));
+                return HandleAcquireResult(recordedEvent, tid, thread, ReadBoolOrDefault(returnValue, byRefArgumentValues, true));
 
             case RecordedEventType.MonitorLockReleaseResult:
             case RecordedEventType.LockReleaseResult:
@@ -175,7 +176,7 @@ internal sealed class ReorderingPluginHost(IPluginHost inner, ILogger<Reordering
                 return HandleWaitResult(recordedEvent, tid, thread);
 
             case RecordedEventType.SemaphoreAcquireResult:
-                return HandleSemaphoreAcquireResult(recordedEvent, tid, thread, ReadBoolOrDefault(returnValue, true));
+                return HandleSemaphoreAcquireResult(recordedEvent, tid, thread, ReadBoolOrDefault(returnValue, byRefArgumentValues, true));
 
             case RecordedEventType.SemaphoreReleaseResult:
                 return HandleSemaphoreReleaseResult(recordedEvent, tid, thread);
@@ -184,7 +185,7 @@ internal sealed class ReorderingPluginHost(IPluginHost inner, ILogger<Reordering
                 return HandleTaskComplete(recordedEvent, thread);
 
             case RecordedEventType.TaskJoinFinish:
-                return HandleTaskJoinFinish(recordedEvent, tid, thread, ReadBoolOrDefault(returnValue, true));
+                return HandleTaskJoinFinish(recordedEvent, tid, thread, ReadBoolOrDefault(returnValue, byRefArgumentValues, true));
 
             case RecordedEventType.MonitorPulseOneResult:
             case RecordedEventType.MonitorPulseAllResult:
@@ -438,11 +439,13 @@ internal sealed class ReorderingPluginHost(IPluginHost inner, ILogger<Reordering
         return new ProcessTrackedObjectId(pid, new TrackedObjectId(raw));
     }
 
-    private static bool ReadBoolOrDefault(byte[]? buffer, bool defaultValue)
+    private static bool ReadBoolOrDefault(byte[]? returnValue, byte[]? byRefArgumentValues, bool defaultValue)
     {
-        if (buffer is null || buffer.Length == 0)
-            return defaultValue;
-        return MemoryMarshal.Read<bool>(buffer);
+        if (returnValue is not null && returnValue.Length > 0)
+            return MemoryMarshal.Read<bool>(returnValue);
+        if (byRefArgumentValues is not null && byRefArgumentValues.Length > 0)
+            return MemoryMarshal.Read<bool>(byRefArgumentValues);
+        return defaultValue;
     }
     
     private static bool TryPeekTarget(ShadowThread thread, out ProcessTrackedObjectId target)

--- a/src/Tests/SharpDetect.PluginHost.Tests/ReorderingPluginHostTests.cs
+++ b/src/Tests/SharpDetect.PluginHost.Tests/ReorderingPluginHostTests.cs
@@ -872,6 +872,72 @@ public class ReorderingPluginHostTests
         Assert.True(coreIdx < callbackIdx);
     }
 
+    [Fact]
+    public void ReorderingPluginHost_FailedTryEnterViaByRef_NotDeferred_NotReordered()
+    {
+        // Arrange
+        var host = Build(out var recorder);
+
+        // Act
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.MonitorLockAcquire, L1));
+        host.ProcessEvent(SyncEventBuilder.Exit(T1, RecordedEventType.MonitorLockAcquireResult));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T2, RecordedEventType.MonitorLockTryAcquire, L1));
+        host.ProcessEvent(SyncEventBuilder.ExitWithByRefSuccess(T2, RecordedEventType.MonitorLockAcquireResult, success: false));
+
+        // Assert
+        Assert.Equal(4, recorder.Dispatched.Count);
+        Assert.Equal((T2, RecordedEventType.MonitorLockAcquireResult), ClassifyDispatched(recorder.Dispatched[^1]));
+    }
+
+    [Fact]
+    public void ReorderingPluginHost_FailedTryEnterViaByRef_DoesNotCreatePhantomOwner()
+    {
+        // Arrange
+        var host = Build(out var recorder);
+
+        // Act
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.MonitorLockAcquire, L1));
+        host.ProcessEvent(SyncEventBuilder.Exit(T1, RecordedEventType.MonitorLockAcquireResult));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T2, RecordedEventType.MonitorLockTryAcquire, L1));
+        host.ProcessEvent(SyncEventBuilder.ExitWithByRefSuccess(T2, RecordedEventType.MonitorLockAcquireResult, success: false));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.MonitorLockRelease, L1));
+        host.ProcessEvent(SyncEventBuilder.Exit(T1, RecordedEventType.MonitorLockReleaseResult));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T3, RecordedEventType.MonitorLockAcquire, L1));
+        host.ProcessEvent(SyncEventBuilder.Exit(T3, RecordedEventType.MonitorLockAcquireResult));
+
+        // Assert
+        Assert.Contains(recorder.Dispatched, e => e.Metadata.Tid.Value == T3 && IsAcquireResult(e));
+    }
+
+    [Fact]
+    public void ReorderingPluginHost_SuccessfulTryEnterViaByRef_IsDeferred_IsReordered()
+    {
+        // Arrange
+        var host = Build(out var recorder);
+
+        // Act
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.MonitorLockAcquire, L1));
+        host.ProcessEvent(SyncEventBuilder.Exit(T1, RecordedEventType.MonitorLockAcquireResult));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T2, RecordedEventType.MonitorLockTryAcquire, L1));
+        host.ProcessEvent(SyncEventBuilder.ExitWithByRefSuccess(T2, RecordedEventType.MonitorLockAcquireResult, success: true)); // deferred
+        host.ProcessEvent(SyncEventBuilder.FieldRead(T2)); // deferred
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.MonitorLockRelease, L1));
+        host.ProcessEvent(SyncEventBuilder.Exit(T1, RecordedEventType.MonitorLockReleaseResult));
+
+        // Assert
+        var kinds = recorder.Dispatched.Select(ClassifyDispatched).ToArray();
+        Assert.Equal(new[]
+        {
+            (T1, RecordedEventType.MonitorLockAcquire),
+            (T1, RecordedEventType.MonitorLockAcquireResult),
+            (T2, RecordedEventType.MonitorLockTryAcquire),
+            (T1, RecordedEventType.MonitorLockRelease),
+            (T1, RecordedEventType.MonitorLockReleaseResult),
+            (T2, RecordedEventType.MonitorLockAcquireResult),
+            (T2, RecordedEventType.InstanceFieldRead),
+        }, kinds);
+    }
+
     private static (uint Tid, RecordedEventType Type) ClassifyDispatched(RecordedEvent e)
     {
         var tid = e.Metadata.Tid.Value;

--- a/src/Tests/SharpDetect.PluginHost.Tests/SyncEventBuilder.cs
+++ b/src/Tests/SharpDetect.PluginHost.Tests/SyncEventBuilder.cs
@@ -84,6 +84,19 @@ internal static class SyncEventBuilder
             ByRefArgumentInfos: []));
     }
 
+    public static RecordedEvent ExitWithByRefSuccess(uint tid, RecordedEventType type, bool success)
+    {
+        var byRef = new byte[1];
+        MemoryMarshal.Write(byRef, in success);
+        return new RecordedEvent(Meta(tid), new MethodExitWithArgumentsRecordedEvent(
+            ModuleId: Module,
+            MethodToken: Method,
+            Interpretation: (ushort)type,
+            ReturnValue: [],
+            ByRefArgumentValues: byRef,
+            ByRefArgumentInfos: []));
+    }
+
     public static RecordedEvent FieldRead(uint tid)
         => new(Meta(tid), new MethodEnterWithArgumentsRecordedEvent(
             ModuleId: Module,


### PR DESCRIPTION
This PR fixes an issue where reordering plugin base was not taking into account by-ref arguments of lock acquire operations. This could have resulted in it interpreting failed lock acquires as successful ones for certain method overloads