### PR TITLE
Improve object publication determining heuristics

### DIFF
--- a/src/Extensibility/SharpDetect.Plugins.DataRace.Common/ConstructorKind.cs
+++ b/src/Extensibility/SharpDetect.Plugins.DataRace.Common/ConstructorKind.cs
@@ -1,0 +1,11 @@
+// Copyright 2026 Andrej Čižmárik and Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+namespace SharpDetect.Plugins.DataRace.Common;
+
+public enum ConstructorKind
+{
+    None,
+    Instance,
+    Static
+}

--- a/src/Extensibility/SharpDetect.Plugins.DataRace.Common/FieldFlags.cs
+++ b/src/Extensibility/SharpDetect.Plugins.DataRace.Common/FieldFlags.cs
@@ -12,5 +12,6 @@ public enum FieldFlags
     IsAsyncStateMachineInternalField = 1 << 3,
     IsTaskOrContinuationInternalField = 1 << 4,
     IsStaticDelegateType = 1 << 5,
+    IsAutoPropertyBackingField = 1 << 6,
 }
 

--- a/src/Extensibility/SharpDetect.Plugins.DataRace.Common/FieldResolver.cs
+++ b/src/Extensibility/SharpDetect.Plugins.DataRace.Common/FieldResolver.cs
@@ -88,7 +88,31 @@ public sealed class FieldResolver(IMetadataContext metadataContext, ILogger logg
         if (IsFieldDelegateCacheInCompilerGeneratedType(fieldDef))
             flags |= FieldFlags.IsStaticDelegateType;
 
+        if (IsAutoPropertyBackingField(fieldDef))
+            flags |= FieldFlags.IsAutoPropertyBackingField;
+
         return flags;
+    }
+
+    private bool IsAutoPropertyBackingField(FieldDef fieldDef)
+    {
+        const string backingFieldNameSuffix = "k__BackingField";
+
+        var name = fieldDef.Name?.String;
+        if (name is null || !name.EndsWith(backingFieldNameSuffix, StringComparison.Ordinal))
+            return false;
+
+        return HasCompilerGeneratedAttribute(fieldDef, fieldDef.Module);
+    }
+
+    private bool HasCompilerGeneratedAttribute(IHasCustomAttribute member, ModuleDef module)
+    {
+        _compilerGeneratedAttributeTypeRef ??= module.CorLibTypes.GetTypeRef(
+            @namespace: "System.Runtime.CompilerServices",
+            name: "CompilerGeneratedAttribute");
+
+        var comparer = new SigComparer();
+        return member.CustomAttributes.Any(a => comparer.Equals(a.AttributeType, _compilerGeneratedAttributeTypeRef));
     }
 
     private static bool IsFieldReadonly(FieldDef fieldDef)
@@ -148,21 +172,13 @@ public sealed class FieldResolver(IMetadataContext metadataContext, ILogger logg
             return false;
         }
 
-        _compilerGeneratedAttributeTypeRef ??= fieldDef.Module.CorLibTypes
-            .GetTypeRef(
-                @namespace: "System.Runtime.CompilerServices",
-                name: "CompilerGeneratedAttribute");
-
-        var sigComparer = new SigComparer();
-        var hasCompilerGenerated = declaringType.CustomAttributes.Any(a =>
-            sigComparer.Equals(a.AttributeType, _compilerGeneratedAttributeTypeRef));
-
-        if (!hasCompilerGenerated)
+        if (!HasCompilerGeneratedAttribute(declaringType, fieldDef.Module))
             return false;
 
         _multicastDelegateTypeRef ??= fieldDef.Module.CorLibTypes
             .GetTypeRef(@namespace: "System", name: "MulticastDelegate");
 
