### PR TITLE
Fix lock and semaphore release timing in reordering pipeline

### DIFF
--- a/src/Extensibility/SharpDetect.PluginHost/Services/Strategies/ReorderingPluginHost.cs
+++ b/src/Extensibility/SharpDetect.PluginHost/Services/Strategies/ReorderingPluginHost.cs
@@ -32,8 +32,12 @@ internal sealed class ReorderingPluginHost(IPluginHost inner, ILogger<Reordering
         
         var topResult = ProcessOne(thread, recordedEvent);
         if (topResult == RecordedEventState.Deferred)
+        {
             thread.EnqueuePendingEvent(recordedEvent);
-        
+            if (thread.PendingQueueCount % 64 == 0)
+                LogLargePendingQueue(thread);
+        }
+
         if (topResult == RecordedEventState.Failed)
             return RecordedEventState.Failed;
 
@@ -239,7 +243,7 @@ internal sealed class ReorderingPluginHost(IPluginHost inner, ILogger<Reordering
         if (!TryPeekTarget(thread, out var semaphoreId))
             return inner.ProcessEvent(recordedEvent);
 
-        if (success && !_semaphores[semaphoreId].TryAcquire(tid))
+        if (success && _semaphores.TryGetValue(semaphoreId, out var shadow) && !shadow.TryAcquire(tid))
             return Defer(thread, semaphoreId);
         
         thread.SyncTargetStack.Pop();
@@ -255,8 +259,11 @@ internal sealed class ReorderingPluginHost(IPluginHost inner, ILogger<Reordering
         thread.PendingReleaseCount = null;
 
         var result = inner.ProcessEvent(recordedEvent);
-        foreach (var waiter in _semaphores[semaphoreId].Release(tid, count))
-            _drainQueue.Enqueue(waiter);
+        if (_semaphores.TryGetValue(semaphoreId, out var shadow))
+        {
+            foreach (var waiter in shadow.Release(tid, count))
+                _drainQueue.Enqueue(waiter);
+        }
         return result;
     }
 
@@ -347,6 +354,8 @@ internal sealed class ReorderingPluginHost(IPluginHost inner, ILogger<Reordering
             {
                 if (shadowLock.TryDescribeResidualState(out var description))
                     logger.LogWarning("Lock {Lock} garbage collected with residual state: {State}.", key, description);
+                foreach (var waiter in shadowLock.DrainWaiters())
+                    _drainQueue.Enqueue(waiter);
                 _locks.Remove(key);
                 continue;
             }
@@ -355,6 +364,8 @@ internal sealed class ReorderingPluginHost(IPluginHost inner, ILogger<Reordering
             {
                 if (shadowSemaphore.TryDescribeResidualState(out var description))
                     logger.LogWarning("Semaphore {Semaphore} garbage collected with residual state: {State}.", key, description);
+                foreach (var waiter in shadowSemaphore.DrainWaiters())
+                    _drainQueue.Enqueue(waiter);
                 _semaphores.Remove(key);
                 continue;
             }
@@ -363,6 +374,8 @@ internal sealed class ReorderingPluginHost(IPluginHost inner, ILogger<Reordering
             {
                 if (shadowTask.TryDescribeResidualState(out var description))
                     logger.LogWarning("Task {Task} garbage collected with residual state: {State}.", key, description);
+                foreach (var waiter in shadowTask.Complete())
+                    _drainQueue.Enqueue(waiter);
                 _tasks.Remove(key);
             }
         }
@@ -407,10 +420,24 @@ internal sealed class ReorderingPluginHost(IPluginHost inner, ILogger<Reordering
             _drainQueue.Enqueue(waiter.Value);
     }
 
+    private void LogLargePendingQueue(ShadowThread thread)
+    {
+        var targetKind = thread.BlockedOn is not { } target ? "none"
+            : _locks.ContainsKey(target) ? "lock"
+            : _semaphores.ContainsKey(target) ? "semaphore"
+            : _tasks.ContainsKey(target) ? "task"
+            : _pendingThreadStartWaiters.ContainsKey(target) ? "thread-start"
+            : "missing-shadow";
+
+        logger.LogWarning(
+            "Thread {Thread}'s pending queue has {Count} deferred events; blocked on {Target} ({TargetKind}).",
+            thread.Id, thread.PendingQueueCount, thread.BlockedOn, targetKind);
+    }
+
     private ShadowThread GetOrCreateThread(ProcessThreadId tid)
     {
         if (!_threads.TryGetValue(tid, out var thread))
-            _threads[tid] = thread = new ShadowThread(tid, logger);
+            _threads[tid] = thread = new ShadowThread(tid);
         return thread;
     }
 

--- a/src/Extensibility/SharpDetect.PluginHost/Services/Strategies/ReorderingPluginHost.cs
+++ b/src/Extensibility/SharpDetect.PluginHost/Services/Strategies/ReorderingPluginHost.cs
@@ -117,9 +117,16 @@ internal sealed class ReorderingPluginHost(IPluginHost inner, ILogger<Reordering
 
             case RecordedEventType.SemaphoreRelease:
             {
-                thread.SyncTargetStack.Push(ReadTargetId(enter.ArgumentValues, tid.ProcessId));
-                thread.PendingReleaseCount = MemoryMarshal.Read<int>(enter.ArgumentValues.AsSpan()[(byte)nint.Size..]);
-                return inner.ProcessEvent(recordedEvent);
+                var semaphoreId = ReadTargetId(enter.ArgumentValues, tid.ProcessId);
+                var count = MemoryMarshal.Read<int>(enter.ArgumentValues.AsSpan()[(byte)nint.Size..]);
+
+                var result = inner.ProcessEvent(recordedEvent);
+                if (_semaphores.TryGetValue(semaphoreId, out var shadow))
+                {
+                    foreach (var waiter in shadow.Release(tid, count))
+                        _drainQueue.Enqueue(waiter);
+                }
+                return result;
             }
 
             case RecordedEventType.TaskStart:
@@ -198,7 +205,7 @@ internal sealed class ReorderingPluginHost(IPluginHost inner, ILogger<Reordering
                 return HandleSemaphoreAcquireResult(recordedEvent, tid, thread, ReadBoolOrDefault(returnValue, byRefArgumentValues, true));
 
             case RecordedEventType.SemaphoreReleaseResult:
-                return HandleSemaphoreReleaseResult(recordedEvent, tid, thread);
+                return inner.ProcessEvent(recordedEvent);
 
             case RecordedEventType.TaskComplete:
                 return HandleTaskComplete(recordedEvent, thread);
@@ -251,23 +258,6 @@ internal sealed class ReorderingPluginHost(IPluginHost inner, ILogger<Reordering
         
         thread.SyncTargetStack.Pop();
         return inner.ProcessEvent(recordedEvent);
-    }
-
-    private RecordedEventState HandleSemaphoreReleaseResult(RecordedEvent recordedEvent, ProcessThreadId tid, ShadowThread thread)
-    {
-        if (!TryPopTarget(thread, out var semaphoreId))
-            return inner.ProcessEvent(recordedEvent);
-
-        var count = thread.PendingReleaseCount!.Value;
-        thread.PendingReleaseCount = null;
-
-        var result = inner.ProcessEvent(recordedEvent);
-        if (_semaphores.TryGetValue(semaphoreId, out var shadow))
-        {
-            foreach (var waiter in shadow.Release(tid, count))
-                _drainQueue.Enqueue(waiter);
-        }
-        return result;
     }
 
     private RecordedEventState HandleTaskComplete(RecordedEvent recordedEvent, ShadowThread thread)
@@ -340,8 +330,44 @@ internal sealed class ReorderingPluginHost(IPluginHost inner, ILogger<Reordering
                 _drainQueue.Enqueue(waiter);
         }
 
+        if (_threads.TryGetValue(destroyedTid, out var destroyedThread) && destroyedThread.PendingQueueCount > 0)
+            HandleDestroyedThreadPendingQueue(pid, destroyedTid, destroyedThread);
+
         _threads.Remove(destroyedTid);
         return inner.ProcessEvent(recordedEvent);
+    }
+
+    private void HandleDestroyedThreadPendingQueue(uint pid, ProcessThreadId destroyedTid, ShadowThread destroyedThread)
+    {
+        var (targetKind, residualState) = DescribeBlockingShadow(destroyedThread.BlockedOn);
+        logger.LogError(
+            "Thread {Thread} destroyed with {Count} undelivered deferred events; blocked on {Target} ({TargetKind}) for {BlockedFor}; shadow state: {State}.",
+            destroyedTid,
+            destroyedThread.PendingQueueCount,
+            destroyedThread.BlockedOn,
+            targetKind,
+            Stopwatch.GetElapsedTime(destroyedThread.BlockedSinceTimestamp),
+            residualState);
+
+        // The dropped queue may carry a deferred ThreadStartCore for a child
+        foreach (var pending in destroyedThread.PendingEvents)
+        {
+            if (pending.EventArgs is not MethodEnterWithArgumentsRecordedEvent enter ||
+                (RecordedEventType)enter.Interpretation != RecordedEventType.ThreadStartCore)
+                continue;
+
+            var startedObjectId = ReadTargetId(enter.ArgumentValues, pid);
+            _pendingThreadStarts.Remove(startedObjectId);
+            if (_pendingThreadStartWaiters.Remove(startedObjectId, out var childThread))
+            {
+                logger.LogWarning(
+                    "Thread {Parent} destroyed before its deferred ThreadStartCore for tracked object {Object} was processed; waking blocked child {Child}.",
+                    destroyedTid,
+                    startedObjectId,
+                    childThread.Id);
+                _drainQueue.Enqueue(childThread.Id);
+            }
+        }
     }
 
     private RecordedEventState HandleGarbageCollectedTrackedObjects(

--- a/src/Extensibility/SharpDetect.PluginHost/Services/Strategies/ReorderingPluginHost.cs
+++ b/src/Extensibility/SharpDetect.PluginHost/Services/Strategies/ReorderingPluginHost.cs
@@ -1,6 +1,7 @@
 // Copyright 2026 Andrej Čižmárik and Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+using System.Diagnostics;
 using System.Runtime.InteropServices;
 using Microsoft.Extensions.Logging;
 using SharpDetect.Core.Events;
@@ -34,8 +35,11 @@ internal sealed class ReorderingPluginHost(IPluginHost inner, ILogger<Reordering
         if (topResult == RecordedEventState.Deferred)
         {
             thread.EnqueuePendingEvent(recordedEvent);
-            if (thread.PendingQueueCount % 64 == 0)
+            if (thread.PendingQueueCount >= thread.NextPendingQueueWarningCount)
+            {
                 LogLargePendingQueue(thread);
+                thread.NextPendingQueueWarningCount *= 2;
+            }
         }
 
         if (topResult == RecordedEventState.Failed)
@@ -92,13 +96,24 @@ internal sealed class ReorderingPluginHost(IPluginHost inner, ILogger<Reordering
             case RecordedEventType.MonitorLockTryAcquire:
             case RecordedEventType.LockAcquire:
             case RecordedEventType.LockTryAcquire:
-            case RecordedEventType.MonitorLockRelease:
-            case RecordedEventType.LockRelease:
             case RecordedEventType.SemaphoreAcquire:
             case RecordedEventType.SemaphoreTryAcquire:
             case RecordedEventType.TaskJoinStart:
                 thread.SyncTargetStack.Push(ReadTargetId(enter.ArgumentValues, tid.ProcessId));
                 return inner.ProcessEvent(recordedEvent);
+
+            case RecordedEventType.MonitorLockRelease:
+            case RecordedEventType.LockRelease:
+            {
+                var lockId = ReadTargetId(enter.ArgumentValues, tid.ProcessId);
+                var lockTaken = enter.ArgumentValues.Length <= nint.Size ||
+                    MemoryMarshal.Read<bool>(enter.ArgumentValues.AsSpan()[nint.Size..]);
+
+                var result = inner.ProcessEvent(recordedEvent);
+                if (lockTaken && _locks.TryGetValue(lockId, out var shadow))
+                    EnqueueDrain(shadow.Release(tid));
+                return result;
+            }
 
             case RecordedEventType.SemaphoreRelease:
             {
@@ -174,7 +189,7 @@ internal sealed class ReorderingPluginHost(IPluginHost inner, ILogger<Reordering
 
             case RecordedEventType.MonitorLockReleaseResult:
             case RecordedEventType.LockReleaseResult:
-                return HandleReleaseResult(recordedEvent, tid, thread);
+                return inner.ProcessEvent(recordedEvent);
 
             case RecordedEventType.MonitorWaitResult:
                 return HandleWaitResult(recordedEvent, tid, thread);
@@ -209,18 +224,6 @@ internal sealed class ReorderingPluginHost(IPluginHost inner, ILogger<Reordering
         
         thread.SyncTargetStack.Pop();
         return inner.ProcessEvent(recordedEvent);
-    }
-
-    private RecordedEventState HandleReleaseResult(RecordedEvent recordedEvent, ProcessThreadId tid, ShadowThread thread)
-    {
-        if (!TryPopTarget(thread, out var lockId))
-            return inner.ProcessEvent(recordedEvent);
-
-        var result = inner.ProcessEvent(recordedEvent);
-        if (_locks.TryGetValue(lockId, out var shadow))
-            EnqueueDrain(shadow.Release(tid));
-        
-        return result;
     }
 
     private RecordedEventState HandleWaitResult(RecordedEvent recordedEvent, ProcessThreadId tid, ShadowThread thread)
@@ -404,6 +407,9 @@ internal sealed class ReorderingPluginHost(IPluginHost inner, ILogger<Reordering
                 
                 thread.DequeuePendingEvent();
             }
+
+            if (thread.PendingQueueCount == 0)
+                thread.NextPendingQueueWarningCount = ShadowThread.InitialPendingQueueWarningThreshold;
         }
         return RecordedEventState.Executed;
     }
@@ -422,16 +428,26 @@ internal sealed class ReorderingPluginHost(IPluginHost inner, ILogger<Reordering
 
     private void LogLargePendingQueue(ShadowThread thread)
     {
-        var targetKind = thread.BlockedOn is not { } target ? "none"
-            : _locks.ContainsKey(target) ? "lock"
-            : _semaphores.ContainsKey(target) ? "semaphore"
-            : _tasks.ContainsKey(target) ? "task"
-            : _pendingThreadStartWaiters.ContainsKey(target) ? "thread-start"
-            : "missing-shadow";
-
+        var (targetKind, residualState) = DescribeBlockingShadow(thread.BlockedOn);
         logger.LogWarning(
-            "Thread {Thread}'s pending queue has {Count} deferred events; blocked on {Target} ({TargetKind}).",
-            thread.Id, thread.PendingQueueCount, thread.BlockedOn, targetKind);
+            "Thread {Thread}'s pending queue has {Count} deferred events; blocked on {Target} ({TargetKind}) for {BlockedFor}; shadow state: {State}.",
+            thread.Id, thread.PendingQueueCount, thread.BlockedOn, targetKind,
+            Stopwatch.GetElapsedTime(thread.BlockedSinceTimestamp), residualState);
+    }
+
+    private (string Kind, string ResidualState) DescribeBlockingShadow(ProcessTrackedObjectId? blockedOn)
+    {
+        if (blockedOn is not { } target)
+            return ("none", "none");
+        if (_locks.TryGetValue(target, out var shadowLock))
+            return ("lock", shadowLock.TryDescribeResidualState(out var state) ? state : "clean");
+        if (_semaphores.TryGetValue(target, out var shadowSemaphore))
+            return ("semaphore", shadowSemaphore.TryDescribeResidualState(out var state) ? state : "clean");
+        if (_tasks.TryGetValue(target, out var shadowTask))
+            return ("task", shadowTask.TryDescribeResidualState(out var state) ? state : "clean");
+        if (_pendingThreadStartWaiters.ContainsKey(target))
+            return ("thread-start", "waiting for parent's ThreadStartCore");
+        return ("missing-shadow", "none");
     }
 
     private ShadowThread GetOrCreateThread(ProcessThreadId tid)
@@ -504,6 +520,20 @@ internal sealed class ReorderingPluginHost(IPluginHost inner, ILogger<Reordering
         if (_isDisposed)
             return;
         _isDisposed = true;
+
+        foreach (var thread in _threads.Values.Where(thread => thread.PendingQueueCount != 0))
+        {
+            var (targetKind, residualState) = DescribeBlockingShadow(thread.BlockedOn);
+            logger.LogError(
+                "Thread {Thread} has {Count} undelivered deferred events at shutdown; blocked on {Target} ({TargetKind}) for {BlockedFor}; shadow state: {State}.",
+                thread.Id,
+                thread.PendingQueueCount,
+                thread.BlockedOn,
+                targetKind,
+                Stopwatch.GetElapsedTime(thread.BlockedSinceTimestamp),
+                residualState);
+        }
+
         if (inner is IDisposable disposable)
             disposable.Dispose();
     }

--- a/src/Extensibility/SharpDetect.PluginHost/Services/Strategies/Shadows/ShadowLock.cs
+++ b/src/Extensibility/SharpDetect.PluginHost/Services/Strategies/Shadows/ShadowLock.cs
@@ -92,6 +92,16 @@ internal sealed class ShadowLock
         _waiters.Remove(tid);
     }
 
+    public IReadOnlyCollection<ProcessThreadId> DrainWaiters()
+    {
+        if (_waiters.Count == 0)
+            return [];
+
+        var result = _waiters.ToArray();
+        _waiters.Clear();
+        return result;
+    }
+
     public bool TryDescribeResidualState([NotNullWhen(true)] out string? description)
     {
         if (Owner is null && _waiters.Count == 0)

--- a/src/Extensibility/SharpDetect.PluginHost/Services/Strategies/Shadows/ShadowSemaphore.cs
+++ b/src/Extensibility/SharpDetect.PluginHost/Services/Strategies/Shadows/ShadowSemaphore.cs
@@ -57,6 +57,16 @@ internal sealed class ShadowSemaphore(int initialCount, int capacity)
         _waiters.Remove(tid);
     }
 
+    public IReadOnlyCollection<ProcessThreadId> DrainWaiters()
+    {
+        if (_waiters.Count == 0)
+            return [];
+
+        var result = _waiters.ToArray();
+        _waiters.Clear();
+        return result;
+    }
+
     public int AbandonPermitsByDestroy(ProcessThreadId tid)
     {
         return _outstandingPermits.Remove(tid, out var held) ? held : 0;

--- a/src/Extensibility/SharpDetect.PluginHost/Services/Strategies/Shadows/ShadowSemaphore.cs
+++ b/src/Extensibility/SharpDetect.PluginHost/Services/Strategies/Shadows/ShadowSemaphore.cs
@@ -28,7 +28,6 @@ internal sealed class ShadowSemaphore(int initialCount, int capacity)
 
     public IReadOnlyList<ProcessThreadId> Release(ProcessThreadId tid, int count)
     {
-        Count += count;
         if (_outstandingPermits.TryGetValue(tid, out var held) && held > 0)
         {
             var decrement = Math.Min(held, count);
@@ -39,7 +38,12 @@ internal sealed class ShadowSemaphore(int initialCount, int capacity)
                 _outstandingPermits[tid] = remaining;
         }
 
-        var wakeCount = Math.Min(count, _waiters.Count);
+        var effectiveCount = Math.Min(count, Capacity - Count);
+        if (effectiveCount <= 0)
+            return [];
+
+        Count += effectiveCount;
+        var wakeCount = Math.Min(effectiveCount, _waiters.Count);
         if (wakeCount == 0)
             return [];
 

--- a/src/Extensibility/SharpDetect.PluginHost/Services/Strategies/Shadows/ShadowThread.cs
+++ b/src/Extensibility/SharpDetect.PluginHost/Services/Strategies/Shadows/ShadowThread.cs
@@ -1,6 +1,7 @@
 // Copyright 2026 Andrej Čižmárik and Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+using System.Diagnostics;
 using SharpDetect.Core.Events;
 using SharpDetect.Core.Plugins;
 
@@ -8,12 +9,16 @@ namespace SharpDetect.PluginHost.Services.Strategies.Shadows;
 
 internal sealed class ShadowThread(ProcessThreadId id)
 {
+    public const int InitialPendingQueueWarningThreshold = 64;
+
     public Stack<ProcessTrackedObjectId> SyncTargetStack { get; } = [];
     public int? SuspendedWaitCount { get; set; }
     public int? PendingReleaseCount { get; set; }
+    public int NextPendingQueueWarningCount { get; set; } = InitialPendingQueueWarningThreshold;
 
     public ProcessThreadId Id { get; } = id;
     public ProcessTrackedObjectId? BlockedOn { get; private set; }
+    public long BlockedSinceTimestamp { get; private set; }
     public int PendingQueueCount => _pendingQueue.Count;
     private readonly Queue<RecordedEvent> _pendingQueue = [];
 
@@ -35,6 +40,7 @@ internal sealed class ShadowThread(ProcessThreadId id)
     public void SetBlockedOn(ProcessTrackedObjectId blockedOn)
     {
         BlockedOn = blockedOn;
+        BlockedSinceTimestamp = Stopwatch.GetTimestamp();
     }
 
     public void ClearBlockedOn()

--- a/src/Extensibility/SharpDetect.PluginHost/Services/Strategies/Shadows/ShadowThread.cs
+++ b/src/Extensibility/SharpDetect.PluginHost/Services/Strategies/Shadows/ShadowThread.cs
@@ -1,13 +1,12 @@
 // Copyright 2026 Andrej Čižmárik and Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-using Microsoft.Extensions.Logging;
 using SharpDetect.Core.Events;
 using SharpDetect.Core.Plugins;
 
 namespace SharpDetect.PluginHost.Services.Strategies.Shadows;
 
-internal sealed class ShadowThread(ProcessThreadId id, ILogger logger)
+internal sealed class ShadowThread(ProcessThreadId id)
 {
     public Stack<ProcessTrackedObjectId> SyncTargetStack { get; } = [];
     public int? SuspendedWaitCount { get; set; }
@@ -21,8 +20,6 @@ internal sealed class ShadowThread(ProcessThreadId id, ILogger logger)
     public void EnqueuePendingEvent(RecordedEvent recordedEvent)
     {
         _pendingQueue.Enqueue(recordedEvent);
-        if (_pendingQueue.Count % 64 == 0)
-            logger.LogWarning("Thread {tid}'s queue {size} is getting too large", Id, _pendingQueue.Count);
     }
 
     public RecordedEvent PeekPendingEvent()

--- a/src/Extensibility/SharpDetect.PluginHost/Services/Strategies/Shadows/ShadowThread.cs
+++ b/src/Extensibility/SharpDetect.PluginHost/Services/Strategies/Shadows/ShadowThread.cs
@@ -13,13 +13,13 @@ internal sealed class ShadowThread(ProcessThreadId id)
 
     public Stack<ProcessTrackedObjectId> SyncTargetStack { get; } = [];
     public int? SuspendedWaitCount { get; set; }
-    public int? PendingReleaseCount { get; set; }
     public int NextPendingQueueWarningCount { get; set; } = InitialPendingQueueWarningThreshold;
 
     public ProcessThreadId Id { get; } = id;
     public ProcessTrackedObjectId? BlockedOn { get; private set; }
     public long BlockedSinceTimestamp { get; private set; }
     public int PendingQueueCount => _pendingQueue.Count;
+    public IEnumerable<RecordedEvent> PendingEvents => _pendingQueue;
     private readonly Queue<RecordedEvent> _pendingQueue = [];
 
     public void EnqueuePendingEvent(RecordedEvent recordedEvent)

--- a/src/Extensibility/SharpDetect.Plugins.PerThreadOrdering/PerThreadOrderingPluginBase.cs
+++ b/src/Extensibility/SharpDetect.Plugins.PerThreadOrdering/PerThreadOrderingPluginBase.cs
@@ -109,24 +109,23 @@ public abstract class PerThreadOrderingPluginBase : PluginBase
     [RecordedEventBind((ushort)RecordedEventType.LockRelease)]
     [RecordedEventBind((ushort)RecordedEventType.MonitorLockRelease)]
     public void OnLockReleaseEnter(RecordedEventMetadata metadata, MethodEnterWithArgumentsRecordedEvent args)
-        => PushArgumentsOnCallStack(metadata, args);
+    {
+        var (id, arguments, lockId) = ExtractSynchronizationContext(metadata, args);
+        _callStackTracker.Push(id, new StackFrame(args.ModuleId, args.MethodToken, arguments));
+        var lockTaken = arguments.Count == 1 || (bool)arguments[1].Value.AsT0;
+        if (lockTaken)
+            ProcessLockRelease(id, args.ModuleId, args.MethodToken, lockId);
+    }
 
     [RecordedEventBind((ushort)RecordedEventType.LockReleaseResult)]
     [RecordedEventBind((ushort)RecordedEventType.MonitorLockReleaseResult)]
     public void OnLockReleaseResultExit(RecordedEventMetadata metadata, MethodExitRecordedEvent args)
-    {
-        var (id, lockId) = PopLockContext(metadata, args);
-        ProcessLockRelease(id, args.ModuleId, args.MethodToken, lockId);
-    }
+        => PopFrame(metadata, args.ModuleId, args.MethodToken);
 
     [RecordedEventBind((ushort)RecordedEventType.LockReleaseResult)]
     [RecordedEventBind((ushort)RecordedEventType.MonitorLockReleaseResult)]
     public void OnLockReleaseResultExit(RecordedEventMetadata metadata, MethodExitWithArgumentsRecordedEvent args)
-    {
-        var (id, lockId, lockTaken) = PopLockContextWithFlag(metadata, args);
-        if (lockTaken)
-            ProcessLockRelease(id, args.ModuleId, args.MethodToken, lockId);
-    }
+        => PopFrame(metadata, args.ModuleId, args.MethodToken);
 
     [RecordedEventBind((ushort)RecordedEventType.MonitorPulseOneAttempt)]
     public void OnMonitorPulseOneAttempt(RecordedEventMetadata metadata, MethodEnterWithArgumentsRecordedEvent args)
@@ -555,16 +554,11 @@ public abstract class PerThreadOrderingPluginBase : PluginBase
         return (id, ExtractSynchronizationObjectIdFromFrame(id, frame));
     }
 
-    private (ProcessThreadId Id, ProcessTrackedObjectId LockId, bool LockTaken) PopLockContextWithFlag(
-        RecordedEventMetadata metadata,
-        MethodExitWithArgumentsRecordedEvent args)
+    private void PopFrame(RecordedEventMetadata metadata, ModuleId moduleId, MdMethodDef methodToken)
     {
         var id = new ProcessThreadId(metadata.Pid, metadata.Tid);
         var frame = _callStackTracker.Pop(id);
-        EnsureCallStackIntegrity(frame, args.ModuleId, args.MethodToken);
-        var lockId = new ProcessTrackedObjectId(id.ProcessId, frame.Arguments!.Value[0].Value.AsT1);
-        var lockTaken = frame.Arguments!.Value.Count == 1 || (bool)frame.Arguments!.Value[1].Value.AsT0;
-        return (id, lockId, lockTaken);
+        EnsureCallStackIntegrity(frame, moduleId, methodToken);
     }
 
     private bool DetermineLockTakenFromExitEvent(RecordedEventMetadata metadata, MethodExitWithArgumentsRecordedEvent args)

--- a/src/Extensibility/SharpDetect.Plugins.PerThreadOrdering/PerThreadOrderingPluginBase.cs
+++ b/src/Extensibility/SharpDetect.Plugins.PerThreadOrdering/PerThreadOrderingPluginBase.cs
@@ -199,18 +199,16 @@ public abstract class PerThreadOrderingPluginBase : PluginBase
 
     [RecordedEventBind((ushort)RecordedEventType.SemaphoreRelease)]
     public void OnSemaphoreReleaseEnter(RecordedEventMetadata metadata, MethodEnterWithArgumentsRecordedEvent args)
-        => PushArgumentsOnCallStack(metadata, args);
+    {
+        var (id, arguments, semaphoreId) = ExtractSynchronizationContext(metadata, args);
+        _callStackTracker.Push(id, new StackFrame(args.ModuleId, args.MethodToken, arguments));
+        var releaseCount = (int)arguments[1].Value.AsT0;
+        SemaphoreReleased?.Invoke(new(id, args.ModuleId, args.MethodToken, semaphoreId, releaseCount));
+    }
 
     [RecordedEventBind((ushort)RecordedEventType.SemaphoreReleaseResult)]
     public void OnSemaphoreReleaseExit(RecordedEventMetadata metadata, MethodExitRecordedEvent args)
-    {
-        var id = new ProcessThreadId(metadata.Pid, metadata.Tid);
-        var frame = _callStackTracker.Pop(id);
-        EnsureCallStackIntegrity(frame, args.ModuleId, args.MethodToken);
-        var semaphoreId = ExtractSynchronizationObjectIdFromFrame(id, frame);
-        var releaseCount = (int)frame.Arguments!.Value[1].Value.AsT0;
-        SemaphoreReleased?.Invoke(new(id, args.ModuleId, args.MethodToken, semaphoreId, releaseCount));
-    }
+        => PopFrame(metadata, args.ModuleId, args.MethodToken);
     
     [RecordedEventBind((ushort)RecordedEventType.ThreadStartCore)]
     public void OnThreadStartCore(RecordedEventMetadata metadata, MethodEnterWithArgumentsRecordedEvent args)

--- a/src/Tests/SharpDetect.PluginHost.Tests/ReorderingPluginHostTests.cs
+++ b/src/Tests/SharpDetect.PluginHost.Tests/ReorderingPluginHostTests.cs
@@ -36,7 +36,7 @@ public class ReorderingPluginHostTests
     }
 
     [Fact]
-    public void ReorderingPluginHost_AcquireExitBeforeReleaseExit_IsDeferred_IsReordered()
+    public void ReorderingPluginHost_AcquireResultAfterReleaseEnter_NotDeferred()
     {
         // Arrange
         var host = Build(out var recorder);
@@ -46,10 +46,10 @@ public class ReorderingPluginHostTests
         host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T2, RecordedEventType.MonitorLockAcquire, L1));
         host.ProcessEvent(SyncEventBuilder.Exit(T2, RecordedEventType.MonitorLockAcquireResult));
         host.ProcessEvent(SyncEventBuilder.FieldRead(T2));
-        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T2, RecordedEventType.MonitorLockRelease, L1));
-        host.ProcessEvent(SyncEventBuilder.Exit(T1, RecordedEventType.MonitorLockAcquireResult)); // arrives too early
-        host.ProcessEvent(SyncEventBuilder.FieldRead(T1)); // arrives too early
-        host.ProcessEvent(SyncEventBuilder.Exit(T2, RecordedEventType.MonitorLockReleaseResult)); // unblocks
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T2, RecordedEventType.MonitorLockRelease, L1)); // releases shadow
+        host.ProcessEvent(SyncEventBuilder.Exit(T1, RecordedEventType.MonitorLockAcquireResult));
+        host.ProcessEvent(SyncEventBuilder.FieldRead(T1));
+        host.ProcessEvent(SyncEventBuilder.Exit(T2, RecordedEventType.MonitorLockReleaseResult));
         var kinds = recorder.Dispatched.Select(ClassifyDispatched).ToArray();
         
         // Assert
@@ -60,9 +60,9 @@ public class ReorderingPluginHostTests
             (T2, RecordedEventType.MonitorLockAcquireResult),
             (T2, RecordedEventType.InstanceFieldRead),
             (T2, RecordedEventType.MonitorLockRelease),
-            (T2, RecordedEventType.MonitorLockReleaseResult),
             (T1, RecordedEventType.MonitorLockAcquireResult),
             (T1, RecordedEventType.InstanceFieldRead),
+            (T2, RecordedEventType.MonitorLockReleaseResult),
         }, kinds);
     }
 
@@ -117,15 +117,15 @@ public class ReorderingPluginHostTests
         host.ProcessEvent(SyncEventBuilder.Exit(T2, RecordedEventType.MonitorLockAcquireResult)); // deferred [1st in wake queue]
         host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T3, RecordedEventType.MonitorLockAcquire, L1));
         host.ProcessEvent(SyncEventBuilder.Exit(T3, RecordedEventType.MonitorLockAcquireResult)); // deferred [2nd in wake queue]
