### PR TITLE
Fix issue with spam resolve issues from dynamically emitted assemblies

### DIFF
--- a/src/Extensibility/SharpDetect.PluginHost/Services/Strategies/ReorderingPluginHost.cs
+++ b/src/Extensibility/SharpDetect.PluginHost/Services/Strategies/ReorderingPluginHost.cs
@@ -55,6 +55,13 @@ internal sealed class ReorderingPluginHost(IPluginHost inner, ILogger<Reordering
     {
         if (thread.BlockedOn is not null)
         {
+            // A destroyed thread cannot progress further - do not defer past thread destroy event
+            if (recordedEvent.EventArgs is ThreadDestroyRecordedEvent destroy &&
+                new ProcessThreadId(recordedEvent.Metadata.Pid, destroy.ThreadId) == thread.Id)
+            {
+                return HandleThreadDestroy(recordedEvent, destroy);
+            }
+
             if (recordedEvent.EventArgs is MethodEnterWithArgumentsRecordedEvent deferredEnter &&
                 (RecordedEventType)deferredEnter.Interpretation == RecordedEventType.ThreadStartCore)
             {

--- a/src/Extensibility/SharpDetect.Plugins.DataRace.Common/FieldResolver.cs
+++ b/src/Extensibility/SharpDetect.Plugins.DataRace.Common/FieldResolver.cs
@@ -12,7 +12,7 @@ namespace SharpDetect.Plugins.DataRace.Common;
 public sealed class FieldResolver(IMetadataContext metadataContext, ILogger logger)
 {
     private readonly record struct ResolvedFieldInfo(FieldDef FieldDef, FieldFlags Flags);
-    private readonly Dictionary<FieldDefOrRef, ResolvedFieldInfo> _resolvedFields = [];
+    private readonly Dictionary<FieldDefOrRef, ResolvedFieldInfo?> _resolvedFields = [];
     private TypeRef? _threadStaticAttributeTypeRef;
     private TypeRef? _compilerGeneratedAttributeTypeRef;
     private TypeRef? _multicastDelegateTypeRef;
@@ -31,8 +31,15 @@ public sealed class FieldResolver(IMetadataContext metadataContext, ILogger logg
 
         if (_resolvedFields.TryGetValue(fieldDefOrRef, out var cached))
         {
-            fieldDef = cached.FieldDef;
-            fieldFlags = cached.Flags;
+            if (cached is not { } cachedInfo)
+            {
+                fieldDef = null;
+                fieldFlags = FieldFlags.None;
+                return false;
+            }
+
+            fieldDef = cachedInfo.FieldDef;
+            fieldFlags = cachedInfo.Flags;
             return true;
         }
 
@@ -41,11 +48,15 @@ public sealed class FieldResolver(IMetadataContext metadataContext, ILogger logg
 
         if (resolveResult.IsError)
         {
-            logger.LogWarning(
-                "Skipping analysis of field with token={FieldToken} in module {ModuleId} because it could not be resolved",
-                fieldToken.Value,
-                moduleId);
+            if (resolveResult.Error != MetadataResolverErrorType.ModuleDynamicallyGenerated)
+            {
+                logger.LogWarning(
+                    "Skipping analysis of field with token={FieldToken} in module {ModuleId} because it could not be resolved",
+                    fieldToken.Value,
+                    moduleId);
+            }
 
+            _resolvedFields.Add(fieldDefOrRef, null);
             fieldDef = null;
             fieldFlags = FieldFlags.None;
             return false;

--- a/src/SharpDetect.Core/Loader/ModuleLoadErrorType.cs
+++ b/src/SharpDetect.Core/Loader/ModuleLoadErrorType.cs
@@ -6,5 +6,6 @@ namespace SharpDetect.Core.Loader;
 public enum ModuleLoadErrorType
 {
     ModuleNotLoaded = 1,
-    ErrorDuringLoading = 2
+    ErrorDuringLoading = 2,
+    DynamicallyGenerated = 3
 }

--- a/src/SharpDetect.Core/Metadata/MetadataResolverErrorType.cs
+++ b/src/SharpDetect.Core/Metadata/MetadataResolverErrorType.cs
@@ -9,4 +9,5 @@ public enum MetadataResolverErrorType
     TypeNotFound = 2,
     MethodNotFound = 3,
     FieldNotFound = 4,
+    ModuleDynamicallyGenerated = 5,
 }

--- a/src/SharpDetect.Loader/Services/ModuleBindContext.cs
+++ b/src/SharpDetect.Loader/Services/ModuleBindContext.cs
@@ -16,6 +16,7 @@ internal class ModuleBindContext : IModuleBindContext
     private readonly IAssemblyLoadContext _assemblyLoadContext;
     private readonly Dictionary<ModuleEntry, ModuleDef> _modules;
     private readonly Dictionary<uint, ModuleDef> _coreLibraries;
+    private readonly HashSet<ModuleEntry> _dynamicModules;
     private readonly ILogger<ModuleBindContext> _logger;
 
     public ModuleBindContext(
@@ -26,6 +27,7 @@ internal class ModuleBindContext : IModuleBindContext
         _logger = logger;
         _modules = new();
         _coreLibraries = new();
+        _dynamicModules = new();
     }
 
     public Result<ModuleDef, ModuleLoadErrorType> TryGetModule(RecordedEventMetadata metadata, ModuleId moduleId)
@@ -36,6 +38,9 @@ internal class ModuleBindContext : IModuleBindContext
         var moduleEntry = new ModuleEntry(pid, moduleId);
         if (_modules.TryGetValue(moduleEntry, out var module))
             return Ok(module);
+
+        if (_dynamicModules.Contains(moduleEntry))
+            return Error(ModuleLoadErrorType.DynamicallyGenerated);
 
         return Error(ModuleLoadErrorType.ModuleNotLoaded);
     }
@@ -55,6 +60,7 @@ internal class ModuleBindContext : IModuleBindContext
             {
                 // Dynamically generated assembly (this is not supported)
                 // There is not an easy way to obtain a dynamically emitted assembly
+                _dynamicModules.Add(new ModuleEntry(metadata.Pid, moduleId));
                 _logger.LogWarning("[PID={Pid}] Could not load assembly \"{Path}\" for module with identifier={Id}. It was probably generated during runtime.",
                     metadata.Pid, path, moduleId.Value);
             }

--- a/src/SharpDetect.Metadata/Services/MetadataResolver.cs
+++ b/src/SharpDetect.Metadata/Services/MetadataResolver.cs
@@ -39,6 +39,9 @@ internal class MetadataResolver : IMetadataResolver
         var moduleGetResult = _moduleBindContext.TryGetModule(pid, moduleId);
         if (moduleGetResult.IsError)
         {
+            if (moduleGetResult.Error == ModuleLoadErrorType.DynamicallyGenerated)
+                return Error(MetadataResolverErrorType.ModuleDynamicallyGenerated);
+
             _logger.LogError("Could not resolve module with identifier={Id}", moduleId.Value);
             return Error(MetadataResolverErrorType.ModuleNotFound);
         }
@@ -55,7 +58,8 @@ internal class MetadataResolver : IMetadataResolver
         var moduleResolveResult = ResolveModule(pid, moduleId);
         if (moduleResolveResult.IsError)
         {
-            _logger.LogError("Could not resolve type with token={Tok} because module was not resolved", typeToken.Value);
+            if (moduleResolveResult.Error != MetadataResolverErrorType.ModuleDynamicallyGenerated)
+                _logger.LogError("Could not resolve type with token={Tok} because module was not resolved", typeToken.Value);
             return Error(moduleResolveResult.Error);
         }
 
@@ -83,7 +87,8 @@ internal class MetadataResolver : IMetadataResolver
         var moduleResolveResult = ResolveModule(pid, moduleId);
         if (moduleResolveResult.IsError)
         {
-            _logger.LogError("Could not resolve method with token={Tok} because module was not resolved", methodToken.Value);
+            if (moduleResolveResult.Error != MetadataResolverErrorType.ModuleDynamicallyGenerated)
+                _logger.LogError("Could not resolve method with token={Tok} because module was not resolved", methodToken.Value);
             return Error(moduleResolveResult.Error);
         }
 
@@ -107,7 +112,8 @@ internal class MetadataResolver : IMetadataResolver
         var moduleResolveResult = ResolveModule(pid, moduleId);
         if (moduleResolveResult.IsError)
         {
-            _logger.LogError("Could not resolve field with token={Tok} because module was not resolved", fieldToken.Value);
+            if (moduleResolveResult.Error != MetadataResolverErrorType.ModuleDynamicallyGenerated)
+                _logger.LogError("Could not resolve field with token={Tok} because module was not resolved", fieldToken.Value);
             return Error(moduleResolveResult.Error);
         }
 

--- a/src/Tests/SharpDetect.PluginHost.Tests/ReorderingPluginHostTests.cs
+++ b/src/Tests/SharpDetect.PluginHost.Tests/ReorderingPluginHostTests.cs
@@ -875,6 +875,28 @@ public class ReorderingPluginHostTests
     }
 
     [Fact]
+    public void ReorderingPluginHost_ThreadDestroy_SelfEmittedWhileBlocked_AbandonsOwnedLock_NoResidualGcWarning()
+    {
+        // Arrange
+        var host = Build(out var recorder, out var logger);
+
+        // Act
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T2, RecordedEventType.MonitorLockAcquire, L2));
+        host.ProcessEvent(SyncEventBuilder.Exit(T2, RecordedEventType.MonitorLockAcquireResult));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.MonitorLockAcquire, L1));
+        host.ProcessEvent(SyncEventBuilder.Exit(T1, RecordedEventType.MonitorLockAcquireResult));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T2, RecordedEventType.MonitorLockAcquire, L1));
+        host.ProcessEvent(SyncEventBuilder.Exit(T2, RecordedEventType.MonitorLockAcquireResult)); // T2 blocked on L1
+        host.ProcessEvent(SyncEventBuilder.ThreadDestroy(T2));
+        host.ProcessEvent(SyncEventBuilder.GarbageCollected(TReaper, L2)); // L2 collected once T2 is gone
+
+        // Assert
+        Assert.Contains(recorder.Dispatched, e => e.EventArgs is ThreadDestroyRecordedEvent);
+        Assert.DoesNotContain(logger.Entries, e =>
+            e.Level == LogLevel.Warning && e.Message.Contains("garbage collected with residual state"));
+    }
+
+    [Fact]
     public void ReorderingPluginHost_ThreadDestroy_ParentWithDeferredThreadStartCore_DrainsBlockedChild()
     {
         // Arrange


### PR DESCRIPTION
This PR fixes an issue when target program dynamically emits code that we cannot properly inspect.

* We now emit only 1 warning that `RefEmit_InMemoryManifestModule` cannot be analyzed.
* We no longer emit resolve failed errors for every method / field that we failed to process from dynamic assemblies.
* `ThreadDestroy` events are never deferred and always processed immediately