+        var sigComparer = new SigComparer();
         var fieldType = fieldDef.FieldType.ToTypeDefOrRef();
         while (fieldType != null)
         {

--- a/src/Extensibility/SharpDetect.Plugins.DataRace.Common/MethodDefOrRef.cs
+++ b/src/Extensibility/SharpDetect.Plugins.DataRace.Common/MethodDefOrRef.cs
@@ -1,0 +1,8 @@
+// Copyright 2026 Andrej Čižmárik and Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+using SharpDetect.Core.Events.Profiler;
+
+namespace SharpDetect.Plugins.DataRace.Common;
+
+public readonly record struct MethodDefOrRef(uint ProcessId, ModuleId ModuleId, MdMethodDef Token);

--- a/src/Extensibility/SharpDetect.Plugins.DataRace.Common/MethodResolver.cs
+++ b/src/Extensibility/SharpDetect.Plugins.DataRace.Common/MethodResolver.cs
@@ -1,0 +1,46 @@
+// Copyright 2026 Andrej Čižmárik and Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+using dnlib.DotNet;
+using Microsoft.Extensions.Logging;
+using SharpDetect.Core.Events.Profiler;
+using SharpDetect.Core.Metadata;
+using ILogger = Microsoft.Extensions.Logging.ILogger;
+
+namespace SharpDetect.Plugins.DataRace.Common;
+
+public sealed class MethodResolver(IMetadataContext metadataContext, ILogger logger)
+{
+    private readonly Dictionary<MethodDefOrRef, MethodDef> _resolvedMethods = [];
+
+    public ConstructorKind GetConstructorKind(uint processId, ModuleId moduleId, MdMethodDef methodToken)
+    {
+        var key = new MethodDefOrRef(processId, moduleId, methodToken);
+        if (_resolvedMethods.TryGetValue(key, out var methodDef))
+            return GetConstructorKind(methodDef);
+
+        var resolver = metadataContext.GetResolver(processId);
+        var resolveResult = resolver.ResolveMethod(processId, moduleId, methodToken);
+
+        if (resolveResult.IsError)
+        {
+            logger.LogWarning(
+                "Could not resolve method with token={MethodToken} in module {ModuleId}",
+                methodToken.Value,
+                moduleId.Value);
+            return ConstructorKind.None;
+        }
+
+        methodDef = resolveResult.Value;
+        _resolvedMethods.Add(key, methodDef);
+        return GetConstructorKind(methodDef);
+    }
+
+    private static ConstructorKind GetConstructorKind(MethodDef methodDef)
+    {
+        if (!methodDef.IsConstructor)
+            return ConstructorKind.None;
+
+        return methodDef.IsInstanceConstructor ? ConstructorKind.Instance : ConstructorKind.Static;
+    }
+}

--- a/src/Extensibility/SharpDetect.Plugins.DataRace.FastTrack/FastTrackDetector.cs
+++ b/src/Extensibility/SharpDetect.Plugins.DataRace.FastTrack/FastTrackDetector.cs
@@ -15,6 +15,7 @@ internal sealed class FastTrackDetector
     private readonly ShadowMemory _shadowMemory = new();
     private readonly AccessTracker _accessTracker;
     private readonly FieldResolver _fieldResolver;
+    private readonly MethodResolver _methodResolver;
     private readonly TimeProvider _timeProvider;
     private readonly Dictionary<ProcessThreadId, VectorClock> _threadClocks = [];
     private readonly Dictionary<ProcessTrackedObjectId, VectorClock> _lockClocks = [];
@@ -22,7 +23,9 @@ internal sealed class FastTrackDetector
     private readonly Dictionary<ProcessTrackedObjectId, VectorClock> _taskClocks = [];
     private readonly Dictionary<(FieldId, ProcessTrackedObjectId?), VectorClock> _volatileClocks = [];
     private readonly Dictionary<ProcessTrackedObjectId, HashSet<FieldId>> _volatileClocksObjectIndex = [];
-
+    private readonly Dictionary<ProcessTrackedObjectId, ObjectEscapeState> _escapeStates = [];
+    private readonly record struct ObjectEscapeState(ProcessThreadId Instantiator, bool Escaped);
+    
     public FastTrackDetector(
         FastTrackPluginConfiguration configuration,
         IMetadataContext metadataContext,
@@ -34,6 +37,7 @@ internal sealed class FastTrackDetector
         _timeProvider = timeProvider;
         _accessTracker = new AccessTracker(timeProvider, threadNameResolver);
         _fieldResolver = new FieldResolver(metadataContext, logger);
+        _methodResolver = new MethodResolver(metadataContext, logger);
     }
 
     public int GetTrackedFieldCount() => _shadowMemory.Count;
@@ -65,6 +69,7 @@ internal sealed class FastTrackDetector
             _lockClocks.Remove(processObjectId);
             _semaphoreClocks.Remove(processObjectId);
             _taskClocks.Remove(processObjectId);
+            _escapeStates.Remove(processObjectId);
         }
 
         foreach (var objectId in removedObjectIds)