-        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.MonitorLockRelease, L1));
-        host.ProcessEvent(SyncEventBuilder.Exit(T1, RecordedEventType.MonitorLockReleaseResult)); // wakes T2
-        var lastT1 = recorder.Dispatched.FindLastIndex(e => e.Metadata.Tid.Value == T1);
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.MonitorLockRelease, L1)); // wakes T2
+        host.ProcessEvent(SyncEventBuilder.Exit(T1, RecordedEventType.MonitorLockReleaseResult));
+        var t1ReleaseEnter = recorder.Dispatched.FindIndex(e => ClassifyDispatched(e) == (T1, RecordedEventType.MonitorLockRelease));
         var firstT2Acq = recorder.Dispatched.FindIndex(e => e.Metadata.Tid.Value == T2 && IsAcquireResult(e));
         host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T2, RecordedEventType.MonitorLockRelease, L1));
         host.ProcessEvent(SyncEventBuilder.Exit(T2, RecordedEventType.MonitorLockReleaseResult));
-        
+
         // Assert
-        Assert.True(firstT2Acq > lastT1, "T2's acquire result should dispatch after T1's release");
+        Assert.True(firstT2Acq > t1ReleaseEnter, "T2's acquire result should dispatch after T1's release enter");
         Assert.Contains(recorder.Dispatched, e => e.Metadata.Tid.Value == T3 && IsAcquireResult(e));
     }
 
