### PR TITLE
Improve net8.0 monitor lock descriptors

### DIFF
--- a/src/Extensibility/SharpDetect.Plugins.Descriptors/Methods/MonitorMethodDescriptors.cs
+++ b/src/Extensibility/SharpDetect.Plugins.Descriptors/Methods/MonitorMethodDescriptors.cs
@@ -24,12 +24,12 @@ public static class MonitorMethodDescriptors
     
     // Enter methods
     private static readonly MethodDescriptor MonitorEnterObjectV8;
+    private static readonly MethodDescriptor MonitorEnterObjectLockTakenV8;
     private static readonly MethodDescriptor MonitorEnterObjectV10;
     private static readonly MethodDescriptor MonitorEnterObjectLockTakenV10;
-    private static readonly MethodDescriptor MonitorReliableEnterV8;
-    private static readonly MethodDescriptor MonitorReliableEnterTimeoutV8;
-    
+
     // TryEnter methods
+    private static readonly MethodDescriptor MonitorReliableEnterTimeoutV8;
     private static readonly MethodDescriptor MonitorTryEnterObjectV10;
     private static readonly MethodDescriptor MonitorTryEnterTimeoutObjectV10;
     private static readonly MethodDescriptor MonitorTryReliableEnterObjectV10;
@@ -51,12 +51,12 @@ public static class MonitorMethodDescriptors
     {
         // Initialize Enter methods
         MonitorEnterObjectV8 = CreateEnterDescriptor_v8();
+        MonitorEnterObjectLockTakenV8 = CreateEnterWithLockTakenDescriptor_v8();
         MonitorEnterObjectV10 = CreateEnterDescriptor_v10();
         MonitorEnterObjectLockTakenV10 = CreateEnterWithLockTakenDescriptor_v10();
-        MonitorReliableEnterV8 = CreateReliableEnterDescriptor_v8();
-        MonitorReliableEnterTimeoutV8 = CreateReliableEnterTimeoutDescriptor_v8();
-        
+
         // Initialize TryEnter methods
+        MonitorReliableEnterTimeoutV8 = CreateReliableEnterTimeoutDescriptor_v8();
         MonitorTryEnterObjectV10 = CreateTryEnterDescriptor_v10();
         MonitorTryEnterTimeoutObjectV10 = CreateTryEnterTimeoutDescriptor_v10();
         MonitorTryReliableEnterObjectV10 = CreateTryReliableEnterDescriptor_v10();
@@ -121,8 +121,8 @@ public static class MonitorMethodDescriptors
             RecordedEventType.MonitorLockAcquire,
             RecordedEventType.MonitorLockAcquireResult));
 