@@ -224,10 +229,12 @@ internal sealed class FastTrackDetector
         var fieldId = new FieldId(threadId.ProcessId, moduleId, fieldToken, fieldDef!);
         var shadow = _shadowMemory.GetOrCreateVirgin(fieldId, objectId);
         var threadVc = GetOrCreateThreadClock(threadId);
-        
-        if (!shadow.WriteEpoch.IsNone && 
-            !shadow.WriteEpoch.HappensBefore(threadVc) && 
-            shadow.ExclusiveWriteThread == null)
+
+        _ = UpdateObjectPublicationState(threadId, objectId);
+
+        if (!shadow.WriteEpoch.IsNone &&
+            !shadow.WriteEpoch.HappensBefore(threadVc) &&
+            shadow.LastWriteKind == WriteKind.Regular)
         {
             // Write-read race detected: last write does not happen-before this read
             var accessType = AccessType.Read;
@@ -274,15 +281,16 @@ internal sealed class FastTrackDetector
         var shadow = _shadowMemory.GetOrCreateVirgin(fieldId, objectId);
         var threadVc = GetOrCreateThreadClock(threadId);
         var currentEpoch = threadVc.GetEpoch(threadId);
+        var writeKind = ClassifyWrite(threadId, moduleId, methodToken, fieldFlags, objectId);
 
-        if (!shadow.WriteEpoch.IsNone && 
-            shadow.WriteEpoch.ThreadId != threadId && 
+        if (!shadow.WriteEpoch.IsNone &&
+            shadow.WriteEpoch.ThreadId != threadId &&
             !shadow.WriteEpoch.HappensBefore(threadVc))
         {
             var currentAccess = _accessTracker.CreateAccessInfo(threadId, moduleId, methodToken, methodOffset, AccessType.Write);
             var lastAccess = _accessTracker.GetLastWriteAccess(fieldId, objectId);
             _accessTracker.RecordAccess(fieldId, objectId, currentAccess);
-            shadow.SetWrite(currentEpoch);
+            shadow.SetWrite(currentEpoch, writeKind);
             shadow.SetRead(Epoch.None);
 
             if (lastAccess != null && lastAccess.ProcessThreadId != threadId)
@@ -305,7 +313,7 @@ internal sealed class FastTrackDetector
             var currentAccess = _accessTracker.CreateAccessInfo(threadId, moduleId, methodToken, methodOffset, AccessType.Write);
             var lastAccess = _accessTracker.GetLastAccess(fieldId, objectId);
             _accessTracker.RecordAccess(fieldId, objectId, currentAccess);
-            shadow.SetWrite(currentEpoch);
+            shadow.SetWrite(currentEpoch, writeKind);
             shadow.SetRead(Epoch.None);
 
             if (lastAccess != null && lastAccess.ProcessThreadId != threadId)
@@ -324,11 +332,61 @@ internal sealed class FastTrackDetector
 
         var writeAccess = _accessTracker.CreateAccessInfo(threadId, moduleId, methodToken, methodOffset, AccessType.Write);
         _accessTracker.RecordAccess(fieldId, objectId, writeAccess);
-        shadow.SetWrite(currentEpoch);
+        shadow.SetWrite(currentEpoch, writeKind);
         shadow.SetRead(Epoch.None);
         return null;
     }
     
+    private WriteKind ClassifyWrite(
+        ProcessThreadId threadId,
+        ModuleId moduleId,
+        MdMethodDef methodToken,
+        FieldFlags fieldFlags,
+        ProcessTrackedObjectId? objectId)
+    {
+        var isStaticField = objectId == null;
+        var constructorKind = _methodResolver.GetConstructorKind(threadId.ProcessId, moduleId, methodToken);
+        var isInstantiatorExclusive = UpdateObjectPublicationState(threadId, objectId);
+
+        if (isStaticField)
+        {
+            return constructorKind == ConstructorKind.Static
+                ? WriteKind.Instantiation
+                : WriteKind.Regular;
+        }
+
+        if (constructorKind != ConstructorKind.None)
+            return WriteKind.Instantiation;
+
+        // An auto-property is written via its compiler-generated setter
+        // Treat it as initialization if object not escaped instantiation thread yet
+        if (isInstantiatorExclusive && fieldFlags.HasFlag(FieldFlags.IsAutoPropertyBackingField))
+            return WriteKind.MaybeInstantiation;
+
+        return WriteKind.Regular;
+    }
+    
+    private bool UpdateObjectPublicationState(ProcessThreadId threadId, ProcessTrackedObjectId? objectId)
+    {
+        if (objectId is not { } objId)
+            return false;
+
+        if (!_escapeStates.TryGetValue(objId, out var state))
+        {
+            _escapeStates[objId] = new ObjectEscapeState(threadId, Escaped: false);
+            return true;
+        }
+
+        if (state.Escaped)
+            return false;
+
+        if (state.Instantiator == threadId)
+            return true;
+
+        _escapeStates[objId] = state with { Escaped = true };
+        return false;
+    }
+
     private static void UpdateReadState(ProcessThreadId threadId, ShadowVariable shadow, VectorClock threadVc)
     {
         if (shadow.HasReadVectorClock)

--- a/src/Extensibility/SharpDetect.Plugins.DataRace.FastTrack/ShadowVariable.cs
+++ b/src/Extensibility/SharpDetect.Plugins.DataRace.FastTrack/ShadowVariable.cs
@@ -1,8 +1,6 @@
 // Copyright 2026 Andrej Čižmárik and Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-using SharpDetect.Core.Plugins;
-
 namespace SharpDetect.Plugins.DataRace.FastTrack;
 
 internal sealed class ShadowVariable
@@ -10,34 +8,23 @@ internal sealed class ShadowVariable
     public Epoch WriteEpoch { get; private set; }
     public Epoch ReadEpoch { get; private set; }
     public VectorClock? ReadVectorClock { get; private set; }
-    public ProcessThreadId? ExclusiveWriteThread { get; private set; }
+    public WriteKind LastWriteKind { get; private set; }
     public bool HasReadVectorClock => ReadVectorClock != null;
-    private bool _hasMultipleWriters;
 
     private ShadowVariable()
     {
         WriteEpoch = Epoch.None;
         ReadEpoch = Epoch.None;
         ReadVectorClock = null;
-        ExclusiveWriteThread = null;
+        LastWriteKind = WriteKind.Regular;
     }
 
     public static ShadowVariable CreateVirgin() => new();
 
-    public void SetWrite(Epoch epoch)
+    public void SetWrite(Epoch epoch, WriteKind kind)
     {
         WriteEpoch = epoch;
-        
-        if (!_hasMultipleWriters)
-        {
-            if (ExclusiveWriteThread == null)
-                ExclusiveWriteThread = epoch.ThreadId;
-            else if (ExclusiveWriteThread != epoch.ThreadId)
-            {
-                ExclusiveWriteThread = null;
-                _hasMultipleWriters = true;
-            }
-        }
+        LastWriteKind = kind;
     }
 
     public void SetRead(Epoch epoch)
@@ -49,32 +36,6 @@ internal sealed class ShadowVariable
     public void ExpandReadToVectorClock(VectorClock vc)
     {
         ReadVectorClock = vc;
-    }
-
-    public string GetStateDescription()
-    {
-        var writeStr = WriteEpoch.IsNone ? "W:⊥" : $"W:{WriteEpoch}";
-        string readStr;
-        if (HasReadVectorClock)
-            readStr = "R:VC";
-        else if (ReadEpoch.IsNone)
-            readStr = "R:⊥";
-        else
-            readStr = $"R:{ReadEpoch}";
-        return $"[{writeStr}, {readStr}]";
-    }
-
-    public string GetStateDescription(Func<ProcessThreadId, string?> threadNameResolver)
-    {
-        var writeStr = WriteEpoch.IsNone ? "W:⊥" : $"W:{WriteEpoch.ToDisplayString(threadNameResolver)}";
-        string readStr;
-        if (HasReadVectorClock)
-            readStr = "R:VC";
-        else if (ReadEpoch.IsNone)
-            readStr = "R:⊥";
-        else
-            readStr = $"R:{ReadEpoch.ToDisplayString(threadNameResolver)}";
-        return $"[{writeStr}, {readStr}]";
     }
 }
 

--- a/src/Extensibility/SharpDetect.Plugins.DataRace.FastTrack/WriteKind.cs
+++ b/src/Extensibility/SharpDetect.Plugins.DataRace.FastTrack/WriteKind.cs
@@ -1,0 +1,11 @@
+// Copyright 2026 Andrej Čižmárik and Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+namespace SharpDetect.Plugins.DataRace.FastTrack;
+
+internal enum WriteKind
+{
+    Regular,
+    Instantiation,
+    MaybeInstantiation
+}

--- a/src/Tests/SharpDetect.E2ETests.Subject/Entrypoint.cs
+++ b/src/Tests/SharpDetect.E2ETests.Subject/Entrypoint.cs
@@ -443,6 +443,27 @@ namespace SharpDetect.E2ETests.Subject
                 case nameof(Test_DataRace_ValueType_Instance_WriteWriteRace):
                     Test_DataRace_ValueType_Instance_WriteWriteRace();
                     break;
+                case nameof(Test_DataRace_ReferenceType_Instance_SingleWriterWriteReadRace):
+                    Test_DataRace_ReferenceType_Instance_SingleWriterWriteReadRace();
+                    break;
+                case nameof(Test_DataRace_ValueType_Instance_SingleWriterWriteReadRace):
+                    Test_DataRace_ValueType_Instance_SingleWriterWriteReadRace();
+                    break;
+                case nameof(Test_DataRace_AutoProperty_Instance_PostPublicationWriteReadRace):
+                    Test_DataRace_AutoProperty_Instance_PostPublicationWriteReadRace();
+                    break;
+                case nameof(Test_DataRace_Static_WrittenInInstanceCtor_WriteReadRace):
+                    Test_DataRace_Static_WrittenInInstanceCtor_WriteReadRace();
+                    break;
+                case nameof(Test_DataRace_Static_AutoProperty_WriteReadRace):
+                    Test_DataRace_Static_AutoProperty_WriteReadRace();
+                    break;
+                case nameof(Test_NoDataRace_ConstructorWrite_PublishThenRead):
+                    Test_NoDataRace_ConstructorWrite_PublishThenRead();
+                    break;
+                case nameof(Test_NoDataRace_ConstructorAutoPropertyWrite_PublishThenRead):
+                    Test_NoDataRace_ConstructorAutoPropertyWrite_PublishThenRead();
+                    break;
                 case nameof(Test_NoDataRace_ReferenceType_Static_ReadReadNoRace):
                     Test_NoDataRace_ReferenceType_Static_ReadReadNoRace();
                     break;

--- a/src/Tests/SharpDetect.E2ETests.Subject/Helpers/Concurrency.cs
+++ b/src/Tests/SharpDetect.E2ETests.Subject/Helpers/Concurrency.cs
@@ -7,6 +7,8 @@ namespace SharpDetect.E2ETests.Subject.Helpers.DataRaces
     {
         public static object? Test_DataRace_ReferenceType_Static;
         public static int Test_DataRace_ValueType_Static;
+        public static int Test_DataRace_ValueType_StaticWrittenInCtor;
+        public static int Test_DataRace_ValueType_StaticProperty { get; set; }
         public static volatile int Test_Volatile_ValueType_Static;
         [ThreadStatic]
         public static object? Test_ThreadStatic_ReferenceType;
@@ -14,8 +16,30 @@ namespace SharpDetect.E2ETests.Subject.Helpers.DataRaces
         public static int Test_ThreadStatic_ValueType;
         public static Action? Test_StaticDelegate;
         
-        public object? Test_DataRace_ReferenceType_Instance;
-        public int Test_DataRace_ValueType_Instance;
+        public object? Test_DataRace_ReferenceType_InstanceField;
+        public object? Test_DataRace_ReferenceType_InstanceProperty { get; set; }
+        public int Test_DataRace_ValueType_InstanceField;
+        public int Test_DataRace_ValueType_InstanceProperty { get; set; }
         public volatile int Test_Volatile_ValueType_Instance;
+
+        public DataRace()
+        {
+            
+        }
+
+        public DataRace(int value, object referenceValue, bool setProperties)
+        {
+            if (setProperties)
+            {
+                Test_DataRace_ValueType_InstanceProperty = value;
+                Test_DataRace_ReferenceType_InstanceProperty = referenceValue;
+            }
+            else
+            {
+                Test_DataRace_ValueType_InstanceField = value;
+                Test_DataRace_ReferenceType_InstanceField = referenceValue;
+                Test_DataRace_ValueType_StaticWrittenInCtor = value;
+            }
+        }
     }
 }

--- a/src/Tests/SharpDetect.E2ETests.Subject/SimpleTests.cs
+++ b/src/Tests/SharpDetect.E2ETests.Subject/SimpleTests.cs
@@ -1019,18 +1019,18 @@ namespace SharpDetect.E2ETests.Subject
 
         public static void Test_DataRace_ReferenceType_Instance_ReadWriteRace()
         {
-            var instance = new DataRace { Test_DataRace_ReferenceType_Instance = new object() };
+            var instance = new DataRace { Test_DataRace_ReferenceType_InstanceField = new object() };
             RunConcurrently(
-                () => _ = instance.Test_DataRace_ReferenceType_Instance,
-                () => instance.Test_DataRace_ReferenceType_Instance = new object());
+                () => _ = instance.Test_DataRace_ReferenceType_InstanceField,
+                () => instance.Test_DataRace_ReferenceType_InstanceField = new object());
         }
 
         public static void Test_DataRace_ValueType_Instance_ReadWriteRace()
         {
-            var instance = new DataRace { Test_DataRace_ValueType_Instance = 0 };
+            var instance = new DataRace { Test_DataRace_ValueType_InstanceField = 0 };
             RunConcurrently(
-                () => _ = instance.Test_DataRace_ValueType_Instance,
-                () => instance.Test_DataRace_ValueType_Instance = 123);
+                () => _ = instance.Test_DataRace_ValueType_InstanceField,
+                () => instance.Test_DataRace_ValueType_InstanceField = 123);
         }
 
         public static void Test_DataRace_ReferenceType_Static_WriteReadRace()