@@ -222,7 +222,7 @@ public class ReorderingPluginHostTests
     }
     
     [Fact]
-    public void ReorderingPluginHost_MonitorWaitExitBeforeReleaseExit_IsDeferred_IsReordered()
+    public void ReorderingPluginHost_MonitorWaitResultAfterReleaseEnter_NotDeferred()
     {
         // Arrange
         var host = Build(out var recorder);
@@ -233,17 +233,19 @@ public class ReorderingPluginHostTests
         host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.MonitorWaitAttempt, L1));
         host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T2, RecordedEventType.MonitorLockAcquire, L1));
         host.ProcessEvent(SyncEventBuilder.Exit(T2, RecordedEventType.MonitorLockAcquireResult));
-        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T2, RecordedEventType.MonitorLockRelease, L1));
-        host.ProcessEvent(SyncEventBuilder.ExitWithSuccess(T1, RecordedEventType.MonitorWaitResult, true)); // deferred
-        host.ProcessEvent(SyncEventBuilder.Exit(T2, RecordedEventType.MonitorLockReleaseResult)); // wake up
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T2, RecordedEventType.MonitorLockRelease, L1)); // releases shadow
+        host.ProcessEvent(SyncEventBuilder.ExitWithSuccess(T1, RecordedEventType.MonitorWaitResult, true)); // reacquires immediately
+        host.ProcessEvent(SyncEventBuilder.Exit(T2, RecordedEventType.MonitorLockReleaseResult));
 
         // Assert
         Assert.Equal(8, recorder.Dispatched.Count);
