### PR TITLE
Fix issue with exception unwinding corrupting shadow runtime state

### DIFF
--- a/src/Extensibility/SharpDetect.PluginHost/Services/Strategies/ReorderingPluginHost.cs
+++ b/src/Extensibility/SharpDetect.PluginHost/Services/Strategies/ReorderingPluginHost.cs
@@ -68,6 +68,7 @@ internal sealed class ReorderingPluginHost(IPluginHost inner, ILogger<Reordering
             MethodEnterWithArgumentsRecordedEvent enter => HandleEnter(recordedEvent, enter, thread.Id, thread),
             MethodExitRecordedEvent exit => HandleExit(recordedEvent, exit.Interpretation, thread.Id, thread, returnValue: null, byRefArgumentValues: null),
             MethodExitWithArgumentsRecordedEvent exit => HandleExit(recordedEvent, exit.Interpretation, thread.Id, thread, exit.ReturnValue, exit.ByRefArgumentValues),
+            MethodUnwoundRecordedEvent unwound => HandleUnwind(recordedEvent, unwound.Interpretation, thread.Id, thread),
             ThreadDestroyRecordedEvent destroy => HandleThreadDestroy(recordedEvent, destroy),
             GarbageCollectedTrackedObjectsRecordedEvent gc => HandleGarbageCollectedTrackedObjects(recordedEvent, gc),
             _ => inner.ProcessEvent(recordedEvent)
@@ -216,6 +217,30 @@ internal sealed class ReorderingPluginHost(IPluginHost inner, ILogger<Reordering
             case RecordedEventType.MonitorPulseOneResult:
             case RecordedEventType.MonitorPulseAllResult:
             case RecordedEventType.ThreadJoinResult:
+            default:
+                return inner.ProcessEvent(recordedEvent);
+        }
+    }
+
+    private RecordedEventState HandleUnwind(
+        RecordedEvent recordedEvent,
+        ushort interpretation,
+        ProcessThreadId tid,
+        ShadowThread thread)
+    {
+        // The instrumented method exited via an exception
+        switch ((RecordedEventType)interpretation)
+        {
+            case RecordedEventType.MonitorLockAcquireResult:
+            case RecordedEventType.LockAcquireResult:
+            case RecordedEventType.SemaphoreAcquireResult:
+            case RecordedEventType.TaskJoinFinish:
+                TryPopTarget(thread, out _);
+                return inner.ProcessEvent(recordedEvent);
+            case RecordedEventType.MonitorWaitResult:
+                return HandleWaitResult(recordedEvent, tid, thread);
+            case RecordedEventType.TaskComplete:
+                return HandleTaskComplete(recordedEvent, thread);
             default:
                 return inner.ProcessEvent(recordedEvent);
         }

--- a/src/Extensibility/SharpDetect.Plugins.DataRace.Eraser/EraserPlugin.cs
+++ b/src/Extensibility/SharpDetect.Plugins.DataRace.Eraser/EraserPlugin.cs
@@ -59,6 +59,7 @@ public partial class EraserPlugin : PerThreadOrderingPluginBase, IPlugin
                        COR_PRF_MONITOR.COR_PRF_MONITOR_JIT_COMPILATION |
                        COR_PRF_MONITOR.COR_PRF_MONITOR_THREADS |
                        COR_PRF_MONITOR.COR_PRF_MONITOR_ENTERLEAVE |
+                       COR_PRF_MONITOR.COR_PRF_MONITOR_EXCEPTIONS |
                        COR_PRF_MONITOR.COR_PRF_MONITOR_GC |
                        COR_PRF_MONITOR.COR_PRF_ENABLE_FUNCTION_ARGS |
                        COR_PRF_MONITOR.COR_PRF_ENABLE_FUNCTION_RETVAL |

--- a/src/Extensibility/SharpDetect.Plugins.DataRace.FastTrack/FastTrackPlugin.cs
+++ b/src/Extensibility/SharpDetect.Plugins.DataRace.FastTrack/FastTrackPlugin.cs
@@ -60,6 +60,7 @@ public partial class FastTrackPlugin : PerThreadOrderingPluginBase, IPlugin
                        COR_PRF_MONITOR.COR_PRF_MONITOR_JIT_COMPILATION |
                        COR_PRF_MONITOR.COR_PRF_MONITOR_THREADS |
                        COR_PRF_MONITOR.COR_PRF_MONITOR_ENTERLEAVE |
+                       COR_PRF_MONITOR.COR_PRF_MONITOR_EXCEPTIONS |
                        COR_PRF_MONITOR.COR_PRF_MONITOR_GC |
                        COR_PRF_MONITOR.COR_PRF_ENABLE_FUNCTION_ARGS |
                        COR_PRF_MONITOR.COR_PRF_ENABLE_FUNCTION_RETVAL |

--- a/src/Extensibility/SharpDetect.Plugins.Deadlock/DeadlockPlugin.cs
+++ b/src/Extensibility/SharpDetect.Plugins.Deadlock/DeadlockPlugin.cs
@@ -60,6 +60,7 @@ public partial class DeadlockPlugin : PerThreadOrderingPluginBase, IPlugin
                        COR_PRF_MONITOR.COR_PRF_MONITOR_JIT_COMPILATION |
                        COR_PRF_MONITOR.COR_PRF_MONITOR_THREADS |
                        COR_PRF_MONITOR.COR_PRF_MONITOR_ENTERLEAVE |
+                       COR_PRF_MONITOR.COR_PRF_MONITOR_EXCEPTIONS |
                        COR_PRF_MONITOR.COR_PRF_MONITOR_GC |
                        COR_PRF_MONITOR.COR_PRF_ENABLE_FUNCTION_ARGS |
                        COR_PRF_MONITOR.COR_PRF_ENABLE_FUNCTION_RETVAL |

--- a/src/Extensibility/SharpDetect.Plugins.PerThreadOrdering/PerThreadOrderingPluginBase.cs
+++ b/src/Extensibility/SharpDetect.Plugins.PerThreadOrdering/PerThreadOrderingPluginBase.cs
@@ -374,6 +374,63 @@ public abstract class PerThreadOrderingPluginBase : PluginBase
         base.Visit(metadata, args);
     }
 