@@ -1049,20 +1049,34 @@ namespace SharpDetect.E2ETests.Subject
                 () => _ = DataRace.Test_DataRace_ValueType_Static);
         }
 
+        public static void Test_DataRace_Static_WrittenInInstanceCtor_WriteReadRace()
+        {
+            RunConcurrently(
+                () => _ = new DataRace(123, new object(), setProperties: false),
+                () => _ = DataRace.Test_DataRace_ValueType_StaticWrittenInCtor);
+        }
+
+        public static void Test_DataRace_Static_AutoProperty_WriteReadRace()
+        {
+            RunConcurrently(
+                () => DataRace.Test_DataRace_ValueType_StaticProperty = 99,
+                () => _ = DataRace.Test_DataRace_ValueType_StaticProperty);
+        }
+
         public static void Test_DataRace_ReferenceType_Instance_WriteReadRace()
         {
-            var instance = new DataRace { Test_DataRace_ReferenceType_Instance = new object() };
+            var instance = new DataRace { Test_DataRace_ReferenceType_InstanceField = new object() };
             RunConcurrently(
-                () => instance.Test_DataRace_ReferenceType_Instance = new object(),
-                () => _ = instance.Test_DataRace_ReferenceType_Instance);
+                () => instance.Test_DataRace_ReferenceType_InstanceField = new object(),
+                () => _ = instance.Test_DataRace_ReferenceType_InstanceField);
         }
 
         public static void Test_DataRace_ValueType_Instance_WriteReadRace()
         {
-            var instance = new DataRace { Test_DataRace_ValueType_Instance = 0 };
+            var instance = new DataRace { Test_DataRace_ValueType_InstanceField = 0 };
             RunConcurrently(
-                () => instance.Test_DataRace_ValueType_Instance = 123,
-                () => _ = instance.Test_DataRace_ValueType_Instance);
+                () => instance.Test_DataRace_ValueType_InstanceField = 123,
+                () => _ = instance.Test_DataRace_ValueType_InstanceField);
         }
 
         public static void Test_NoDataRace_ReferenceType_Static_ReadReadNoRace()