-        Assert.Equal((T1, RecordedEventType.MonitorWaitResult), ClassifyDispatched(recorder.Dispatched.Last()));
+        var releaseEnter = recorder.Dispatched.FindIndex(e => ClassifyDispatched(e) == (T2, RecordedEventType.MonitorLockRelease));
+        var waitResult = recorder.Dispatched.FindIndex(e => ClassifyDispatched(e) == (T1, RecordedEventType.MonitorWaitResult));
+        Assert.True(waitResult > releaseEnter, "T1's wait result should dispatch after T2's release enter");
     }
-    
+
     [Fact]
-    public void ReorderingPluginHost_FailedMonitorWait_IsDeferred_IsReordered()
+    public void ReorderingPluginHost_FailedMonitorWaitResultAfterReleaseEnter_NotDeferred()
     {
         // Arrange
         var host = Build(out var recorder);
@@ -254,13 +256,15 @@ public class ReorderingPluginHostTests
         host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.MonitorWaitAttempt, L1));
         host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T2, RecordedEventType.MonitorLockAcquire, L1));
         host.ProcessEvent(SyncEventBuilder.Exit(T2, RecordedEventType.MonitorLockAcquireResult));
-        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T2, RecordedEventType.MonitorLockRelease, L1));
-        host.ProcessEvent(SyncEventBuilder.ExitWithSuccess(T1, RecordedEventType.MonitorWaitResult, false)); // deferred — wait timeout still reacquires
-        host.ProcessEvent(SyncEventBuilder.Exit(T2, RecordedEventType.MonitorLockReleaseResult)); // wakes T1
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T2, RecordedEventType.MonitorLockRelease, L1)); // releases shadow
+        host.ProcessEvent(SyncEventBuilder.ExitWithSuccess(T1, RecordedEventType.MonitorWaitResult, false)); // wait timeout still reacquires immediately
+        host.ProcessEvent(SyncEventBuilder.Exit(T2, RecordedEventType.MonitorLockReleaseResult));
 
         // Assert
         Assert.Equal(8, recorder.Dispatched.Count);