-    private static MethodDescriptor CreateReliableEnterDescriptor_v8() => new(
-        "ReliableEnter",
+    private static MethodDescriptor CreateEnterWithLockTakenDescriptor_v8() => new(
+        "Enter",
         MonitorTypeName,
         MethodVersionDescriptor.Create(Version8, Version9Max),
         CreateSignature(
@@ -135,7 +135,7 @@ public static class MonitorMethodDescriptors
             returnValue: null,
             RecordedEventType.MonitorLockAcquire,
             RecordedEventType.MonitorLockAcquireResult));
-
+    
     private static MethodDescriptor CreateReliableEnterTimeoutDescriptor_v8() => new(
         "ReliableEnterTimeout",
         MonitorTypeName,
@@ -337,11 +337,11 @@ public static class MonitorMethodDescriptors
     {
         // Common public API
         yield return MonitorEnterObjectV8;
-        yield return MonitorExitV8;
-        
-        // Internal API (usable only by BCL)
-        yield return MonitorReliableEnterV8;
+        yield return MonitorEnterObjectLockTakenV8;
+
+        // Internal API (usable only by BCL) — single instrumentation point for all TryEnter overloads.
         yield return MonitorReliableEnterTimeoutV8;
+        yield return MonitorExitV8;
     }
 
     private static IEnumerable<MethodDescriptor> GetAllMethodsV10()

--- a/src/Tests/SharpDetect.E2ETests.Subject/Entrypoint.cs
+++ b/src/Tests/SharpDetect.E2ETests.Subject/Entrypoint.cs
@@ -56,6 +56,12 @@ namespace SharpDetect.E2ETests.Subject
                 case nameof(Test_MonitorMethods_TryEnterExit3):
                     Test_MonitorMethods_TryEnterExit3();
                     break;
+                case nameof(Test_MonitorMethods_EnterExitLoop):
+                    Test_MonitorMethods_EnterExitLoop();
+                    break;
+                case nameof(Test_MonitorMethods_TryEnterExitLoop):
+                    Test_MonitorMethods_TryEnterExitLoop();
+                    break;
                 case nameof(Test_MonitorMethods_Wait1):
                     Test_MonitorMethods_Wait1();
                     break;

--- a/src/Tests/SharpDetect.E2ETests.Subject/SimpleTests.cs
+++ b/src/Tests/SharpDetect.E2ETests.Subject/SimpleTests.cs
@@ -52,6 +52,25 @@ namespace SharpDetect.E2ETests.Subject
                 Monitor.Exit(obj);
         }
 
+        public const int MonitorBalanceLoopIterations = 16;
+
+        public static void Test_MonitorMethods_EnterExitLoop()
+        {
+            var obj = new object();
+            for (var i = 0; i < MonitorBalanceLoopIterations; i++)
+                lock (obj) { }
+        }
+
+        public static void Test_MonitorMethods_TryEnterExitLoop()
+        {
+            var obj = new object();
+            for (var i = 0; i < MonitorBalanceLoopIterations; i++)
+            {
+                if (Monitor.TryEnter(obj))
+                    Monitor.Exit(obj);
+            }
+        }
+
         public static void Test_MonitorMethods_Wait1()
         {
             var obj = new object();

--- a/src/Tests/SharpDetect.E2ETests/MethodInterpretationTests.cs
+++ b/src/Tests/SharpDetect.E2ETests/MethodInterpretationTests.cs
@@ -62,6 +62,20 @@ public class MethodInterpretationTests(ITestOutputHelper testOutput)
 
     [Theory]
     [MemberData(nameof(SdkVersions.All), MemberType = typeof(SdkVersions))]
+    public async Task MethodInterpretation_Monitor_EnterExitLoop_AcquireReleaseBalanced(string sdk)
+    {
+        await MonitorAcquireReleaseBalanced("Test_MonitorMethods_EnterExitLoop", sdk);
+    }
+
+    [Theory]
+    [MemberData(nameof(SdkVersions.All), MemberType = typeof(SdkVersions))]
+    public async Task MethodInterpretation_Monitor_TryEnterExitLoop_AcquireReleaseBalanced(string sdk)
+    {
+        await MonitorAcquireReleaseBalanced("Test_MonitorMethods_TryEnterExitLoop", sdk);
+    }
+
+    [Theory]
+    [MemberData(nameof(SdkVersions.All), MemberType = typeof(SdkVersions))]
     public async Task MethodInterpretation_Monitor_Wait1(string sdk)
     {
         await MonitorWait("Test_MonitorMethods_Wait1", sdk);
@@ -309,6 +323,28 @@ public class MethodInterpretationTests(ITestOutputHelper testOutput)
     public async Task MethodInterpretation_SemaphoreSlim_TryWaitRelease4(string sdk)
     {
         await SemaphoreSlimWaitRelease("Test_SemaphoreSlimMethods_TryWaitRelease4", sdk);
+    }
+
+    private async Task MonitorAcquireReleaseBalanced(string subjectArgs, string sdk)
+    {
+        // Arrange
+        using var services = E2ETestBuilder
+            .ForSubject(subjectArgs)
+            .WithPlugin<TestPerThreadOrderingPlugin>()
+            .Build(sdk, testOutput);
+        var plugin = services.GetRequiredService<TestPerThreadOrderingPlugin>();
+        var analysisWorker = services.GetRequiredService<IAnalysisWorker>();
+        var events = new TestEventsEnumerable(plugin);
+
+        // Execute
+        await analysisWorker.ExecuteAsync(CancellationToken.None);
+        var acquireResults = events.Count(e => e.Type == RecordedEventType.LockAcquireResult);
+        var releaseResults = events.Count(e => e.Type == RecordedEventType.LockReleaseResult);
+
+        Assert.True(
+            acquireResults >= Subject.Program.MonitorBalanceLoopIterations,
+            $"Expected at least {Subject.Program.MonitorBalanceLoopIterations} acquire results, observed {acquireResults}.");
+        Assert.Equal(releaseResults, acquireResults);
     }
 
     private async Task MonitorEnterExit(string subjectArgs, string sdk)


### PR DESCRIPTION
These have benefits when partially analyzing dynamic assemblies. Previously, we would get notification for lock acquires but not releases. Now, we use same mechanism for enter and exit for main lock methods on net8.0