@@ -1083,34 +1097,74 @@ namespace SharpDetect.E2ETests.Subject
 
         public static void Test_DataRace_ReferenceType_Instance_WriteWriteRace()
         {
-            var instance = new DataRace { Test_DataRace_ReferenceType_Instance = new object() };
+            var instance = new DataRace { Test_DataRace_ReferenceType_InstanceField = new object() };
             RunConcurrently(
-                () => instance.Test_DataRace_ReferenceType_Instance = new object(),
-                () => instance.Test_DataRace_ReferenceType_Instance = new object());
+                () => instance.Test_DataRace_ReferenceType_InstanceField = new object(),
+                () => instance.Test_DataRace_ReferenceType_InstanceField = new object());
         }
 
         public static void Test_DataRace_ValueType_Instance_WriteWriteRace()
         {
-            var instance = new DataRace { Test_DataRace_ValueType_Instance = 0 };
+            var instance = new DataRace { Test_DataRace_ValueType_InstanceField = 0 };
             RunConcurrently(
-                () => instance.Test_DataRace_ValueType_Instance = 123,
-                () => instance.Test_DataRace_ValueType_Instance = 456);
+                () => instance.Test_DataRace_ValueType_InstanceField = 123,
+                () => instance.Test_DataRace_ValueType_InstanceField = 456);
+        }
+
+        public static void Test_DataRace_ReferenceType_Instance_SingleWriterWriteReadRace()
+        {
+            var instance = new DataRace();
+            RunConcurrently(
+                () => instance.Test_DataRace_ReferenceType_InstanceField = new object(),
+                () => _ = instance.Test_DataRace_ReferenceType_InstanceField);
+        }
+
+        public static void Test_DataRace_ValueType_Instance_SingleWriterWriteReadRace()
+        {
+            var instance = new DataRace();
+            RunConcurrently(
+                () => instance.Test_DataRace_ValueType_InstanceField = 123,
+                () => _ = instance.Test_DataRace_ValueType_InstanceField);
+        }
+
+        public static void Test_DataRace_AutoProperty_Instance_PostPublicationWriteReadRace()
+        {
+            var instance = new DataRace(42, new object(), setProperties: true);
+            RunConcurrently(
+                () => instance.Test_DataRace_ValueType_InstanceProperty = 99,
+                () => _ = instance.Test_DataRace_ValueType_InstanceProperty);
+        }
+
+        public static void Test_NoDataRace_ConstructorWrite_PublishThenRead()
+        {
+            var instance = new DataRace(42, new object(), setProperties: false);
+            RunConcurrently(
+                () => _ = instance.Test_DataRace_ValueType_InstanceField,
+                () => _ = instance.Test_DataRace_ValueType_InstanceField);
+        }
+
+        public static void Test_NoDataRace_ConstructorAutoPropertyWrite_PublishThenRead()
+        {
+            var instance = new DataRace(42, new object(), setProperties: true);
+            RunConcurrently(
+                () => _ = instance.Test_DataRace_ValueType_InstanceProperty,
+                () => _ = instance.Test_DataRace_ValueType_InstanceProperty);
         }
 
         public static void Test_NoDataRace_ReferenceType_Instance_ReadReadNoRace()
         {
-            var instance = new DataRace { Test_DataRace_ReferenceType_Instance = new object() };
+            var instance = new DataRace { Test_DataRace_ReferenceType_InstanceField = new object() };
             RunConcurrently(
-                () => _ = instance.Test_DataRace_ReferenceType_Instance,
-                () => _ = instance.Test_DataRace_ReferenceType_Instance);
+                () => _ = instance.Test_DataRace_ReferenceType_InstanceField,
+                () => _ = instance.Test_DataRace_ReferenceType_InstanceField);
         }
 
         public static void Test_NoDataRace_ValueType_Instance_ReadReadNoRace()
         {
-            var instance = new DataRace { Test_DataRace_ValueType_Instance = 123 };
+            var instance = new DataRace { Test_DataRace_ValueType_InstanceField = 123 };
             RunConcurrently(
-                () => _ = instance.Test_DataRace_ValueType_Instance,
-                () => _ = instance.Test_DataRace_ValueType_Instance);
+                () => _ = instance.Test_DataRace_ValueType_InstanceField,
+                () => _ = instance.Test_DataRace_ValueType_InstanceField);
         }
 
         public static void Test_NoDataRace_ThreadStatic_ReferenceType()