-        Assert.Equal((T1, RecordedEventType.MonitorWaitResult), ClassifyDispatched(recorder.Dispatched.Last()));
+        var releaseEnter = recorder.Dispatched.FindIndex(e => ClassifyDispatched(e) == (T2, RecordedEventType.MonitorLockRelease));
+        var waitResult = recorder.Dispatched.FindIndex(e => ClassifyDispatched(e) == (T1, RecordedEventType.MonitorWaitResult));
+        Assert.True(waitResult > releaseEnter, "T1's wait result should dispatch after T2's release enter");
     }
 
     [Fact]
@@ -1004,7 +1008,7 @@ public class ReorderingPluginHostTests
         host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T2, RecordedEventType.MonitorLockTryAcquire, L1));
         host.ProcessEvent(SyncEventBuilder.ExitWithByRefSuccess(T2, RecordedEventType.MonitorLockAcquireResult, success: true)); // deferred
         host.ProcessEvent(SyncEventBuilder.FieldRead(T2)); // deferred
-        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.MonitorLockRelease, L1));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.MonitorLockRelease, L1)); // wakes T2
         host.ProcessEvent(SyncEventBuilder.Exit(T1, RecordedEventType.MonitorLockReleaseResult));
 
         // Assert
@@ -1015,10 +1019,119 @@ public class ReorderingPluginHostTests
             (T1, RecordedEventType.MonitorLockAcquireResult),
             (T2, RecordedEventType.MonitorLockTryAcquire),
             (T1, RecordedEventType.MonitorLockRelease),
-            (T1, RecordedEventType.MonitorLockReleaseResult),
             (T2, RecordedEventType.MonitorLockAcquireResult),
             (T2, RecordedEventType.InstanceFieldRead),
