### PR TITLE
Improve build and release

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,11 @@
 name: CI
 
-on: ["push"]
+on:
+  push:
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - 'LICENSE'
 
 jobs:
   build:
@@ -67,3 +72,41 @@ jobs:
         name: Tests (${{ matrix.rid }})
         path: src/TestResults/**/*.trx
         reporter: dotnet-trx
+    - name: Upload coverage data
+      uses: actions/upload-artifact@v7
+      if: ${{ !cancelled() }}
+      with:
+        name: coverage-data-${{ matrix.rid }}
+        path: src/TestResults/**/coverage.cobertura.xml
+        if-no-files-found: warn
+
+  coverage:
+    needs: tests
+    if: ${{ !cancelled() }}
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v5
+      with:
+        dotnet-version: 10.0.*
+    - name: Download coverage data
+      uses: actions/download-artifact@v7
+      with:
+        pattern: coverage-data-*
+        path: src/TestResults
+        merge-multiple: true
+    - name: Generate combined coverage report
+      run: |
+        cd src
+        dotnet tool restore
+        dotnet cake --target=Coverage-Report
+    - name: Write coverage to job summary
+      shell: bash
+      run: cat src/TestResults/CoverageReport/SummaryGithub.md >> "$GITHUB_STEP_SUMMARY"
+    - name: Upload coverage report
+      uses: actions/upload-artifact@v7
+      with:
+        name: coverage-report
+        path: src/TestResults/CoverageReport
+        if-no-files-found: warn

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
       run: |
         cd src
         dotnet tool restore
-        dotnet cake --rid=${{ matrix.rid }} --target="CI-Prepare-Native-Libs" --configuration=Release
+        dotnet cake --rid=${{ matrix.rid }} --target="Build-Profiler" --configuration=Release
     - name: Upload
       uses: actions/upload-artifact@v7
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
       run: |
         cd src
         dotnet tool restore
-        dotnet cake --rid=${{ matrix.rid }} --target="Build-Profiler" --configuration=Release
+        dotnet cake --rid=${{ matrix.rid }} --target="Build-Local-Environment" --configuration=Release
     - name: Upload
       uses: actions/upload-artifact@v7
       with:

--- a/src/.config/dotnet-tools.json
+++ b/src/.config/dotnet-tools.json
@@ -8,6 +8,13 @@
         "dotnet-cake"
       ],
       "rollForward": false
+    },
+    "dotnet-reportgenerator-globaltool": {
+      "version": "5.5.10",
+      "commands": [
+        "reportgenerator"
+      ],
+      "rollForward": false
     }
   }
 }

--- a/src/SharpDetect.Cli/SharpDetect.Cli.csproj
+++ b/src/SharpDetect.Cli/SharpDetect.Cli.csproj
@@ -26,7 +26,6 @@
   <ItemGroup>
     <None Include="../artifacts/Profilers/linux-x64/*.so" Pack="true" PackagePath="tools/$(TargetFramework)/any/Profilers/linux-x64/" Visible="false" />
     <None Include="../artifacts/Profilers/win-x64/*.dll" Pack="true" PackagePath="tools/$(TargetFramework)/any/Profilers/win-x64/" Visible="false" />
-    <None Include="../artifacts/Plugins/**/*.*" Pack="true" PackagePath="tools/$(TargetFramework)/any/Plugins/" Visible="false" />
     <None Include="../../LICENSE" Pack="true" PackagePath="" Visible="false" />
     <None Include="../../THIRD-PARTY-NOTICES.md" Pack="true" PackagePath="" Visible="false" />
   </ItemGroup>

--- a/src/SharpDetect.InterProcessQueue/SharpDetect.InterProcessQueue.csproj
+++ b/src/SharpDetect.InterProcessQueue/SharpDetect.InterProcessQueue.csproj
@@ -2,6 +2,7 @@
 	<PropertyGroup>
 		<PublishAot>true</PublishAot>
 		<IsAotCompatible>true</IsAotCompatible>
+		<StripSymbols Condition="'$(Configuration)' == 'Release'">true</StripSymbols>
 	</PropertyGroup>
 	
   <ItemGroup>

--- a/src/SharpDetect.Profiler/cmake/compiler_options.cmake
+++ b/src/SharpDetect.Profiler/cmake/compiler_options.cmake
@@ -9,7 +9,7 @@ endif()
 function(apply_profiler_compile_options target_name)
     if (UNIX AND NOT APPLE)
         target_compile_options(${target_name} PRIVATE
-            -g
+            $<$<NOT:$<CONFIG:Release>>:-g>
             -fPIC
             -fms-extensions
             -Wno-pragma-pack)
@@ -18,6 +18,7 @@ function(apply_profiler_compile_options target_name)
             HOST_64BIT
             PLATFORM_UNIX
             PAL_STDCPP_COMPAT)
+        target_link_options(${target_name} PRIVATE $<$<CONFIG:Release>:LINKER:-s>)
     endif()
 endfunction()
 