@@ -1165,8 +1219,8 @@ namespace SharpDetect.E2ETests.Subject
         {
             var dataRace = new DataRace();
             RunConcurrently(
-                () => Volatile.Read(ref dataRace.Test_DataRace_ValueType_Instance), 
-                () => Volatile.Write(ref dataRace.Test_DataRace_ValueType_Instance, 123));
+                () => Volatile.Read(ref dataRace.Test_DataRace_ValueType_InstanceField), 
+                () => Volatile.Write(ref dataRace.Test_DataRace_ValueType_InstanceField, 123));
         }
         
         public static void Test_NoDataRace_Task_WriteInsideTask_ReadAfterTaskJoin()

--- a/src/Tests/SharpDetect.E2ETests/DataRacePluginTests.cs
+++ b/src/Tests/SharpDetect.E2ETests/DataRacePluginTests.cs
@@ -65,6 +65,41 @@ public class DataRacePluginTests(ITestOutputHelper testOutput)
         => AssertDetectsDataRace("Test_DataRace_ValueType_Instance_WriteWriteRace", sdk, plugin);
 
     [Theory]
+    [MemberData(nameof(SdkVersions.AllWithFastTrackOnly), MemberType = typeof(SdkVersions))]
+    public Task CanDetectDataRace_ReferenceType_Instance_SingleWriterWriteReadRace(string sdk, string plugin)
+        => AssertDetectsDataRace("Test_DataRace_ReferenceType_Instance_SingleWriterWriteReadRace", sdk, plugin);
+
+    [Theory]
+    [MemberData(nameof(SdkVersions.AllWithFastTrackOnly), MemberType = typeof(SdkVersions))]
+    public Task CanDetectDataRace_ValueType_Instance_SingleWriterWriteReadRace(string sdk, string plugin)
+        => AssertDetectsDataRace("Test_DataRace_ValueType_Instance_SingleWriterWriteReadRace", sdk, plugin);
+
+    [Theory]
+    [MemberData(nameof(SdkVersions.AllWithFastTrackOnly), MemberType = typeof(SdkVersions))]
+    public Task CanDetectDataRace_AutoProperty_Instance_PostPublicationWriteReadRace(string sdk, string plugin)
+        => AssertDetectsDataRace("Test_DataRace_AutoProperty_Instance_PostPublicationWriteReadRace", sdk, plugin);
+
+    [Theory]
+    [MemberData(nameof(SdkVersions.AllWithFastTrackOnly), MemberType = typeof(SdkVersions))]
+    public Task CanDetectDataRace_Static_WrittenInInstanceCtor_WriteReadRace(string sdk, string plugin)
+        => AssertDetectsDataRace("Test_DataRace_Static_WrittenInInstanceCtor_WriteReadRace", sdk, plugin);
+
+    [Theory]
+    [MemberData(nameof(SdkVersions.AllWithFastTrackOnly), MemberType = typeof(SdkVersions))]
+    public Task CanDetectDataRace_Static_AutoProperty_WriteReadRace(string sdk, string plugin)
+        => AssertDetectsDataRace("Test_DataRace_Static_AutoProperty_WriteReadRace", sdk, plugin);
+
+    [Theory]
+    [MemberData(nameof(SdkVersions.AllWithFastTrackOnly), MemberType = typeof(SdkVersions))]
+    public Task NoDataRace_ConstructorWrite_PublishThenRead(string sdk, string plugin)
+        => AssertDoesNotDetectDataRace("Test_NoDataRace_ConstructorWrite_PublishThenRead", sdk, plugin);
+
+    [Theory]
+    [MemberData(nameof(SdkVersions.AllWithFastTrackOnly), MemberType = typeof(SdkVersions))]
+    public Task NoDataRace_ConstructorAutoPropertyWrite_PublishThenRead(string sdk, string plugin)
+        => AssertDoesNotDetectDataRace("Test_NoDataRace_ConstructorAutoPropertyWrite_PublishThenRead", sdk, plugin);
+
+    [Theory]
     [MemberData(nameof(SdkVersions.AllWithBothDataRacePlugins), MemberType = typeof(SdkVersions))]
     public Task NoDataRace_ReferenceType_Static_ReadReadNoRace(string sdk, string plugin)
         => AssertDoesNotDetectDataRace("Test_NoDataRace_ReferenceType_Static_ReadReadNoRace", sdk, plugin);