+            (T1, RecordedEventType.MonitorLockReleaseResult),
         }, kinds);
+    }
+
+    [Fact]
+    public void ReorderingPluginHost_ReleaseEnter_WakesWaiter_WithoutReleaseResult()
+    {
+        // Arrange
+        var host = Build(out var recorder);
+
+        // Act & Assert
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.MonitorLockAcquire, L1));
+        host.ProcessEvent(SyncEventBuilder.Exit(T1, RecordedEventType.MonitorLockAcquireResult));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T2, RecordedEventType.MonitorLockAcquire, L1));
+        host.ProcessEvent(SyncEventBuilder.Exit(T2, RecordedEventType.MonitorLockAcquireResult)); // deferred [T1 owns]
+        host.ProcessEvent(SyncEventBuilder.FieldRead(T2)); // also deferred
+        Assert.DoesNotContain(recorder.Dispatched, e => e.Metadata.Tid.Value == T2 && IsAcquireResult(e));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.MonitorLockRelease, L1)); // wakes T2; ReleaseResult never arrives
+        Assert.Contains(recorder.Dispatched, e => e.Metadata.Tid.Value == T2 && IsAcquireResult(e));
+        Assert.Contains(recorder.Dispatched, e => ClassifyDispatched(e) == (T2, RecordedEventType.InstanceFieldRead));
+    }
+
+    [Fact]
+    public void ReorderingPluginHost_ReentrantRelease_OnlyLastReleaseEnterWakesWaiter()
+    {
+        // Arrange
+        var host = Build(out var recorder);
+
+        // Act & Assert
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.MonitorLockAcquire, L1));
+        host.ProcessEvent(SyncEventBuilder.Exit(T1, RecordedEventType.MonitorLockAcquireResult));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.MonitorLockAcquire, L1));
+        host.ProcessEvent(SyncEventBuilder.Exit(T1, RecordedEventType.MonitorLockAcquireResult)); // depth 2
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T2, RecordedEventType.MonitorLockAcquire, L1));
+        host.ProcessEvent(SyncEventBuilder.Exit(T2, RecordedEventType.MonitorLockAcquireResult)); // deferred
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.MonitorLockRelease, L1)); // depth 2 -> 1
+        host.ProcessEvent(SyncEventBuilder.Exit(T1, RecordedEventType.MonitorLockReleaseResult));
+        Assert.DoesNotContain(recorder.Dispatched, e => e.Metadata.Tid.Value == T2 && IsAcquireResult(e));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.MonitorLockRelease, L1)); // depth 1 -> 0, wakes T2
+        Assert.Contains(recorder.Dispatched, e => e.Metadata.Tid.Value == T2 && IsAcquireResult(e));
+    }
+
+    [Fact]
+    public void ReorderingPluginHost_ReleaseEnterFromNonOwner_IsNoOp()
+    {
+        // Arrange
+        var host = Build(out var recorder);
+
+        // Act & Assert
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.MonitorLockAcquire, L1));
+        host.ProcessEvent(SyncEventBuilder.Exit(T1, RecordedEventType.MonitorLockAcquireResult));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T2, RecordedEventType.MonitorLockRelease, L1)); // non-owner; must not free the shadow
+        host.ProcessEvent(SyncEventBuilder.Exit(T2, RecordedEventType.MonitorLockReleaseResult));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T3, RecordedEventType.MonitorLockAcquire, L1));
+        host.ProcessEvent(SyncEventBuilder.Exit(T3, RecordedEventType.MonitorLockAcquireResult)); // deferred [T1 still owns]
+        Assert.DoesNotContain(recorder.Dispatched, e => e.Metadata.Tid.Value == T3 && IsAcquireResult(e));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.MonitorLockRelease, L1)); // owner releases, wakes T3
+        Assert.Contains(recorder.Dispatched, e => e.Metadata.Tid.Value == T3 && IsAcquireResult(e));
+    }
+
+    [Fact]
+    public void ReorderingPluginHost_ExitIfLockTaken_FlagFalse_DoesNotReleaseShadow()
+    {
+        // Arrange
+        var host = Build(out var recorder);
+
+        // Act & Assert
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.MonitorLockAcquire, L1));
+        host.ProcessEvent(SyncEventBuilder.Exit(T1, RecordedEventType.MonitorLockAcquireResult));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTargetAndFlag(T1, RecordedEventType.MonitorLockRelease, L1, flag: false)); // lockTaken == false
+        host.ProcessEvent(SyncEventBuilder.Exit(T1, RecordedEventType.MonitorLockReleaseResult));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T2, RecordedEventType.MonitorLockAcquire, L1));
+        host.ProcessEvent(SyncEventBuilder.Exit(T2, RecordedEventType.MonitorLockAcquireResult)); // deferred [shadow still owned]
+        Assert.DoesNotContain(recorder.Dispatched, e => e.Metadata.Tid.Value == T2 && IsAcquireResult(e));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTargetAndFlag(T1, RecordedEventType.MonitorLockRelease, L1, flag: true)); // wakes T2
+        Assert.Contains(recorder.Dispatched, e => e.Metadata.Tid.Value == T2 && IsAcquireResult(e));
+    }
+
+    [Fact]
+    public void ReorderingPluginHost_Dispose_WithUndeliveredDeferredEvents_LogsError()
+    {
+        // Arrange
+        var host = Build(out _, out var logger);
+
+        // Act
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.MonitorLockAcquire, L1));
+        host.ProcessEvent(SyncEventBuilder.Exit(T1, RecordedEventType.MonitorLockAcquireResult));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T2, RecordedEventType.MonitorLockAcquire, L1));
+        host.ProcessEvent(SyncEventBuilder.Exit(T2, RecordedEventType.MonitorLockAcquireResult)); // deferred, never delivered
+        host.Dispose();
+
+        // Assert
+        Assert.Contains(logger.Entries, e => e.Level == LogLevel.Error && e.Message.Contains("(lock)"));
+    }
+
+    [Fact]
+    public void ReorderingPluginHost_LargePendingQueue_WarningsBackOffExponentially()
+    {
+        // Arrange
+        var host = Build(out _, out var logger);
+
+        // Act
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.MonitorLockAcquire, L1));
+        host.ProcessEvent(SyncEventBuilder.Exit(T1, RecordedEventType.MonitorLockAcquireResult));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T2, RecordedEventType.MonitorLockAcquire, L1));
+        host.ProcessEvent(SyncEventBuilder.Exit(T2, RecordedEventType.MonitorLockAcquireResult)); // deferred [1]
+        for (var i = 0; i < 255; i++)
+            host.ProcessEvent(SyncEventBuilder.FieldRead(T2)); // deferred [2..256]
+
+        // Assert: warned at 64, 128 and 256 deferred events only
+        Assert.Equal(3, logger.Entries.Count(e => e.Level == LogLevel.Warning && e.Message.Contains("pending queue")));
     }
 
     private static (uint Tid, RecordedEventType Type) ClassifyDispatched(RecordedEvent e)

--- a/src/Tests/SharpDetect.PluginHost.Tests/ReorderingPluginHostTests.cs
+++ b/src/Tests/SharpDetect.PluginHost.Tests/ReorderingPluginHostTests.cs
@@ -340,8 +340,8 @@ public class ReorderingPluginHostTests
         host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T2, RecordedEventType.SemaphoreAcquire, S1));
         host.ProcessEvent(SyncEventBuilder.ExitWithSuccess(T2, RecordedEventType.SemaphoreAcquireResult, true)); // deferred [no permits]
         host.ProcessEvent(SyncEventBuilder.FieldRead(T2)); // also deferred