+    protected override void Visit(RecordedEventMetadata metadata, MethodUnwoundRecordedEvent args)
+    {
+        // The instrumented method exited via an exception, so no method-exit event was produced
+        var id = new ProcessThreadId(metadata.Pid, metadata.Tid);
+        var frame = _callStackTracker.Pop(id);
+        EnsureCallStackIntegrity(frame, args.ModuleId, args.MethodToken);
+
+        switch ((RecordedEventType)args.Interpretation)
+        {
+            case RecordedEventType.MonitorLockAcquireResult:
+            case RecordedEventType.LockAcquireResult:
+            {
+                var lockId = ExtractSynchronizationObjectIdFromFrame(id, frame);
+                LockAcquireReturned?.Invoke(new(id, args.ModuleId, args.MethodToken, lockId, IsSuccess: false));
+                break;
+            }
+
+            case RecordedEventType.SemaphoreAcquireResult:
+            {
+                var semaphoreId = ExtractSynchronizationObjectIdFromFrame(id, frame);
+                SemaphoreAcquireReturned?.Invoke(new(id, args.ModuleId, args.MethodToken, semaphoreId, IsSuccess: false));
+                break;
+            }
+
+            case RecordedEventType.MonitorWaitResult:
+            {
+                var lockId = ExtractSynchronizationObjectIdFromFrame(id, frame);
+                OnAfterWaitReturn(id, lockId);
+                ObjectWaitReturned?.Invoke(new ObjectWaitResultArgs(id, args.ModuleId, args.MethodToken, lockId, IsSuccess: false));
+                break;
+            }
+
+            case RecordedEventType.ThreadJoinResult:
+            {
+                var joinedThreadObjectId = new ProcessTrackedObjectId(id.ProcessId, frame.Arguments!.Value[0].Value.AsT1);
+                if (_threadObjectRegistry.TryGetThreadId(joinedThreadObjectId, out var joinedThreadId))
+                    ThreadJoinReturned?.Invoke(new ThreadJoinResultArgs(id, joinedThreadId, args.ModuleId, args.MethodToken, IsSuccess: false));
+                break;
+            }
+
+            case RecordedEventType.TaskComplete:
+            {
+                // A task whose body faulted completes and release its waiters.
+                var taskObjectId = new ProcessTrackedObjectId(id.ProcessId, frame.Arguments!.Value[0].Value.AsT1);
+                ProcessTaskComplete(id, taskObjectId);
+                break;
+            }
+
+            case RecordedEventType.TaskJoinFinish:
+            {
+                var taskObjectId = new ProcessTrackedObjectId(id.ProcessId, frame.Arguments!.Value[0].Value.AsT1);
+                ProcessTaskJoinFinish(id, taskObjectId, isSuccess: false);
+                break;
+            }
+        }
+    }
+
     protected virtual void HandleLockAcquireExit(
         RecordedEventMetadata metadata,
         ModuleId moduleId,

--- a/src/SharpDetect.Core/Events/IRecordedEventArgs.cs
+++ b/src/SharpDetect.Core/Events/IRecordedEventArgs.cs
@@ -24,6 +24,7 @@ namespace SharpDetect.Core.Events;
 [Union((int)RecordedEventType.Tailcall, typeof(TailcallRecordedEvent))]
 [Union((int)RecordedEventType.MethodEnterWithArguments, typeof(MethodEnterWithArgumentsRecordedEvent))]
 [Union((int)RecordedEventType.MethodExitWithArguments, typeof(MethodExitWithArgumentsRecordedEvent))]
+[Union((int)RecordedEventType.MethodUnwound, typeof(MethodUnwoundRecordedEvent))]
 [Union((int)RecordedEventType.TailcallWithArguments, typeof(TailcallWithArgumentsRecordedEvent))]
 [Union((int)RecordedEventType.AssemblyReferenceInjection, typeof(AssemblyReferenceInjectionRecordedEvent))]
 [Union((int)RecordedEventType.TypeDefinitionInjection, typeof(TypeDefinitionInjectionRecordedEvent))]

--- a/src/SharpDetect.Core/Events/RecordedEventActionVisitorBase.cs
+++ b/src/SharpDetect.Core/Events/RecordedEventActionVisitorBase.cs
@@ -25,6 +25,7 @@ public abstract class RecordedEventActionVisitorBase
             case GarbageCollectionFinishRecordedEvent gcFinishedArgs: Visit(metadata, gcFinishedArgs); break;
             case MethodEnterRecordedEvent methodEnterArgs: Visit(metadata, methodEnterArgs); break;
             case MethodExitRecordedEvent methodExitArgs: Visit(metadata, methodExitArgs); break;
+            case MethodUnwoundRecordedEvent methodUnwoundArgs: Visit(metadata, methodUnwoundArgs); break;
             case TailcallRecordedEvent tailcallArgs: Visit(metadata, tailcallArgs); break;
             case MethodEnterWithArgumentsRecordedEvent methodEnterWithArgumentsArgs: Visit(metadata, methodEnterWithArgumentsArgs); break;
             case MethodExitWithArgumentsRecordedEvent methodExitWithArgumentsArgs: Visit(metadata, methodExitWithArgumentsArgs); break;
@@ -89,6 +90,9 @@ public abstract class RecordedEventActionVisitorBase
         => DefaultVisit(metadata, args);
 
     protected virtual void Visit(RecordedEventMetadata metadata, MethodExitRecordedEvent args)
+        => DefaultVisit(metadata, args);
+
+    protected virtual void Visit(RecordedEventMetadata metadata, MethodUnwoundRecordedEvent args)
         => DefaultVisit(metadata, args);
 
     protected virtual void Visit(RecordedEventMetadata metadata, TailcallRecordedEvent args)

--- a/src/SharpDetect.Core/Events/RecordedEventType.cs
+++ b/src/SharpDetect.Core/Events/RecordedEventType.cs
@@ -63,6 +63,9 @@ public enum RecordedEventType : ushort
     InstanceFieldRead = 43,
     InstanceFieldWrite = 44,
 
+    /* Exceptions */
+    MethodUnwound = 90,
+
     /* Synchronization */
     MonitorLockAcquire = 100,
     MonitorLockTryAcquire = 101,

--- a/src/SharpDetect.Core/Events/RecordedEvents.cs
+++ b/src/SharpDetect.Core/Events/RecordedEvents.cs
@@ -84,6 +84,12 @@ public sealed record MethodExitRecordedEvent(
     [property: Key(2)] ushort Interpretation) : IRecordedEventArgs, ICustomizableEventType;
 
 [MessagePackObject]
+public sealed record MethodUnwoundRecordedEvent(
+    [property: Key(0)] ModuleId ModuleId,
+    [property: Key(1)] MdMethodDef MethodToken,
+    [property: Key(2)] ushort Interpretation) : IRecordedEventArgs, ICustomizableEventType;
+
+[MessagePackObject]
 public sealed record TailcallRecordedEvent(
     [property: Key(0)] ModuleId ModuleId,
     [property: Key(1)] MdMethodDef MethodToken) : IRecordedEventArgs;

--- a/src/SharpDetect.Profiler/LibIPC/Messages.cpp
+++ b/src/SharpDetect.Profiler/LibIPC/Messages.cpp
@@ -112,6 +112,12 @@ MethodExitMsg Helpers::CreateMethodExitMsg(MetadataMsg&& metadataMsg, UINT64 mod
     return { std::move(metadataMsg), MethodExitMsgArgsInstance(discriminator, MethodExitMsgArgs(moduleId, mdMethodDef, interpretation)) };
 }
 
+MethodUnwoundMsg Helpers::CreateMethodUnwoundMsg(MetadataMsg&& metadataMsg, UINT64 moduleId, UINT32 mdMethodDef, USHORT interpretation)
+{
+    constexpr auto discriminator = static_cast<INT32>(RecordedEventType::MethodUnwound);
+    return { std::move(metadataMsg), MethodUnwoundMsgArgsInstance(discriminator, MethodUnwoundMsgArgs(moduleId, mdMethodDef, interpretation)) };
+}
+
 TailcallMsg Helpers::CreateTailcallrMsg(MetadataMsg&& metadataMsg, UINT64 moduleId, UINT32 mdMethodDef)
 {
     constexpr auto discriminator = static_cast<INT32>(RecordedEventType::Tailcall);

--- a/src/SharpDetect.Profiler/LibIPC/Messages.h
+++ b/src/SharpDetect.Profiler/LibIPC/Messages.h
@@ -77,6 +77,9 @@ namespace LibIPC
 		StaticFieldWrite = 42,
 		InstanceFieldRead = 43,
 		InstanceFieldWrite = 44,
+
+		/* Exceptions */
+		MethodUnwound = 90,
 	};
 
 	enum class ProfilerCommandType
@@ -164,6 +167,10 @@ namespace LibIPC
 	using MethodExitMsgArgsInstance = msgpack::type::tuple<INT32, MethodExitMsgArgs>;
 	using MethodExitMsg = msgpack::type::tuple<MetadataMsg, MethodExitMsgArgsInstance>;
 
+	using MethodUnwoundMsgArgs = msgpack::type::tuple<UINT64, UINT32, USHORT>;
+	using MethodUnwoundMsgArgsInstance = msgpack::type::tuple<INT32, MethodUnwoundMsgArgs>;
+	using MethodUnwoundMsg = msgpack::type::tuple<MetadataMsg, MethodUnwoundMsgArgsInstance>;
+
 	using TailcallMsgArgs = msgpack::type::tuple<UINT64, UINT32>;
 	using TailcallMsgArgsInstance = msgpack::type::tuple<INT32, TailcallMsgArgs>;
 	using TailcallMsg = msgpack::type::tuple<MetadataMsg, TailcallMsgArgsInstance>;
@@ -243,6 +250,7 @@ namespace LibIPC
 		
 		MethodEnterMsg CreateMethodEnterMsg(MetadataMsg&& metadataMsg, UINT64 moduleId, UINT32 mdMethodDef, USHORT interpretation);
 		MethodExitMsg CreateMethodExitMsg(MetadataMsg&& metadataMsg, UINT64 moduleId, UINT32 mdMethodDef, USHORT interpretation);
+		MethodUnwoundMsg CreateMethodUnwoundMsg(MetadataMsg&& metadataMsg, UINT64 moduleId, UINT32 mdMethodDef, USHORT interpretation);
 		TailcallMsg CreateTailcallrMsg(MetadataMsg&& metadataMsg, UINT64 moduleId, UINT32 mdMethodDef);
 		MethodEnterWithArgumentsMsg CreateMethodEnterWithArgumentsMsg(MetadataMsg&& metadataMsg, UINT64 moduleId, UINT32 mdMethodDef, USHORT interpretation, std::vector<BYTE>&& argValues, std::vector<BYTE>&& argInfos);
 		MethodExitWithArgumentsMsg CreateMethodExitWithArgumentsMsg(MetadataMsg&& metadataMsg, UINT64 moduleId, UINT32 mdMethodDef, USHORT, std::vector<BYTE>&& returnValue, std::vector<BYTE>&& argValues, std::vector<BYTE>&& argInfos);

--- a/src/SharpDetect.Profiler/SharpDetect.Concurrency.Profiler/CorProfiler.cpp
+++ b/src/SharpDetect.Profiler/SharpDetect.Concurrency.Profiler/CorProfiler.cpp
@@ -651,6 +651,51 @@ HRESULT Profiler::CorProfiler::LeaveMethod(const FunctionIDOrClientID functionOr
     return S_OK;
 }
 
+HRESULT STDMETHODCALLTYPE Profiler::CorProfiler::ExceptionUnwindFunctionEnter(const FunctionID functionId)
+{
+    if (_terminating)
+        return S_OK;
+
+    ModuleID moduleId;
+    mdMethodDef methodDef;
+    HRESULT hr = _corProfilerInfo->GetFunctionInfo(functionId, nullptr, &moduleId, &methodDef);
+    if (FAILED(hr))
+        return S_OK;
+
+    constexpr auto originalMethodExitEvent = static_cast<USHORT>(LibIPC::RecordedEventType::MethodExit);
+    constexpr auto originalMethodExitWithArgumentsEvent = static_cast<USHORT>(LibIPC::RecordedEventType::MethodExitWithArguments);
+    auto const [
+        hasCustomMethodExitEvent,
+        customMethodExitEvent,
+        hasCustomMethodExitWithArgumentsEvent,
+        customMethodExitWithArgumentsEvent] =
+        _rewriteRegistry.FindMethodExitMappings(
+            moduleId,
+            methodDef,
+            originalMethodExitEvent,
+            originalMethodExitWithArgumentsEvent);
+
+    if (!hasCustomMethodExitEvent && !hasCustomMethodExitWithArgumentsEvent)
+        return S_OK;
+
+    // Balance the per-thread by-ref/return-value argument stack that EnterMethod pushed
+    const auto descriptorPointer = _methodDescriptorRegistry.TryGet(moduleId, methodDef);
+    if (descriptorPointer)
+    {
+        const auto& descriptor = *descriptorPointer.get();
+        if ((descriptor.rewritingDescriptor.returnValue.has_value() || HasIndirects(descriptor)) && !ArgsCallStack.empty())
+            ArgsCallStack.pop();
+    }
+
+    auto const interpretation = hasCustomMethodExitEvent ? customMethodExitEvent : customMethodExitWithArgumentsEvent;
+    _client.Send(LibIPC::Helpers::CreateMethodUnwoundMsg(
+        CreateMetadataMsg(),
+        moduleId,
+        methodDef,
+        interpretation));
+    return S_OK;
+}
+
 HRESULT Profiler::CorProfiler::TailcallMethod(FunctionIDOrClientID functionOrClientId, COR_PRF_ELT_INFO eltInfo)
 {
     if (_terminating)

--- a/src/SharpDetect.Profiler/SharpDetect.Concurrency.Profiler/CorProfiler.h
+++ b/src/SharpDetect.Profiler/SharpDetect.Concurrency.Profiler/CorProfiler.h
@@ -43,7 +43,8 @@ namespace Profiler
 		HRESULT STDMETHODCALLTYPE ThreadCreated(ThreadID threadId) override;
 		HRESULT STDMETHODCALLTYPE ThreadDestroyed(ThreadID threadId) override;
 		HRESULT STDMETHODCALLTYPE ThreadNameChanged(ThreadID threadId, ULONG cchName, WCHAR name[]) override;
-		
+		HRESULT STDMETHODCALLTYPE ExceptionUnwindFunctionEnter(FunctionID functionId) override;
+
 		HRESULT EnterMethod(FunctionIDOrClientID functionId, COR_PRF_ELT_INFO eltInfo);
 		HRESULT LeaveMethod(FunctionIDOrClientID functionId, COR_PRF_ELT_INFO eltInfo);
 		HRESULT TailcallMethod(FunctionIDOrClientID functionId, COR_PRF_ELT_INFO eltInfo);

--- a/src/Tests/SharpDetect.E2ETests.Subject/Entrypoint.cs
+++ b/src/Tests/SharpDetect.E2ETests.Subject/Entrypoint.cs
@@ -25,6 +25,12 @@ namespace SharpDetect.E2ETests.Subject
                 case nameof(Test_ShadowCallstack_MonitorPulseAll):
                     Test_ShadowCallstack_MonitorPulseAll();
                     break;
+                case nameof(Test_ShadowCallstack_SyncMethodThrowsInsideTaskBody):
+                    Test_ShadowCallstack_SyncMethodThrowsInsideTaskBody();
+                    break;
+                case nameof(Test_ShadowCallstack_FaultedTaskJoinThrows):
+                    Test_ShadowCallstack_FaultedTaskJoinThrows();
+                    break;
 #if NET10_0_OR_GREATER
                 case nameof(Test_ShadowCallstack_MonitorExitIfLockTaken):
                     Test_ShadowCallstack_MonitorExitIfLockTaken();

--- a/src/Tests/SharpDetect.E2ETests.Subject/SimpleTests.cs
+++ b/src/Tests/SharpDetect.E2ETests.Subject/SimpleTests.cs
@@ -186,6 +186,34 @@ namespace SharpDetect.E2ETests.Subject
             thread1.Join();
         }
 
+        public static void Test_ShadowCallstack_SyncMethodThrowsInsideTaskBody()
+        {
+            Task.Run(() =>
+            {
+                try
+                {
+                    Monitor.Exit(new object());
+                }
+                catch (SynchronizationLockException)
+                {
+                    // Swallow so that Task.InnerInvoke returns normally and triggers TaskComplete.
+                }
+            }).Wait();
+        }
+
+        public static void Test_ShadowCallstack_FaultedTaskJoinThrows()
+        {
+            var task = Task.Run(() => throw new InvalidOperationException("TEST"));
+            try
+            {
+                task.Wait();
+            }
+            catch (AggregateException)
+            {
+                // Swallow so the entrypoint returns normally.
+            }
+        }
+
 #if NET10_0_OR_GREATER
         public static void Test_ShadowCallstack_MonitorExitIfLockTaken()
         {

--- a/src/Tests/SharpDetect.E2ETests/EndToEndTestCollection.cs
+++ b/src/Tests/SharpDetect.E2ETests/EndToEndTestCollection.cs
@@ -24,6 +24,9 @@ public sealed class MultiProcessTestsCollection : ICollectionFixture<EndToEndCol
 [CollectionDefinition(ObjectTrackingTests.CollectionName)]
 public sealed class ObjectTrackingTestsCollection : ICollectionFixture<EndToEndCollectionFixture> { }
 
+[CollectionDefinition(ShadowRuntimeStateIntegrityTests.CollectionName)]
+public sealed class ShadowRuntimeStateIntegrityTestsCollection : ICollectionFixture<EndToEndCollectionFixture> { }
+
 [CollectionDefinition(TestProjectIntegrationTests.CollectionName)]
 public sealed class TestProjectIntegrationTestsCollection : ICollectionFixture<EndToEndCollectionFixture> { }
 

--- a/src/Tests/SharpDetect.E2ETests/ShadowRuntimeStateIntegrityTests.cs
+++ b/src/Tests/SharpDetect.E2ETests/ShadowRuntimeStateIntegrityTests.cs
@@ -1,0 +1,59 @@
+// Copyright 2026 Andrej Čižmárik and Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+using Microsoft.Extensions.DependencyInjection;
+using SharpDetect.Core.Events;
+using SharpDetect.E2ETests.Utils;
+using SharpDetect.TemporalAsserts;
+using SharpDetect.TemporalAsserts.TemporalOperators;
+using SharpDetect.Worker;
+using SharpDetect.Worker.Commands.Run;
+using Xunit;
+using Xunit.Abstractions;
+using static SharpDetect.E2ETests.TemporalAssertionBuilders;
+
+namespace SharpDetect.E2ETests;
+
+[Collection(CollectionName)]
+public class ShadowRuntimeStateIntegrityTests(ITestOutputHelper testOutput)
+{
+    public const string CollectionName = "E2E_ShadowRuntimeStateIntegrityTests";
+
+    [Theory]
+    [MemberData(nameof(SdkVersions.All), MemberType = typeof(SdkVersions))]
+    public Task ShadowCallstack_SyncMethodThrowsInsideTaskBody(string sdk)
+    {
+        return ShadowStateIntegrityTest("Test_ShadowCallstack_SyncMethodThrowsInsideTaskBody", sdk);
+    }
+
+    [Theory]
+    [MemberData(nameof(SdkVersions.All), MemberType = typeof(SdkVersions))]
+    public Task ShadowCallstack_FaultedTaskJoinThrows(string sdk)
+    {
+        return ShadowStateIntegrityTest("Test_ShadowCallstack_FaultedTaskJoinThrows", sdk);
+    }
+
+    private async Task ShadowStateIntegrityTest(string subjectArgs, string sdk)
+    {
+        // Arrange
+        using var services = E2ETestBuilder
+            .ForSubject(subjectArgs)
+            .WithPlugin<TestPerThreadOrderingPlugin>()
+            .Build(sdk, testOutput);
+        var args = services.GetRequiredService<RunCommandArgs>();
+        var plugin = services.GetRequiredService<TestPerThreadOrderingPlugin>();
+        var analysisWorker = services.GetRequiredService<IAnalysisWorker>();
+        var events = new TestEventsEnumerable(plugin);
+        var assert = EventuallyMethodEnter(args.Target.Args!, plugin)
+            .Then(EventuallyEventType(RecordedEventType.TaskStart))
+            .Then(EventuallyEventType(RecordedEventType.TaskComplete))
+            .Then(EventuallyEventType(RecordedEventType.TaskJoinFinish))
+            .Then(EventuallyMethodExit(args.Target.Args!, plugin));
+
+        // Execute
+        await analysisWorker.ExecuteAsync(CancellationToken.None);
+
+        // Assert
+        Assert.True(AssertStatus.Satisfied == assert.Evaluate(events), assert.GetDiagnosticInfo());
+    }
+}

--- a/src/Tests/SharpDetect.E2ETests/Utils/TestMethodDescriptors.cs
+++ b/src/Tests/SharpDetect.E2ETests/Utils/TestMethodDescriptors.cs
@@ -43,6 +43,8 @@ internal static class TestMethodDescriptors
             "Test_ShadowCallstack_MonitorTryEnter_LockNotTaken",
             "Test_ShadowCallstack_MonitorPulse",
             "Test_ShadowCallstack_MonitorPulseAll",
+            "Test_ShadowCallstack_SyncMethodThrowsInsideTaskBody",
+            "Test_ShadowCallstack_FaultedTaskJoinThrows",
             "Test_ThreadMethods_StartCallback1",
             "Test_ThreadMethods_StartCallback2",
             "Test_ThreadMethods_get_CurrentThread",

--- a/src/Tests/SharpDetect.E2ETests/Utils/TestPerThreadOrderingPlugin.cs
+++ b/src/Tests/SharpDetect.E2ETests/Utils/TestPerThreadOrderingPlugin.cs
@@ -80,6 +80,7 @@ public sealed class TestPerThreadOrderingPlugin : PerThreadOrderingPluginBase, I
                        COR_PRF_MONITOR.COR_PRF_MONITOR_JIT_COMPILATION |
                        COR_PRF_MONITOR.COR_PRF_MONITOR_THREADS |
                        COR_PRF_MONITOR.COR_PRF_MONITOR_ENTERLEAVE |
+                       COR_PRF_MONITOR.COR_PRF_MONITOR_EXCEPTIONS |
                        COR_PRF_MONITOR.COR_PRF_MONITOR_GC |
                        COR_PRF_MONITOR.COR_PRF_ENABLE_FUNCTION_ARGS |
                        COR_PRF_MONITOR.COR_PRF_ENABLE_FUNCTION_RETVAL |

--- a/src/Tests/SharpDetect.PluginHost.Tests/ReorderingPluginHostTests.cs
+++ b/src/Tests/SharpDetect.PluginHost.Tests/ReorderingPluginHostTests.cs
@@ -175,6 +175,123 @@ public class ReorderingPluginHostTests
     }
 
     [Fact]
+    public void ReorderingPluginHost_TaskComplete_Unwound_ReleasesJoinWaiters()
+    {
+        // Arrange
+        var host = Build(out var recorder);
+
+        // Act & Assert
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T2, RecordedEventType.TaskStart, Task1));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.TaskJoinStart, Task1));
+        host.ProcessEvent(SyncEventBuilder.Exit(T1, RecordedEventType.TaskJoinFinish)); // deferred [wait on task complete]
+        Assert.DoesNotContain(recorder.Dispatched, e =>
+            e.Metadata.Tid.Value == T1 &&
+            (e.EventArgs as MethodExitRecordedEvent)?.Interpretation == (ushort)RecordedEventType.TaskJoinFinish);
+        host.ProcessEvent(SyncEventBuilder.Unwound(T2, RecordedEventType.TaskComplete)); // faulted body completes
+        Assert.Contains(recorder.Dispatched, e =>
+            e.Metadata.Tid.Value == T1 &&
+            (e.EventArgs as MethodExitRecordedEvent)?.Interpretation == (ushort)RecordedEventType.TaskJoinFinish);
+    }
+
+    [Fact]
+    public void ReorderingPluginHost_AcquireUnwound_PopsTarget_SoLaterTaskCompletePopsCorrectTarget()
+    {
+        // Arrange
+        var host = Build(out var recorder);
+
+        // Act & Assert
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.TaskStart, Task1));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T2, RecordedEventType.TaskJoinStart, Task1));
+        host.ProcessEvent(SyncEventBuilder.Exit(T2, RecordedEventType.TaskJoinFinish)); // deferred
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.MonitorLockAcquire, L1));
+        host.ProcessEvent(SyncEventBuilder.Unwound(T1, RecordedEventType.MonitorLockAcquireResult)); // must drop L1 target
+        host.ProcessEvent(SyncEventBuilder.Exit(T1, RecordedEventType.TaskComplete));
+        Assert.Contains(recorder.Dispatched, e =>
+            e.Metadata.Tid.Value == T2 &&
+            (e.EventArgs as MethodExitRecordedEvent)?.Interpretation == (ushort)RecordedEventType.TaskJoinFinish);
+    }
+
+    [Fact]
+    public void ReorderingPluginHost_AcquireUnwound_DoesNotHoldLock()
+    {
+        // Arrange
+        var host = Build(out var recorder);
+
+        // Act & Assert
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.MonitorLockAcquire, L1));
+        host.ProcessEvent(SyncEventBuilder.Unwound(T1, RecordedEventType.MonitorLockAcquireResult));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T2, RecordedEventType.MonitorLockAcquire, L1));
+        host.ProcessEvent(SyncEventBuilder.Exit(T2, RecordedEventType.MonitorLockAcquireResult));
+        Assert.Contains(recorder.Dispatched, e => ClassifyDispatched(e) == (T2, RecordedEventType.MonitorLockAcquireResult));
+    }
+
+    [Fact]
+    public void ReorderingPluginHost_MonitorWaitUnwound_PopsTarget_SoLaterTaskCompletePopsCorrectTarget()
+    {
+        // Arrange
+        var host = Build(out var recorder);
+
+        // Act & Assert
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.TaskStart, Task1));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T2, RecordedEventType.TaskJoinStart, Task1));
+        host.ProcessEvent(SyncEventBuilder.Exit(T2, RecordedEventType.TaskJoinFinish)); // deferred
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.MonitorLockAcquire, L1));
+        host.ProcessEvent(SyncEventBuilder.Exit(T1, RecordedEventType.MonitorLockAcquireResult));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.MonitorWaitAttempt, L1));
+        host.ProcessEvent(SyncEventBuilder.Unwound(T1, RecordedEventType.MonitorWaitResult)); // must drop L1 target
+        host.ProcessEvent(SyncEventBuilder.Exit(T1, RecordedEventType.TaskComplete));
+        Assert.Contains(recorder.Dispatched, e =>
+            e.Metadata.Tid.Value == T2 &&
+            (e.EventArgs as MethodExitRecordedEvent)?.Interpretation == (ushort)RecordedEventType.TaskJoinFinish);
+    }
+
+    [Fact]
+    public void ReorderingPluginHost_MonitorWaitUnwound_ReacquiresShadowLockForOwner()
+    {
+        // Arrange
+        var host = Build(out var recorder);
+
+        // Act & Assert
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.MonitorLockAcquire, L1));
+        host.ProcessEvent(SyncEventBuilder.Exit(T1, RecordedEventType.MonitorLockAcquireResult));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.MonitorWaitAttempt, L1));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T2, RecordedEventType.MonitorLockAcquire, L1));
+        host.ProcessEvent(SyncEventBuilder.Exit(T2, RecordedEventType.MonitorLockAcquireResult));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T2, RecordedEventType.MonitorLockRelease, L1));
+        host.ProcessEvent(SyncEventBuilder.Exit(T2, RecordedEventType.MonitorLockReleaseResult));
+        host.ProcessEvent(SyncEventBuilder.Unwound(T1, RecordedEventType.MonitorWaitResult)); // reacquires for T1, then throws
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T3, RecordedEventType.MonitorLockAcquire, L1));
+        host.ProcessEvent(SyncEventBuilder.Exit(T3, RecordedEventType.MonitorLockAcquireResult));
+        Assert.DoesNotContain(recorder.Dispatched, e => e.Metadata.Tid.Value == T3 && IsAcquireResult(e));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.MonitorLockRelease, L1));
+        host.ProcessEvent(SyncEventBuilder.Exit(T1, RecordedEventType.MonitorLockReleaseResult));
+        Assert.Contains(recorder.Dispatched, e => e.Metadata.Tid.Value == T3 && IsAcquireResult(e));
+    }
+
+    [Fact]
+    public void ReorderingPluginHost_MonitorWaitUnwound_AfterReleaseEnter_NotDeferred()
+    {
+        // Arrange
+        var host = Build(out var recorder);
+
+        // Act & Assert
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.MonitorLockAcquire, L1));
+        host.ProcessEvent(SyncEventBuilder.Exit(T1, RecordedEventType.MonitorLockAcquireResult));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.MonitorWaitAttempt, L1));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T2, RecordedEventType.MonitorLockAcquire, L1));
+        host.ProcessEvent(SyncEventBuilder.Exit(T2, RecordedEventType.MonitorLockAcquireResult));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T2, RecordedEventType.MonitorLockRelease, L1)); // releases shadow
+        host.ProcessEvent(SyncEventBuilder.Unwound(T1, RecordedEventType.MonitorWaitResult)); // reacquires immediately
+        host.ProcessEvent(SyncEventBuilder.Exit(T2, RecordedEventType.MonitorLockReleaseResult));
+        Assert.Equal(8, recorder.Dispatched.Count);
+        var releaseEnter = recorder.Dispatched.FindIndex(e => ClassifyDispatched(e) == (T2, RecordedEventType.MonitorLockRelease));
+        var waitResult = recorder.Dispatched.FindIndex(e =>
+            e.Metadata.Tid.Value == T1 &&
+            (e.EventArgs as MethodUnwoundRecordedEvent)?.Interpretation == (ushort)RecordedEventType.MonitorWaitResult);
+        Assert.True(waitResult > releaseEnter, "T1's unwound wait result should dispatch after T2's release enter");
+    }
+
+    [Fact]
     public void ReorderingPluginHost_TaskJoin_QueuesSubsequentPlainMethodExitOnSameThread()
     {
         // Arrange
@@ -1242,6 +1359,7 @@ public class ReorderingPluginHostTests
             MethodEnterWithArgumentsRecordedEvent enter => (RecordedEventType)enter.Interpretation,
             MethodExitRecordedEvent exit => (RecordedEventType)exit.Interpretation,
             MethodExitWithArgumentsRecordedEvent exit => (RecordedEventType)exit.Interpretation,
+            MethodUnwoundRecordedEvent unwound => (RecordedEventType)unwound.Interpretation,
             ProfilerDestroyRecordedEvent => RecordedEventType.ProfilerDestroy,
             ThreadDestroyRecordedEvent => RecordedEventType.ThreadDestroy,
             _ => RecordedEventType.NotSpecified

--- a/src/Tests/SharpDetect.PluginHost.Tests/SyncEventBuilder.cs
+++ b/src/Tests/SharpDetect.PluginHost.Tests/SyncEventBuilder.cs
@@ -88,6 +88,12 @@ internal static class SyncEventBuilder
             MethodToken: Method,
             Interpretation: (ushort)type));
 
+    public static RecordedEvent Unwound(uint tid, RecordedEventType type)
+        => new(Meta(tid), new MethodUnwoundRecordedEvent(
+            ModuleId: Module,
+            MethodToken: Method,
+            Interpretation: (ushort)type));
+
     public static RecordedEvent ExitWithSuccess(uint tid, RecordedEventType type, bool success)
     {
         var ret = new byte[1];


### PR DESCRIPTION
This PR fixes an issue when instrumented methods exit via exception. The reordering plugin host's shadow state wasn't being cleaned up properly. This could leave stale entries on sync-target stacks.

- Added `MethodUnwound` event type
- Implemented `HandleUnwind(...)` in `ReorderingPluginHost` to clean up shadow state on exceptions