--- a/src/Tests/SharpDetect.E2ETests/TestProjectIntegrationTests.cs
+++ b/src/Tests/SharpDetect.E2ETests/TestProjectIntegrationTests.cs
@@ -21,7 +21,7 @@ public class TestProjectIntegrationTests(ITestOutputHelper testOutput)
     private const string VsTestRelativePath =
         "../../../../../Samples/SimpleDataRaceTestsVSTest/bin/%BUILD_CONFIGURATION%/%SDK%/SimpleDataRaceTestsVSTest.dll";
 
-    private static readonly string[] SkipSystemAssemblies = [ "System.", "Microsoft.", "TUnit.", "xunit." ];
+    private static readonly string[] SkipSystemAssemblies = [ "System.", "Microsoft.", "TUnit.", "xunit.", "Newtonsoft." ];
 
     [Fact]
     public Task Mtp_RaceFact_Detects_Race()


### PR DESCRIPTION
This PR improves FastTrack's object publication heuristics to reduce false positives:

* Constructor detection: Track whether objects are instantiated in instance vs static constructors, exempting constructor writes from race analysis on unpublished objects
* Auto-property backing fields: Recognize compiler-generated auto-property backing fields for proper write classification
* Escape analysis: Refine heuristics for determining when objects escape their instantiating thread