-        host.ProcessEvent(SyncEventBuilder.EnterWithTargetAndCount(T1, RecordedEventType.SemaphoreRelease, S1, 1));
-        host.ProcessEvent(SyncEventBuilder.Exit(T1, RecordedEventType.SemaphoreReleaseResult)); // wakes T2
+        host.ProcessEvent(SyncEventBuilder.EnterWithTargetAndCount(T1, RecordedEventType.SemaphoreRelease, S1, 1)); // wakes T2
+        host.ProcessEvent(SyncEventBuilder.Exit(T1, RecordedEventType.SemaphoreReleaseResult));
 
         // Assert
         var kinds = recorder.Dispatched.Select(ClassifyDispatched).ToArray();
@@ -352,9 +352,9 @@ public class ReorderingPluginHostTests
             (T1, RecordedEventType.SemaphoreAcquireResult),
             (T2, RecordedEventType.SemaphoreAcquire),
             (T1, RecordedEventType.SemaphoreRelease),
-            (T1, RecordedEventType.SemaphoreReleaseResult),
             (T2, RecordedEventType.SemaphoreAcquireResult),
             (T2, RecordedEventType.InstanceFieldRead),
+            (T1, RecordedEventType.SemaphoreReleaseResult),
         }, kinds);
     }
 
@@ -403,6 +403,66 @@ public class ReorderingPluginHostTests
         // Assert
         Assert.Contains(recorder.Dispatched, e => e.Metadata.Tid.Value == T2 && IsSemaphoreAcquireResult(e));
         Assert.Contains(recorder.Dispatched, e => e.Metadata.Tid.Value == T3 && IsSemaphoreAcquireResult(e));
+    }
+
+    [Fact]
+    public void ReorderingPluginHost_SemaphoreReleaseEnter_WakesWaiter_WithoutReleaseResult()
+    {
+        // Arrange
+        var host = Build(out var recorder);
+
+        // Act & Assert
+        host.ProcessEvent(SyncEventBuilder.EnterWithTargetCountAndCapacity(T1, RecordedEventType.SemaphoreCreate, S1, 1, 1));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.SemaphoreAcquire, S1));
+        host.ProcessEvent(SyncEventBuilder.ExitWithSuccess(T1, RecordedEventType.SemaphoreAcquireResult, true));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T2, RecordedEventType.SemaphoreAcquire, S1));
+        host.ProcessEvent(SyncEventBuilder.ExitWithSuccess(T2, RecordedEventType.SemaphoreAcquireResult, true)); // deferred [no permits]
+        host.ProcessEvent(SyncEventBuilder.FieldRead(T2)); // also deferred
+        Assert.DoesNotContain(recorder.Dispatched, e => e.Metadata.Tid.Value == T2 && IsSemaphoreAcquireResult(e));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTargetAndCount(T1, RecordedEventType.SemaphoreRelease, S1, 1)); // wakes T2; ReleaseResult never arrives
+        Assert.Contains(recorder.Dispatched, e => e.Metadata.Tid.Value == T2 && IsSemaphoreAcquireResult(e));
+        Assert.Contains(recorder.Dispatched, e => ClassifyDispatched(e) == (T2, RecordedEventType.InstanceFieldRead));
+    }
+
+    [Fact]
+    public void ReorderingPluginHost_SemaphoreReleaseBeyondCapacity_DoesNotMintPermits()
+    {
+        // Arrange
+        var host = Build(out var recorder);
+
+        // Act
+        host.ProcessEvent(SyncEventBuilder.EnterWithTargetCountAndCapacity(T1, RecordedEventType.SemaphoreCreate, S1, 0, 1));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.SemaphoreAcquire, S1));
+        host.ProcessEvent(SyncEventBuilder.ExitWithSuccess(T1, RecordedEventType.SemaphoreAcquireResult, true)); // deferred [no permits, 1st waiter]
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T2, RecordedEventType.SemaphoreAcquire, S1));
+        host.ProcessEvent(SyncEventBuilder.ExitWithSuccess(T2, RecordedEventType.SemaphoreAcquireResult, true)); // deferred [2nd waiter]
+        host.ProcessEvent(SyncEventBuilder.EnterWithTargetAndCount(T3, RecordedEventType.SemaphoreRelease, S1, 5)); // real Release would throw; clamps to 1 permit
+
+        // Assert: only one waiter freed (clamped to capacity), the rest stay deferred
+        Assert.Contains(recorder.Dispatched, e => e.Metadata.Tid.Value == T1 && IsSemaphoreAcquireResult(e));
+        Assert.DoesNotContain(recorder.Dispatched, e => e.Metadata.Tid.Value == T2 && IsSemaphoreAcquireResult(e));
+    }
+
+    [Fact]
+    public void ReorderingPluginHost_SemaphoreReleaseCountPartiallyBeyondCapacity_ClampsToHeadroom()
+    {
+        // Arrange
+        var host = Build(out var recorder);
+
+        // Act
+        host.ProcessEvent(SyncEventBuilder.EnterWithTargetCountAndCapacity(T1, RecordedEventType.SemaphoreCreate, S1, 0, 2));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.SemaphoreAcquire, S1));
+        host.ProcessEvent(SyncEventBuilder.ExitWithSuccess(T1, RecordedEventType.SemaphoreAcquireResult, true)); // deferred [1st waiter]
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T2, RecordedEventType.SemaphoreAcquire, S1));
+        host.ProcessEvent(SyncEventBuilder.ExitWithSuccess(T2, RecordedEventType.SemaphoreAcquireResult, true)); // deferred [2nd waiter]
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T3, RecordedEventType.SemaphoreAcquire, S1));
+        host.ProcessEvent(SyncEventBuilder.ExitWithSuccess(T3, RecordedEventType.SemaphoreAcquireResult, true)); // deferred [3rd waiter]
+        host.ProcessEvent(SyncEventBuilder.EnterWithTargetAndCount(TReaper, RecordedEventType.SemaphoreRelease, S1, 5)); // clamps to headroom of 2
+
+        // Assert: exactly the two available permits wake the two FIFO waiters, the third stays deferred
+        Assert.Contains(recorder.Dispatched, e => e.Metadata.Tid.Value == T1 && IsSemaphoreAcquireResult(e));
+        Assert.Contains(recorder.Dispatched, e => e.Metadata.Tid.Value == T2 && IsSemaphoreAcquireResult(e));
+        Assert.DoesNotContain(recorder.Dispatched, e => e.Metadata.Tid.Value == T3 && IsSemaphoreAcquireResult(e));
     }
 
     [Fact]
@@ -676,6 +736,46 @@ public class ReorderingPluginHostTests
             (T2, RecordedEventType.MonitorLockAcquireResult),
             (T2, RecordedEventType.InstanceFieldRead),
         }, t2Events);
+    }
+
+    [Fact]
+    public void ReorderingPluginHost_ThreadDestroy_WithNonEmptyPendingQueue_LogsError()
+    {
+        // Arrange
+        var host = Build(out _, out var logger);
+
+        // Act
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.MonitorLockAcquire, L1));
+        host.ProcessEvent(SyncEventBuilder.Exit(T1, RecordedEventType.MonitorLockAcquireResult));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T2, RecordedEventType.MonitorLockAcquire, L1));
+        host.ProcessEvent(SyncEventBuilder.Exit(T2, RecordedEventType.MonitorLockAcquireResult)); // deferred
+        host.ProcessEvent(SyncEventBuilder.FieldRead(T2)); // also deferred behind T2's BlockedOn
+        host.ProcessEvent(SyncEventBuilder.ThreadDestroy(T2, TReaper)); // destroyed while still blocked with a pending queue
+
+        // Assert
+        Assert.Contains(logger.Entries, e =>
+            e.Level == LogLevel.Error && e.Message.Contains("destroyed with") && e.Message.Contains("(lock)"));
+    }
+
+    [Fact]
+    public void ReorderingPluginHost_ThreadDestroy_ParentWithDeferredThreadStartCore_DrainsBlockedChild()
+    {
+        // Arrange
+        var host = Build(out var recorder, out var logger);
+
+        // Act
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.MonitorLockAcquire, L1));
+        host.ProcessEvent(SyncEventBuilder.Exit(T1, RecordedEventType.MonitorLockAcquireResult));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T2, RecordedEventType.MonitorLockAcquire, L1));
+        host.ProcessEvent(SyncEventBuilder.Exit(T2, RecordedEventType.MonitorLockAcquireResult)); // T2 blocked on L1
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T2, RecordedEventType.ThreadStartCore, T3)); // deferred in T2's pending queue
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T3, RecordedEventType.ThreadStartCallback, T3)); // child defers awaiting parent's core
+        Assert.DoesNotContain(recorder.Dispatched, e => ClassifyDispatched(e) == (T3, RecordedEventType.ThreadStartCallback));
+        host.ProcessEvent(SyncEventBuilder.ThreadDestroy(T2, TReaper)); // parent dies; its dropped queue takes ThreadStartCore with it
+
+        // Assert: the child is rescued and drains instead of blocking forever
+        Assert.Contains(recorder.Dispatched, e => ClassifyDispatched(e) == (T3, RecordedEventType.ThreadStartCallback));
+        Assert.Contains(logger.Entries, e => e.Level == LogLevel.Warning && e.Message.Contains("waking blocked child"));
     }
 
     [Fact]