--- a/src/build.cake
+++ b/src/build.cake
@@ -6,7 +6,15 @@ var rid = Argument<string>("rid", GetDefaultRuntimeIdentifier());
 var libraryExtension = rid.StartsWith("win") ? "dll" : "so";
 var target = Argument("target", "Build-Local-Environment");
 var configuration = Argument("configuration", "Debug");
-var sdk = Argument("sdk", "net10.0");
+var sdk = Argument("sdk", GetTargetFramework());
+
+string GetTargetFramework()
+{
+    var tfm = XmlPeek("./Directory.Build.props", "/Project/PropertyGroup/TargetFramework/text()");
+    if (string.IsNullOrEmpty(tfm))
+        throw new Exception("Could not read <TargetFramework> from Directory.Build.props.");
+    return tfm;
+}
 
 string GetDefaultRuntimeIdentifier()
 {
@@ -130,16 +138,21 @@ Task("Copy-Native-Artifacts")
 
     foreach (var profilerName in profilers)
     {
-        var profilerLibrary = (rid.StartsWith("win"))
-            ? $"./SharpDetect.Profiler/artifacts/{rid}/{profilerName}/{configuration}/{profilerName}.{libraryExtension}"
-            : $"./SharpDetect.Profiler/artifacts/{rid}/{profilerName}/{profilerName}.{libraryExtension}";
-        
+        var profilerLibrary = GetProfilerLibraryPath(profilerName);
         if (!System.IO.File.Exists(profilerLibrary))
             throw new Exception($"Profiler library not found at: {profilerLibrary}");
         
         CopyFileToDirectory(profilerLibrary, nativeArtifactsDirectory);
     }
 });
+
+string GetProfilerLibraryPath(string profilerName)
+{
+    var baseDirectory = $"./SharpDetect.Profiler/artifacts/{rid}/{profilerName}";
+    return rid.StartsWith("win")
+        ? $"{baseDirectory}/{configuration}/{profilerName}.{libraryExtension}"
+        : $"{baseDirectory}/{profilerName}.{libraryExtension}";
+}
 
 Task("Tests")
     .IsDependentOn("Build-Local-Environment")

--- a/src/build.cake
+++ b/src/build.cake
@@ -77,6 +77,7 @@ Task("Build-IPQ")
 });
 
 Task("Build-Profiler")
+    .IsDependentOn("Build-IPQ")
     .Does(() =>
 {
     var profilerArtifactsDirectory = $"./SharpDetect.Profiler/artifacts/{rid}";
@@ -159,31 +160,6 @@ Task("CI-Prepare-Managed")
     {
         Configuration = configuration
     });
-});
-
-Task("CI-Prepare-Native-Libs")
-    .IsDependentOn("Build-IPQ")
-    .IsDependentOn("Build-Profiler")
-    .IsDependentOn("Copy-Native-Artifacts")
-    .Does(() =>
-{
-    var files = GetFiles($"{nativeArtifactsDirectory}*");
-    foreach (var file in files)
-    {
-        if (rid.StartsWith("linux"))
-        {
-            Information($"Stripping symbols from: {file.GetFilename()}");
-            var exitCode = StartProcess("strip", new ProcessSettings
-            {
-                Arguments = new ProcessArgumentBuilder()
-                    .Append("-s")
-                    .Append(file.FullPath)
-            });
-            
-            if (exitCode != 0)
-                Warning($"Failed to strip {file.GetFilename()}, exit code: {exitCode}");
-        }
-    }
 });
 
 Task("CI-Pack")

--- a/src/build.cake
+++ b/src/build.cake
@@ -162,8 +162,32 @@ Task("Tests")
     {
         Configuration = configuration,
         Loggers = new[] { "trx" },
+        Collectors = new[] { "XPlat Code Coverage" },
         ResultsDirectory = "./TestResults"
     });
+});
+
+Task("Coverage-Report")
+    .Does(() =>
+{
+    var reportDirectory = "./TestResults/CoverageReport";
+    EnsureDirectoryExists(reportDirectory);
+
+    var exitCode = StartProcess("dotnet", new ProcessSettings
+    {
+        Arguments = new ProcessArgumentBuilder()
+            .Append("tool")
+            .Append("run")
+            .Append("reportgenerator")
+            .Append("-reports:./TestResults/**/coverage.cobertura.xml")
+            .Append($"-targetdir:{reportDirectory}")
+            .Append("-reporttypes:Html;MarkdownSummaryGithub")
+    });
+
+    if (exitCode != 0)
+        throw new Exception($"ReportGenerator failed with exit code: {exitCode}");
+
+    Information($"Coverage report generated in: {reportDirectory}");
 });
 
 Task("CI-Prepare-Managed")


### PR DESCRIPTION
This PR improves the following:

- Target framework in `build.cake` is read from `Directory.Build.props`
- Added code coverage report generation and integration with GitHub
- Misc improvements:
   - Removes obsolete msbuild packaging properties
   - Release builds for native artifacts do not include symbols. They are no longer stripped as separate CI step
   - Code refactoring and improvements to `build.cake`