--- a/src/Tests/SharpDetect.PluginHost.Tests/ReorderingPluginHostTests.cs
+++ b/src/Tests/SharpDetect.PluginHost.Tests/ReorderingPluginHostTests.cs
@@ -759,6 +759,89 @@ public class ReorderingPluginHostTests
     }
 
     [Fact]
+    public void ReorderingPluginHost_GarbageCollected_LockWithWaiters_DrainsWaiters()
+    {
+        // Arrange
+        var host = Build(out var recorder);
+
+        // Act
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.MonitorLockAcquire, L1));
+        host.ProcessEvent(SyncEventBuilder.Exit(T1, RecordedEventType.MonitorLockAcquireResult));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T2, RecordedEventType.MonitorLockAcquire, L1));
+        host.ProcessEvent(SyncEventBuilder.Exit(T2, RecordedEventType.MonitorLockAcquireResult)); // deferred
+        host.ProcessEvent(SyncEventBuilder.FieldRead(T2)); // also deferred behind T2's BlockedOn
+        host.ProcessEvent(SyncEventBuilder.GarbageCollected(TReaper, L1)); // owner's release was never observed
+
+        // Assert
+        var t2Events = recorder.Dispatched
+            .Where(e => e.Metadata.Tid.Value == T2)
+            .Select(ClassifyDispatched)
+            .ToArray();
+        Assert.Equal(new[]
+        {
+            (T2, RecordedEventType.MonitorLockAcquire),
+            (T2, RecordedEventType.MonitorLockAcquireResult),
+            (T2, RecordedEventType.InstanceFieldRead),
+        }, t2Events);
+    }
+
+    [Fact]
+    public void ReorderingPluginHost_GarbageCollected_SemaphoreWithWaiters_DrainsWaiters()
+    {
+        // Arrange
+        var host = Build(out var recorder);
+
+        // Act
+        host.ProcessEvent(SyncEventBuilder.EnterWithTargetCountAndCapacity(T1, RecordedEventType.SemaphoreCreate, S1, 0, 1));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T2, RecordedEventType.SemaphoreAcquire, S1));
+        host.ProcessEvent(SyncEventBuilder.ExitWithSuccess(T2, RecordedEventType.SemaphoreAcquireResult, true)); // deferred
+        host.ProcessEvent(SyncEventBuilder.FieldRead(T2)); // also deferred behind T2's BlockedOn
+        host.ProcessEvent(SyncEventBuilder.GarbageCollected(TReaper, S1)); // releaser's exit was never observed
+
+        // Assert
+        Assert.Contains(recorder.Dispatched, e => e.Metadata.Tid.Value == T2 && IsSemaphoreAcquireResult(e));
+        Assert.Contains(recorder.Dispatched, e => ClassifyDispatched(e) == (T2, RecordedEventType.InstanceFieldRead));
+    }
+
+    [Fact]
+    public void ReorderingPluginHost_GarbageCollected_TaskWithJoiners_DrainsJoiners()
+    {
+        // Arrange
+        var host = Build(out var recorder);
+
+        // Act
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T2, RecordedEventType.TaskStart, Task1));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.TaskJoinStart, Task1));
+        host.ProcessEvent(SyncEventBuilder.ExitWithSuccess(T1, RecordedEventType.TaskJoinFinish, true)); // deferred
+        host.ProcessEvent(SyncEventBuilder.FieldRead(T1)); // also deferred behind T1's BlockedOn
+        host.ProcessEvent(SyncEventBuilder.GarbageCollected(TReaper, Task1)); // task's completion was never observed
+
+        // Assert
+        Assert.Contains(recorder.Dispatched, e =>
+            e.Metadata.Tid.Value == T1 &&
+            (e.EventArgs as MethodExitWithArgumentsRecordedEvent)?.Interpretation == (ushort)RecordedEventType.TaskJoinFinish);
+        Assert.Contains(recorder.Dispatched, e => ClassifyDispatched(e) == (T1, RecordedEventType.InstanceFieldRead));
+    }
+
+    [Fact]
+    public void ReorderingPluginHost_LargePendingQueue_LogsWarningWithBlockTargetKind()
+    {
+        // Arrange
+        var host = Build(out _, out var logger);
+
+        // Act
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.MonitorLockAcquire, L1));
+        host.ProcessEvent(SyncEventBuilder.Exit(T1, RecordedEventType.MonitorLockAcquireResult));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T2, RecordedEventType.MonitorLockAcquire, L1));
+        host.ProcessEvent(SyncEventBuilder.Exit(T2, RecordedEventType.MonitorLockAcquireResult)); // deferred [1]
+        for (var i = 0; i < 63; i++)
+            host.ProcessEvent(SyncEventBuilder.FieldRead(T2)); // deferred [2..64]
+
+        // Assert
+        Assert.Contains(logger.Entries, e => e.Level == LogLevel.Warning && e.Message.Contains("(lock)"));
+    }
+
+    [Fact]
     public void ReorderingPluginHost_GarbageCollected_LockWithOwner_LogsWarning()
     {
         // Arrange

--- a/src/Tests/SharpDetect.PluginHost.Tests/SyncEventBuilder.cs
+++ b/src/Tests/SharpDetect.PluginHost.Tests/SyncEventBuilder.cs
@@ -46,6 +46,23 @@ internal static class SyncEventBuilder
             ArgumentInfos: []));
     }
 
+    public static RecordedEvent EnterWithTargetAndFlag(
+        uint tid,
+        RecordedEventType type,
+        nuint targetObjectId,
+        bool flag)
+    {
+        var args = new byte[Unsafe.SizeOf<nuint>() + sizeof(bool)];
+        MemoryMarshal.Write(args, in targetObjectId);
+        MemoryMarshal.Write(args.AsSpan()[Unsafe.SizeOf<nuint>()..], in flag);
+        return new RecordedEvent(Meta(tid), new MethodEnterWithArgumentsRecordedEvent(
+            ModuleId: Module,
+            MethodToken: Method,
+            Interpretation: (ushort)type,
+            ArgumentValues: args,
+            ArgumentInfos: []));
+    }
+
     public static RecordedEvent EnterWithTargetCountAndCapacity(
         uint tid,
         RecordedEventType type,


### PR DESCRIPTION
This PR changes the following:

* Move lock and semaphore releases from `MethodExit` to `MethodEnter`
   * This prevents race conditions where a woken waiter's critical section could run before the releasing thread's `MethodExit` is processed. This can cause significant deferrals in applications with many threads
* Add capacity clamping to `ShadowSemaphore` (prevent permit overflows)
* Handle destroyed thread pending queues
   * Issue warning for unresolved synchronization primitives
   * Start blocked `ThreadStartCore` events to ensure child threads are not blocked forever
* Improve GC diagnostics — prevent GC from silently dropping waiters; return them to drain queue instead