### PR TITLE
Add support for SemaphoreSlim's WaitAsync

### DIFF
--- a/src/Extensibility/SharpDetect.PluginHost/Services/Strategies/ReorderingPluginHost.cs
+++ b/src/Extensibility/SharpDetect.PluginHost/Services/Strategies/ReorderingPluginHost.cs
@@ -16,6 +16,7 @@ internal sealed class ReorderingPluginHost(IPluginHost inner, ILogger<Reordering
     private readonly Dictionary<ProcessTrackedObjectId, ShadowLock> _locks = [];
     private readonly Dictionary<ProcessTrackedObjectId, ShadowSemaphore> _semaphores = [];
     private readonly Dictionary<ProcessTrackedObjectId, ShadowTask> _tasks = [];
+    private readonly Dictionary<ProcessTrackedObjectId, ProcessTrackedObjectId> _waitAsyncTaskToSemaphore = [];
     private readonly Dictionary<ProcessThreadId, ShadowThread> _threads = [];
     private readonly Queue<ProcessThreadId> _drainQueue = [];
     private readonly HashSet<ProcessTrackedObjectId> _pendingThreadStarts = [];
@@ -106,6 +107,7 @@ internal sealed class ReorderingPluginHost(IPluginHost inner, ILogger<Reordering
             case RecordedEventType.LockTryAcquire:
             case RecordedEventType.SemaphoreAcquire:
             case RecordedEventType.SemaphoreTryAcquire:
+            case RecordedEventType.SemaphoreWaitAsync:
             case RecordedEventType.TaskJoinStart:
                 thread.SyncTargetStack.Push(ReadTargetId(enter.ArgumentValues, tid.ProcessId));
                 return inner.ProcessEvent(recordedEvent);
@@ -212,6 +214,9 @@ internal sealed class ReorderingPluginHost(IPluginHost inner, ILogger<Reordering
             case RecordedEventType.SemaphoreAcquireResult:
                 return HandleSemaphoreAcquireResult(recordedEvent, tid, thread, ReadBoolOrDefault(returnValue, byRefArgumentValues, true));
 
+            case RecordedEventType.SemaphoreWaitAsyncResult:
+                return HandleSemaphoreWaitAsyncResult(recordedEvent, tid, thread, returnValue);
+
             case RecordedEventType.SemaphoreReleaseResult:
                 return inner.ProcessEvent(recordedEvent);
 
@@ -241,8 +246,12 @@ internal sealed class ReorderingPluginHost(IPluginHost inner, ILogger<Reordering
             case RecordedEventType.MonitorLockAcquireResult:
             case RecordedEventType.LockAcquireResult:
             case RecordedEventType.SemaphoreAcquireResult:
-            case RecordedEventType.TaskJoinFinish:
+            case RecordedEventType.SemaphoreWaitAsyncResult:
                 TryPopTarget(thread, out _);
+                return inner.ProcessEvent(recordedEvent);
+            case RecordedEventType.TaskJoinFinish:
+                if (TryPopTarget(thread, out var unwoundTask))
+                    _waitAsyncTaskToSemaphore.Remove(unwoundTask);
                 return inner.ProcessEvent(recordedEvent);
             case RecordedEventType.MonitorWaitResult:
                 return HandleWaitResult(recordedEvent, tid, thread);
@@ -292,6 +301,47 @@ internal sealed class ReorderingPluginHost(IPluginHost inner, ILogger<Reordering
         return inner.ProcessEvent(recordedEvent);
     }
 
+    private RecordedEventState HandleSemaphoreWaitAsyncResult(
+        RecordedEvent recordedEvent,
+        ProcessThreadId tid,
+        ShadowThread thread,
+        byte[]? returnValue)
+    {
+        if (!TryPopTarget(thread, out var semaphoreId))
+            return inner.ProcessEvent(recordedEvent);
+
+        if (TryReadTrackedObjectId(returnValue, tid.ProcessId, out var awaitedTaskId) &&
+            _semaphores.ContainsKey(semaphoreId))
+        {
+            _waitAsyncTaskToSemaphore[awaitedTaskId] = semaphoreId;
+        }
+
+        return inner.ProcessEvent(recordedEvent);
+    }
+
+    private RecordedEventState HandleWaitAsyncContinuation(
+        RecordedEvent recordedEvent,
+        ProcessThreadId tid,
+        ShadowThread thread,
+        ProcessTrackedObjectId awaitedTaskId,
+        ProcessTrackedObjectId semaphoreId,
+        bool success)
+    {
+        if (!success)
+        {
+            _waitAsyncTaskToSemaphore.Remove(awaitedTaskId);
+            thread.SyncTargetStack.Pop();
+            return inner.ProcessEvent(recordedEvent);
+        }
+
+        if (_semaphores.TryGetValue(semaphoreId, out var shadow) && !shadow.TryAcquire(tid))
+            return Defer(thread, semaphoreId);
+
+        _waitAsyncTaskToSemaphore.Remove(awaitedTaskId);
+        thread.SyncTargetStack.Pop();
+        return inner.ProcessEvent(recordedEvent);
+    }
+
     private RecordedEventState HandleTaskComplete(RecordedEvent recordedEvent, ShadowThread thread)
     {
         if (!TryPopTarget(thread, out var taskId))
@@ -308,6 +358,9 @@ internal sealed class ReorderingPluginHost(IPluginHost inner, ILogger<Reordering
     {
         if (!TryPeekTarget(thread, out var taskId))
             return inner.ProcessEvent(recordedEvent);
+
+        if (_waitAsyncTaskToSemaphore.TryGetValue(taskId, out var semaphoreId))
+            return HandleWaitAsyncContinuation(recordedEvent, tid, thread, taskId, semaphoreId, success);
 
         if (!success)
         {
@@ -339,16 +392,9 @@ internal sealed class ReorderingPluginHost(IPluginHost inner, ILogger<Reordering
             _drainQueue.Enqueue(next.Value);
         }
 
-        foreach (var (semaphoreId, shadow) in _semaphores)
+        foreach (var (_, shadow) in _semaphores)
         {
             shadow.RemoveWaiter(destroyedTid);
-            var abandonedPermits = shadow.AbandonPermitsByDestroy(destroyedTid);
-            if (abandonedPermits > 0)
-            {
-                logger.LogWarning(
-                    "Thread {Thread} destroyed while holding {Permits} outstanding permit(s) on semaphore {Semaphore}; permits will not be released.",
-                    destroyedTid, abandonedPermits, semaphoreId);
-            }
         }
 
         foreach (var (taskId, shadow) in _tasks)
@@ -430,6 +476,9 @@ internal sealed class ReorderingPluginHost(IPluginHost inner, ILogger<Reordering
                 _semaphores.Remove(key);
                 continue;
             }
+
+            // A WaitAsync task collected before its continuation ran (could happen with fire-and-forget invocations)
+            _waitAsyncTaskToSemaphore.Remove(key);
 
             if (_tasks.TryGetValue(key, out var shadowTask))
             {
@@ -538,6 +587,18 @@ internal sealed class ReorderingPluginHost(IPluginHost inner, ILogger<Reordering
     {
         var raw = MemoryMarshal.Read<nuint>(argumentValues);
         return new ProcessTrackedObjectId(pid, new TrackedObjectId(raw));
+    }
+
+    private static bool TryReadTrackedObjectId(byte[]? rawValue, uint pid, out ProcessTrackedObjectId objectId)
+    {
+        if (rawValue is { Length: > 0 })
+        {
+            objectId = new ProcessTrackedObjectId(pid, new TrackedObjectId(MemoryMarshal.Read<nuint>(rawValue)));
+            return true;
+        }
+
+        objectId = default;
+        return false;
     }
 
     private static bool ReadBoolOrDefault(byte[]? returnValue, byte[]? byRefArgumentValues, bool defaultValue)

--- a/src/Extensibility/SharpDetect.PluginHost/Services/Strategies/Shadows/ShadowSemaphore.cs
+++ b/src/Extensibility/SharpDetect.PluginHost/Services/Strategies/Shadows/ShadowSemaphore.cs
@@ -11,14 +11,14 @@ internal sealed class ShadowSemaphore(int initialCount, int capacity)
     public int Capacity { get; } = capacity;
     public int Count { get; private set; } = initialCount;
     private readonly LinkedList<ProcessThreadId> _waiters = [];
-    private readonly Dictionary<ProcessThreadId, int> _outstandingPermits = [];
+    private int _outstandingPermits;
 
     public bool TryAcquire(ProcessThreadId tid)
     {
         if (Count > 0)
         {
             Count--;
-            _outstandingPermits[tid] = _outstandingPermits.GetValueOrDefault(tid) + 1;
+            _outstandingPermits++;
             return true;
         }
         
@@ -28,15 +28,7 @@ internal sealed class ShadowSemaphore(int initialCount, int capacity)
 
     public IReadOnlyList<ProcessThreadId> Release(ProcessThreadId tid, int count)
     {
-        if (_outstandingPermits.TryGetValue(tid, out var held) && held > 0)
-        {
-            var decrement = Math.Min(held, count);
-            var remaining = held - decrement;
-            if (remaining == 0)
-                _outstandingPermits.Remove(tid);
-            else
-                _outstandingPermits[tid] = remaining;
-        }
+        _outstandingPermits -= Math.Min(_outstandingPermits, count);
 
         var effectiveCount = Math.Min(count, Capacity - Count);
         if (effectiveCount <= 0)
@@ -71,24 +63,15 @@ internal sealed class ShadowSemaphore(int initialCount, int capacity)
         return result;
     }
 
-    public int AbandonPermitsByDestroy(ProcessThreadId tid)
-    {
-        return _outstandingPermits.Remove(tid, out var held) ? held : 0;
-    }
-
     public bool TryDescribeResidualState([NotNullWhen(true)] out string? description)
     {
-        if (_waiters.Count == 0 && _outstandingPermits.Count == 0)
+        if (_waiters.Count == 0)
         {
             description = null;
             return false;
         }
 
-        var totalPermits = 0;
-        foreach (var kvp in _outstandingPermits)
-            totalPermits += kvp.Value;
-
-        description = $"waiters={_waiters.Count}, outstandingPermits={totalPermits} across {_outstandingPermits.Count} thread(s)";
+        description = $"waiters={_waiters.Count}, outstandingPermits={_outstandingPermits}";
         return true;
     }
 }

--- a/src/Extensibility/SharpDetect.Plugins.DataRace.FastTrack/FastTrackDetector.cs
+++ b/src/Extensibility/SharpDetect.Plugins.DataRace.FastTrack/FastTrackDetector.cs
@@ -155,15 +155,19 @@ internal sealed class FastTrackDetector
 
     public void RecordSemaphoreAcquired(ProcessThreadId threadId, ProcessTrackedObjectId semaphoreId)
     {
+        var pool = GetOrCreateSemaphorePool(semaphoreId);
+        if (pool.Count == 0)
+            return;
+
         var threadVc = GetOrCreateThreadClock(threadId);
-        var slotVc = _semaphoreClocks[semaphoreId].Dequeue();
+        var slotVc = pool.Dequeue();
         threadVc.Join(slotVc);
     }
 
     public void RecordSemaphoreReleased(ProcessThreadId threadId, ProcessTrackedObjectId semaphoreId, int releaseCount)
     {
         var threadVc = GetOrCreateThreadClock(threadId);
-        var pool = _semaphoreClocks[semaphoreId];
+        var pool = GetOrCreateSemaphorePool(semaphoreId);
         for (var i = 0; i < releaseCount; i++)
             pool.Enqueue(threadVc.Clone());
         threadVc.Increment(threadId);
@@ -436,6 +440,17 @@ internal sealed class FastTrackDetector
         }
 
         return vc;
+    }
+
+    private Queue<VectorClock> GetOrCreateSemaphorePool(ProcessTrackedObjectId semaphoreId)
+    {
+        if (!_semaphoreClocks.TryGetValue(semaphoreId, out var pool))
+        {
+            pool = new Queue<VectorClock>();
+            _semaphoreClocks[semaphoreId] = pool;
+        }
+
+        return pool;
     }
 
     private VectorClock GetOrCreateLockClock(ProcessTrackedObjectId lockId)

--- a/src/Extensibility/SharpDetect.Plugins.DataRace.FastTrack/FastTrackPlugin.cs
+++ b/src/Extensibility/SharpDetect.Plugins.DataRace.FastTrack/FastTrackPlugin.cs
@@ -104,6 +104,7 @@ public partial class FastTrackPlugin : PerThreadOrderingPluginBase, IPlugin
         SemaphoreCreated += OnSemaphoreCreated;
         SemaphoreAcquireReturned += OnSemaphoreAcquireReturned;
         SemaphoreReleased += OnSemaphoreReleased;
+        SemaphoreWaitAsyncReturned += OnSemaphoreWaitAsyncReturned;
 
         ReportTemplates = new DirectoryInfo(
             Path.Combine(
@@ -303,6 +304,12 @@ public partial class FastTrackPlugin : PerThreadOrderingPluginBase, IPlugin
     private void OnSemaphoreReleased(SemaphoreReleaseArgs args)
     {
         _detector.RecordSemaphoreReleased(args.ProcessThreadId, args.SemaphoreId, args.ReleaseCount);
+    }
+
+    private void OnSemaphoreWaitAsyncReturned(SemaphoreWaitAsyncArgs args)
+    {
+        // Raised on the continuation's thread once the WaitAsync await completed successfully
+        _detector.RecordSemaphoreAcquired(args.ProcessThreadId, args.SemaphoreId);
     }
 
     protected override void Visit(RecordedEventMetadata metadata, ThreadRenameRecordedEvent args)

--- a/src/Extensibility/SharpDetect.Plugins.Descriptors/ArgumentTypeDescriptor.cs
+++ b/src/Extensibility/SharpDetect.Plugins.Descriptors/ArgumentTypeDescriptor.cs
@@ -33,7 +33,11 @@ public record ArgumentTypeDescriptor
     public static ArgumentTypeDescriptor CreateSZArray(ArgumentTypeDescriptor elementType) 
         => new([CorElementType.ELEMENT_TYPE_SZARRAY, .. elementType.ElementTypes], elementType.TypeName);
     
-    public static ArgumentTypeDescriptor CreateGenericTypeParam(int index) 
+
+    public static ArgumentTypeDescriptor CreateGenericInst(string genericTypeName, ArgumentTypeDescriptor typeArgument)
+        => new([CorElementType.ELEMENT_TYPE_GENERICINST, CorElementType.ELEMENT_TYPE_CLASS, .. typeArgument.ElementTypes], genericTypeName);
+
+    public static ArgumentTypeDescriptor CreateGenericTypeParam(int index)
         => CreateGenericParam(CorElementType.ELEMENT_TYPE_VAR, index);
     
     public static ArgumentTypeDescriptor CreateGenericMethodTypeParam(int index) 

--- a/src/Extensibility/SharpDetect.Plugins.Descriptors/Methods/SemaphoreSlimMethodDescriptors.cs
+++ b/src/Extensibility/SharpDetect.Plugins.Descriptors/Methods/SemaphoreSlimMethodDescriptors.cs
@@ -10,6 +10,7 @@ public static class SemaphoreSlimMethodDescriptors
 {
     private const string SemaphoreSlimTypeName = "System.Threading.SemaphoreSlim";
     private const string CancellationTokenTypeName = "System.Threading.CancellationToken";
+    private const string TaskTResultTypeName = "System.Threading.Tasks.Task`1";
 
     private static readonly Version Version8 = new(8, 0, 0);
     private static readonly Version Version10 = new(10, 0, 0);
@@ -30,6 +31,8 @@ public static class SemaphoreSlimMethodDescriptors
     private static readonly MethodDescriptor CtorWithMaxCount;
     private static readonly MethodDescriptor WaitV8;
     private static readonly MethodDescriptor WaitCoreV10;
+    private static readonly MethodDescriptor WaitAsyncV8;
+    private static readonly MethodDescriptor WaitAsyncCoreV10;
     private static readonly MethodDescriptor ReleaseWithCount;
 
     static SemaphoreSlimMethodDescriptors()
@@ -97,6 +100,52 @@ public static class SemaphoreSlimMethodDescriptors
                 MethodEnterInterpretation: (ushort)RecordedEventType.SemaphoreTryAcquire,
                 MethodExitInterpretation: (ushort)RecordedEventType.SemaphoreAcquireResult));
 
+        WaitAsyncV8 = new MethodDescriptor(
+            MethodName: "WaitAsync",
+            DeclaringTypeFullName: SemaphoreSlimTypeName,
+            VersionDescriptor: MethodVersionDescriptor.Create(Version8, Version10),
+            SignatureDescriptor: new MethodSignatureDescriptor(
+                CallingConvention: CorCallingConvention.IMAGE_CEE_CS_CALLCONV_HASTHIS,
+                ParametersCount: 2,
+                ReturnType: ArgumentTypeDescriptor.CreateGenericInst(
+                    TaskTResultTypeName,
+                    ArgumentTypeDescriptor.CreateSimple(CorElementType.ELEMENT_TYPE_BOOLEAN)),
+                ArgumentTypeElements:
+                [
+                    ArgumentTypeDescriptor.CreateSimple(CorElementType.ELEMENT_TYPE_I4),
+                    ArgumentTypeDescriptor.CreateValueType(CancellationTokenTypeName)
+                ]),
+            RewritingDescriptor: new MethodRewritingDescriptor(
+                InjectHooks: true,
+                InjectManagedWrapper: false,
+                Arguments: [ObjectRefArg],
+                ReturnValue: new CapturedValueDescriptor((byte)nint.Size, CapturedValue.CaptureAsReference),
+                MethodEnterInterpretation: (ushort)RecordedEventType.SemaphoreWaitAsync,
+                MethodExitInterpretation: (ushort)RecordedEventType.SemaphoreWaitAsyncResult));
+
+        WaitAsyncCoreV10 = new MethodDescriptor(
+            MethodName: "WaitAsyncCore",
+            DeclaringTypeFullName: SemaphoreSlimTypeName,
+            VersionDescriptor: MethodVersionDescriptor.Create(Version10, Version10Max),
+            SignatureDescriptor: new MethodSignatureDescriptor(
+                CallingConvention: CorCallingConvention.IMAGE_CEE_CS_CALLCONV_HASTHIS,
+                ParametersCount: 2,
+                ReturnType: ArgumentTypeDescriptor.CreateGenericInst(
+                    TaskTResultTypeName,
+                    ArgumentTypeDescriptor.CreateSimple(CorElementType.ELEMENT_TYPE_BOOLEAN)),
+                ArgumentTypeElements:
+                [
+                    ArgumentTypeDescriptor.CreateSimple(CorElementType.ELEMENT_TYPE_I8),
+                    ArgumentTypeDescriptor.CreateValueType(CancellationTokenTypeName)
+                ]),
+            RewritingDescriptor: new MethodRewritingDescriptor(
+                InjectHooks: true,
+                InjectManagedWrapper: false,
+                Arguments: [ObjectRefArg],
+                ReturnValue: new CapturedValueDescriptor((byte)nint.Size, CapturedValue.CaptureAsReference),
+                MethodEnterInterpretation: (ushort)RecordedEventType.SemaphoreWaitAsync,
+                MethodExitInterpretation: (ushort)RecordedEventType.SemaphoreWaitAsyncResult));
+
         ReleaseWithCount = new MethodDescriptor(
             MethodName: "Release",
             DeclaringTypeFullName: SemaphoreSlimTypeName,
@@ -124,6 +173,8 @@ public static class SemaphoreSlimMethodDescriptors
         // Internal API
         yield return WaitV8;
         yield return WaitCoreV10;
+        yield return WaitAsyncV8;
+        yield return WaitAsyncCoreV10;
     }
 }
 

--- a/src/Extensibility/SharpDetect.Plugins.PerThreadOrdering/PerThreadOrderingPluginBase.cs
+++ b/src/Extensibility/SharpDetect.Plugins.PerThreadOrdering/PerThreadOrderingPluginBase.cs
@@ -19,6 +19,7 @@ public abstract class PerThreadOrderingPluginBase : PluginBase
     private readonly ThreadCallStackTracker _callStackTracker = new();
     private readonly ThreadObjectRegistry _threadObjectRegistry = new();
     private readonly Dictionary<ProcessTrackedObjectId, List<(ProcessThreadId JoiningThread, ModuleId ModuleId, MdMethodDef MethodToken)>> _pendingJoinAttempts = [];
+    private readonly Dictionary<ProcessTrackedObjectId, ProcessTrackedObjectId> _waitAsyncTaskToSemaphore = [];
     private readonly IArgumentsParser _argumentsParser;
 
     public event Action<LockAcquireAttemptArgs>? LockAcquireAttempted;
@@ -44,6 +45,7 @@ public abstract class PerThreadOrderingPluginBase : PluginBase
     public event Action<SemaphoreAcquireAttemptArgs>? SemaphoreAcquireAttempted;
     public event Action<SemaphoreAcquireResultArgs>? SemaphoreAcquireReturned;
     public event Action<SemaphoreReleaseArgs>? SemaphoreReleased;
+    public event Action<SemaphoreWaitAsyncArgs>? SemaphoreWaitAsyncReturned;
 
     protected PerThreadOrderingPluginBase(
         IModuleBindContext moduleBindContext,
@@ -81,6 +83,7 @@ public abstract class PerThreadOrderingPluginBase : PluginBase
     protected void RaiseSemaphoreAcquireAttempted(SemaphoreAcquireAttemptArgs args) => SemaphoreAcquireAttempted?.Invoke(args);
     protected void RaiseSemaphoreAcquireReturned(SemaphoreAcquireResultArgs args) => SemaphoreAcquireReturned?.Invoke(args);
     protected void RaiseSemaphoreReleased(SemaphoreReleaseArgs args) => SemaphoreReleased?.Invoke(args);
+    protected void RaiseSemaphoreWaitAsyncReturned(SemaphoreWaitAsyncArgs args) => SemaphoreWaitAsyncReturned?.Invoke(args);
 
     [RecordedEventBind((ushort)RecordedEventType.LockAcquire)]
     [RecordedEventBind((ushort)RecordedEventType.LockTryAcquire)]
@@ -209,7 +212,29 @@ public abstract class PerThreadOrderingPluginBase : PluginBase
     [RecordedEventBind((ushort)RecordedEventType.SemaphoreReleaseResult)]
     public void OnSemaphoreReleaseExit(RecordedEventMetadata metadata, MethodExitRecordedEvent args)
         => PopFrame(metadata, args.ModuleId, args.MethodToken);
-    
+
+    [RecordedEventBind((ushort)RecordedEventType.SemaphoreWaitAsync)]
+    public void OnSemaphoreWaitAsyncEnter(RecordedEventMetadata metadata, MethodEnterWithArgumentsRecordedEvent args)
+    {
+        var (id, arguments, _) = ExtractSynchronizationContext(metadata, args);
+        _callStackTracker.Push(id, new StackFrame(args.ModuleId, args.MethodToken, arguments));
+    }
+
+    [RecordedEventBind((ushort)RecordedEventType.SemaphoreWaitAsyncResult)]
+    public void OnSemaphoreWaitAsyncExit(RecordedEventMetadata metadata, MethodExitRecordedEvent args)
+        => PopFrame(metadata, args.ModuleId, args.MethodToken);
+
+    [RecordedEventBind((ushort)RecordedEventType.SemaphoreWaitAsyncResult)]
+    public void OnSemaphoreWaitAsyncExit(RecordedEventMetadata metadata, MethodExitWithArgumentsRecordedEvent args)
+    {
+        var id = new ProcessThreadId(metadata.Pid, metadata.Tid);
+        var frame = _callStackTracker.Pop(id);
+        EnsureCallStackIntegrity(frame, args.ModuleId, args.MethodToken);
+        var semaphoreId = new ProcessTrackedObjectId(id.ProcessId, frame.Arguments!.Value[0].Value.AsT1);
+        var waiterTaskId = new ProcessTrackedObjectId(id.ProcessId, new TrackedObjectId(MemoryMarshal.Read<nuint>(args.ReturnValue)));
+        _waitAsyncTaskToSemaphore[waiterTaskId] = semaphoreId;
+    }
+
     [RecordedEventBind((ushort)RecordedEventType.ThreadStartCore)]
     public void OnThreadStartCore(RecordedEventMetadata metadata, MethodEnterWithArgumentsRecordedEvent args)
     {
@@ -374,6 +399,17 @@ public abstract class PerThreadOrderingPluginBase : PluginBase
         base.Visit(metadata, args);
     }
 
+    protected override void Visit(RecordedEventMetadata metadata, GarbageCollectedTrackedObjectsRecordedEvent args)
+    {
+        if (_waitAsyncTaskToSemaphore.Count > 0)
+        {
+            foreach (var objectId in args.RemovedTrackedObjectIds)
+                _waitAsyncTaskToSemaphore.Remove(new ProcessTrackedObjectId(metadata.Pid, objectId));
+        }
+
+        base.Visit(metadata, args);
+    }
+
     protected override void Visit(RecordedEventMetadata metadata, MethodUnwoundRecordedEvent args)
     {
         // The instrumented method exited via an exception, so no method-exit event was produced
@@ -425,6 +461,9 @@ public abstract class PerThreadOrderingPluginBase : PluginBase
             case RecordedEventType.TaskJoinFinish:
             {
                 var taskObjectId = new ProcessTrackedObjectId(id.ProcessId, frame.Arguments!.Value[0].Value.AsT1);
+                if (_waitAsyncTaskToSemaphore.Remove(taskObjectId))
+                    break;
+                
                 ProcessTaskJoinFinish(id, taskObjectId, isSuccess: false);
                 break;
             }
@@ -462,7 +501,15 @@ public abstract class PerThreadOrderingPluginBase : PluginBase
         var frame = _callStackTracker.Pop(id);
         EnsureCallStackIntegrity(frame, moduleId, methodToken);
         var taskObjectId = new ProcessTrackedObjectId(id.ProcessId, frame.Arguments!.Value[0].Value.AsT1);
-        ProcessTaskJoinFinish(id, taskObjectId, isSuccess);
+        
+        if (_waitAsyncTaskToSemaphore.Remove(taskObjectId, out var semaphoreId) && isSuccess)
+        {
+            SemaphoreWaitAsyncReturned?.Invoke(new(id, moduleId, methodToken, semaphoreId, taskObjectId));
+        }
+        else
+        {
+            ProcessTaskJoinFinish(id, taskObjectId, isSuccess);
+        }
     }
 
     protected virtual void ProcessLockAcquire(

--- a/src/SharpDetect.Core/Events/RecordedEventType.cs
+++ b/src/SharpDetect.Core/Events/RecordedEventType.cs
@@ -91,6 +91,8 @@ public enum RecordedEventType : ushort
     SemaphoreRelease = 121,
     SemaphoreReleaseResult = 122,
     SemaphoreCreate = 123,
+    SemaphoreWaitAsync = 124,
+    SemaphoreWaitAsyncResult = 125,
 
     /* Task synchronization */
     TaskSchedule = 200,

--- a/src/SharpDetect.Core/Plugins/PluginEventArgs.cs
+++ b/src/SharpDetect.Core/Plugins/PluginEventArgs.cs
@@ -29,3 +29,4 @@ public readonly record struct SemaphoreAcquireAttemptArgs(ProcessThreadId Proces
 public readonly record struct SemaphoreAcquireResultArgs(ProcessThreadId ProcessThreadId, ModuleId ModuleId, MdMethodDef MethodToken, ProcessTrackedObjectId SemaphoreId, bool IsSuccess);
 public readonly record struct SemaphoreReleaseArgs(ProcessThreadId ProcessThreadId, ModuleId ModuleId, MdMethodDef MethodToken, ProcessTrackedObjectId SemaphoreId, int ReleaseCount);
 public readonly record struct SemaphoreCreatedArgs(ProcessThreadId ProcessThreadId, ModuleId ModuleId, MdMethodDef MethodToken, ProcessTrackedObjectId SemaphoreId, int InitialCount);
+public readonly record struct SemaphoreWaitAsyncArgs(ProcessThreadId ProcessThreadId, ModuleId ModuleId, MdMethodDef MethodToken, ProcessTrackedObjectId SemaphoreId, ProcessTrackedObjectId WaiterTaskId);

--- a/src/SharpDetect.Profiler/SharpDetect.Concurrency.Profiler/TypeInjector.cpp
+++ b/src/SharpDetect.Profiler/SharpDetect.Concurrency.Profiler/TypeInjector.cpp
@@ -38,37 +38,70 @@ LibIPC::MetadataMsg Profiler::TypeInjector::CreateMetadataMsg() const
     return LibIPC::Helpers::CreateMetadataMsg(LibProfiler::PAL_GetCurrentPid(), threadId);
 }
 
+static void AppendCompressedToken(mdToken token, std::vector<COR_SIGNATURE>& result)
+{
+    BYTE bytes[4];
+    const ULONG length = CorSigCompressToken(token, bytes);
+    result.insert(result.end(), bytes, bytes + length);
+}
+
+static void AppendCompressedData(ULONG value, std::vector<COR_SIGNATURE>& result)
+{
+    BYTE bytes[4];
+    const ULONG length = CorSigCompressData(value, bytes);
+    result.insert(result.end(), bytes, bytes + length);
+}
+
 static HRESULT SerializeArgumentTypeDescriptor(
     const Profiler::ArgumentTypeDescriptor& descriptor,
     const LibProfiler::ModuleDef& moduleDef,
     std::vector<COR_SIGNATURE>& result)
 {
-    for (size_t i = 0; i < descriptor.elementTypes.size(); i++)
+    const auto& elementTypes = descriptor.elementTypes;
+
+    for (size_t i = 0; i < elementTypes.size(); )
     {
-        const auto elementType = descriptor.elementTypes[i];
+        const auto elementType = elementTypes[i];
         result.push_back(elementType);
+
+        if (elementType == CorElementType::ELEMENT_TYPE_GENERICINST)
+        {
+            if (i + 1 >= elementTypes.size())
+            {
+                LOG_F(ERROR, "GENERICINST is missing its generic type definition kind.");
+                return E_FAIL;
+            }
+
+            result.push_back(elementTypes[i + 1]);
+
+            mdTypeDef typeDef;
+            if (FAILED(moduleDef.FindTypeDef(descriptor.typeName.value(), &typeDef)))
+            {
+                LOG_F(ERROR, "Generic type %s not found in module", descriptor.typeName.value().c_str());
+                return E_FAIL;
+            }
+            AppendCompressedToken(typeDef, result);
+
+            const ULONG genericArgumentCount = static_cast<ULONG>(elementTypes.size() - (i + 2));
+            AppendCompressedData(genericArgumentCount, result);
+
+            i += 2;
+            continue;
+        }
 
         if (elementType == CorElementType::ELEMENT_TYPE_CLASS || elementType == CorElementType::ELEMENT_TYPE_VALUETYPE)
         {
             mdTypeDef typeDef;
-            auto hr = moduleDef.FindTypeDef(descriptor.typeName.value(), &typeDef);
-
-            if (SUCCEEDED(hr))
-            {
-                // Compress the token into the signature
-                BYTE tokenBytes[4];
-                const ULONG tokenLength = CorSigCompressToken(typeDef, tokenBytes);
-
-                for (ULONG j = 0; j < tokenLength; j++)
-                    result.push_back(tokenBytes[j]);
-            }
-            else
+            if (FAILED(moduleDef.FindTypeDef(descriptor.typeName.value(), &typeDef)))
             {
                 // FIXME: add support for type references
                 LOG_F(ERROR, "Type %s not found in module", descriptor.typeName.value().c_str());
                 return E_FAIL;
             }
+            AppendCompressedToken(typeDef, result);
         }
+
+        ++i;
     }
 
     return S_OK;

--- a/src/Tests/SharpDetect.E2ETests.Subject/Entrypoint.cs
+++ b/src/Tests/SharpDetect.E2ETests.Subject/Entrypoint.cs
@@ -521,6 +521,24 @@ namespace SharpDetect.E2ETests.Subject
                 case nameof(Test_NoDataRace_SemaphoreSlim_ProtectedWriteRead):
                     Test_NoDataRace_SemaphoreSlim_ProtectedWriteRead();
                     break;
+                case nameof(Test_NoDataRace_SemaphoreSlimAsync_ProtectedWriteRead):
+                    Test_NoDataRace_SemaphoreSlimAsync_ProtectedWriteRead();
+                    break;
+                case nameof(Test_NoDataRace_SemaphoreSlimAsync_HighContention_WriteRead):
+                    Test_NoDataRace_SemaphoreSlimAsync_HighContention_WriteRead();
+                    break;
+                case nameof(Test_NoDataRace_SemaphoreSlimAsync_WithCancellationToken_ProtectedWriteRead):
+                    Test_NoDataRace_SemaphoreSlimAsync_WithCancellationToken_ProtectedWriteRead();
+                    break;
+                case nameof(Test_NoDataRace_SemaphoreSlimAsync_WithTimeout_ProtectedWriteRead):
+                    Test_NoDataRace_SemaphoreSlimAsync_WithTimeout_ProtectedWriteRead();
+                    break;
+                case nameof(Test_NoDataRace_SemaphoreSlimAsync_CanceledWait_NoSharedAccess):
+                    Test_NoDataRace_SemaphoreSlimAsync_CanceledWait_NoSharedAccess();
+                    break;
+                case nameof(Test_NoDataRace_SemaphoreSlimAsync_TimeoutExpires_NoSharedAccess):
+                    Test_NoDataRace_SemaphoreSlimAsync_TimeoutExpires_NoSharedAccess();
+                    break;
                 case nameof(Test_NoDataRace_Monitor_HighContention_WriteRead):
                     Test_NoDataRace_Monitor_HighContention_WriteRead();
                     break;

--- a/src/Tests/SharpDetect.E2ETests.Subject/SimpleTests.cs
+++ b/src/Tests/SharpDetect.E2ETests.Subject/SimpleTests.cs
@@ -1357,6 +1357,117 @@ namespace SharpDetect.E2ETests.Subject
             Task.WaitAll(task1, task2);
         }
 
+        public static void Test_NoDataRace_SemaphoreSlimAsync_ProtectedWriteRead()
+        {
+            var sem = new SemaphoreSlim(1, 1);
+            var task1 = Task.Run(async () =>
+            {
+                await sem.WaitAsync();
+                DataRace.Test_DataRace_ValueType_Static = 42;
+                sem.Release();
+            });
+            var task2 = Task.Run(async () =>
+            {
+                await sem.WaitAsync();
+                _ = DataRace.Test_DataRace_ValueType_Static;
+                sem.Release();
+            });
+            Task.WaitAll(task1, task2);
+        }
+
+        public static void Test_NoDataRace_SemaphoreSlimAsync_HighContention_WriteRead()
+        {
+            const int iterations = 5000;
+            var semaphore = new SemaphoreSlim(1, 1);
+            RunConcurrently(
+                () =>
+                {
+                    for (var i = 0; i < iterations; i++)
+                    {
+                        semaphore.WaitAsync().GetAwaiter().GetResult();
+                        DataRace.Test_DataRace_ValueType_Static = i;
+                        semaphore.Release();
+                    }
+                },
+                () =>
+                {
+                    for (var i = 0; i < iterations; i++)
+                    {
+                        semaphore.WaitAsync().GetAwaiter().GetResult();
+                        _ = DataRace.Test_DataRace_ValueType_Static;
+                        semaphore.Release();
+                    }
+                });
+        }
+
+        public static void Test_NoDataRace_SemaphoreSlimAsync_WithCancellationToken_ProtectedWriteRead()
+        {
+            var sem = new SemaphoreSlim(1, 1);
+            using var cts = new CancellationTokenSource();
+            var task1 = Task.Run(async () =>
+            {
+                await sem.WaitAsync(cts.Token);
+                DataRace.Test_DataRace_ValueType_Static = 42;
+                sem.Release();
+            });
+            var task2 = Task.Run(async () =>
+            {
+                await sem.WaitAsync(cts.Token);
+                _ = DataRace.Test_DataRace_ValueType_Static;
+                sem.Release();
+            });
+            Task.WaitAll(task1, task2);
+        }
+
+        public static void Test_NoDataRace_SemaphoreSlimAsync_WithTimeout_ProtectedWriteRead()
+        {
+            var sem = new SemaphoreSlim(1, 1);
+            var task1 = Task.Run(async () =>
+            {
+                if (await sem.WaitAsync(Timeout.Infinite))
+                {
+                    DataRace.Test_DataRace_ValueType_Static = 42;
+                    sem.Release();
+                }
+            });
+            var task2 = Task.Run(async () =>
+            {
+                if (await sem.WaitAsync(Timeout.Infinite))
+                {
+                    _ = DataRace.Test_DataRace_ValueType_Static;
+                    sem.Release();
+                }
+            });
+            Task.WaitAll(task1, task2);
+        }
+
+        public static void Test_NoDataRace_SemaphoreSlimAsync_CanceledWait_NoSharedAccess()
+        {
+            var sem = new SemaphoreSlim(0, 1);
+            using var cts = new CancellationTokenSource();
+            var task = Task.Run(async () =>
+            {
+                try
+                {
+                    await sem.WaitAsync(cts.Token);
+                }
+                catch (OperationCanceledException)
+                {
+                    // expected
+                }
+            });
+            cts.Cancel();
+            task.Wait();
+        }
+
+        public static void Test_NoDataRace_SemaphoreSlimAsync_TimeoutExpires_NoSharedAccess()
+        {
+            var sem = new SemaphoreSlim(0, 1);
+            var acquired = sem.WaitAsync(millisecondsTimeout: 50).GetAwaiter().GetResult();
+            if (acquired)
+                sem.Release();
+        }
+
         public static void Test_NoDataRace_Monitor_HighContention_WriteRead()
         {
             const int iterations = 5000;

--- a/src/Tests/SharpDetect.E2ETests/DataRacePluginTests.cs
+++ b/src/Tests/SharpDetect.E2ETests/DataRacePluginTests.cs
@@ -170,6 +170,36 @@ public class DataRacePluginTests(ITestOutputHelper testOutput)
         => AssertDoesNotDetectDataRace("Test_NoDataRace_SemaphoreSlim_ProtectedWriteRead", sdk, plugin);
 
     [Theory]
+    [MemberData(nameof(SdkVersions.AllWithFastTrackOnly), MemberType = typeof(SdkVersions))]
+    public Task NoDataRace_SemaphoreSlimAsync_ProtectedWriteRead(string sdk, string plugin)
+        => AssertDoesNotDetectDataRace("Test_NoDataRace_SemaphoreSlimAsync_ProtectedWriteRead", sdk, plugin);
+
+    [Theory]
+    [MemberData(nameof(SdkVersions.AllWithFastTrackOnly), MemberType = typeof(SdkVersions))]
+    public Task NoDataRace_SemaphoreSlimAsync_HighContention_WriteRead(string sdk, string plugin)
+        => AssertDoesNotDetectDataRace("Test_NoDataRace_SemaphoreSlimAsync_HighContention_WriteRead", sdk, plugin);
+
+    [Theory]
+    [MemberData(nameof(SdkVersions.AllWithFastTrackOnly), MemberType = typeof(SdkVersions))]
+    public Task NoDataRace_SemaphoreSlimAsync_WithCancellationToken_ProtectedWriteRead(string sdk, string plugin)
+        => AssertDoesNotDetectDataRace("Test_NoDataRace_SemaphoreSlimAsync_WithCancellationToken_ProtectedWriteRead", sdk, plugin);
+
+    [Theory]
+    [MemberData(nameof(SdkVersions.AllWithFastTrackOnly), MemberType = typeof(SdkVersions))]
+    public Task NoDataRace_SemaphoreSlimAsync_WithTimeout_ProtectedWriteRead(string sdk, string plugin)
+        => AssertDoesNotDetectDataRace("Test_NoDataRace_SemaphoreSlimAsync_WithTimeout_ProtectedWriteRead", sdk, plugin);
+
+    [Theory]
+    [MemberData(nameof(SdkVersions.AllWithFastTrackOnly), MemberType = typeof(SdkVersions))]
+    public Task NoDataRace_SemaphoreSlimAsync_CanceledWait_NoSharedAccess(string sdk, string plugin)
+        => AssertDoesNotDetectDataRace("Test_NoDataRace_SemaphoreSlimAsync_CanceledWait_NoSharedAccess", sdk, plugin);
+
+    [Theory]
+    [MemberData(nameof(SdkVersions.AllWithFastTrackOnly), MemberType = typeof(SdkVersions))]
+    public Task NoDataRace_SemaphoreSlimAsync_TimeoutExpires_NoSharedAccess(string sdk, string plugin)
+        => AssertDoesNotDetectDataRace("Test_NoDataRace_SemaphoreSlimAsync_TimeoutExpires_NoSharedAccess", sdk, plugin);
+
+    [Theory]
     [MemberData(nameof(SdkVersions.AllWithBothDataRacePlugins), MemberType = typeof(SdkVersions))]
     public Task NoDataRace_Monitor_HighContention_WriteRead(string sdk, string plugin)
         => AssertDoesNotDetectDataRace("Test_NoDataRace_Monitor_HighContention_WriteRead", sdk, plugin);

--- a/src/Tests/SharpDetect.PluginHost.Tests/ReorderingPluginHostTests.cs
+++ b/src/Tests/SharpDetect.PluginHost.Tests/ReorderingPluginHostTests.cs
@@ -21,6 +21,7 @@ public class ReorderingPluginHostTests
     private const nuint S1 = 0x1800;
     private const nuint Task1 = 0x2000;
     private const nuint Task2 = 0x2001;
+    private const nuint Task3 = 0x2002;
 
     private static ReorderingPluginHost Build(out RecordingPluginHost recorder)
     {
@@ -520,6 +521,149 @@ public class ReorderingPluginHostTests
         // Assert
         Assert.Contains(recorder.Dispatched, e => e.Metadata.Tid.Value == T2 && IsSemaphoreAcquireResult(e));
         Assert.Contains(recorder.Dispatched, e => e.Metadata.Tid.Value == T3 && IsSemaphoreAcquireResult(e));
+    }
+
+    [Fact]
+    public void ReorderingPluginHost_WaitAsyncImmediateAcquire_ContinuationNotDeferred()
+    {
+        // Arrange
+        var host = Build(out var recorder);
+
+        // Act
+        host.ProcessEvent(SyncEventBuilder.EnterWithTargetCountAndCapacity(T1, RecordedEventType.SemaphoreCreate, S1, 1, 1));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.SemaphoreWaitAsync, S1));
+        host.ProcessEvent(SyncEventBuilder.ExitWithReturnedTarget(T1, RecordedEventType.SemaphoreWaitAsyncResult, Task1));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.TaskJoinStart, Task1));
+        host.ProcessEvent(SyncEventBuilder.ExitWithSuccess(T1, RecordedEventType.TaskJoinFinish, true));
+        host.ProcessEvent(SyncEventBuilder.FieldRead(T1));
+
+        // Assert
+        var kinds = recorder.Dispatched.Select(ClassifyDispatched).ToArray();
+        Assert.Equal(new[]
+        {
+            (T1, RecordedEventType.SemaphoreCreate),
+            (T1, RecordedEventType.SemaphoreWaitAsync),
+            (T1, RecordedEventType.SemaphoreWaitAsyncResult),
+            (T1, RecordedEventType.TaskJoinStart),
+            (T1, RecordedEventType.TaskJoinFinish),
+            (T1, RecordedEventType.InstanceFieldRead),
+        }, kinds);
+    }
+
+    [Fact]
+    public void ReorderingPluginHost_WaitAsyncContended_ContinuationDeferredUntilRelease_AndReordered()
+    {
+        // Arrange
+        var host = Build(out var recorder);
+
+        // Act
+        host.ProcessEvent(SyncEventBuilder.EnterWithTargetCountAndCapacity(T1, RecordedEventType.SemaphoreCreate, S1, 1, 1));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.SemaphoreWaitAsync, S1));
+        host.ProcessEvent(SyncEventBuilder.ExitWithReturnedTarget(T1, RecordedEventType.SemaphoreWaitAsyncResult, Task1));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.TaskJoinStart, Task1));
+        host.ProcessEvent(SyncEventBuilder.ExitWithSuccess(T1, RecordedEventType.TaskJoinFinish, true)); // T1 consumes the permit
+
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T2, RecordedEventType.SemaphoreWaitAsync, S1));
+        host.ProcessEvent(SyncEventBuilder.ExitWithReturnedTarget(T2, RecordedEventType.SemaphoreWaitAsyncResult, Task2));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T3, RecordedEventType.TaskJoinStart, Task2));
+        host.ProcessEvent(SyncEventBuilder.ExitWithSuccess(T3, RecordedEventType.TaskJoinFinish, true)); // deferred [no permit]
+        host.ProcessEvent(SyncEventBuilder.FieldRead(T3)); // deferred
+
+        Assert.DoesNotContain(recorder.Dispatched, e => ClassifyDispatched(e) == (T3, RecordedEventType.TaskJoinFinish));
+
+        host.ProcessEvent(SyncEventBuilder.EnterWithTargetAndCount(T1, RecordedEventType.SemaphoreRelease, S1, 1)); // wakes T3
+        host.ProcessEvent(SyncEventBuilder.Exit(T1, RecordedEventType.SemaphoreReleaseResult));
+
+        // Assert
+        var releaseIdx = recorder.Dispatched.FindIndex(e => ClassifyDispatched(e) == (T1, RecordedEventType.SemaphoreRelease));
+        var joinIdx = recorder.Dispatched.FindIndex(e => ClassifyDispatched(e) == (T3, RecordedEventType.TaskJoinFinish));
+        var readIdx = recorder.Dispatched.FindIndex(e => ClassifyDispatched(e) == (T3, RecordedEventType.InstanceFieldRead));
+        Assert.True(releaseIdx >= 0);
+        Assert.True(joinIdx > releaseIdx, "continuation must be ordered after the release");
+        Assert.True(readIdx > joinIdx, "protected read must follow the continuation");
+    }
+
+    [Fact]
+    public void ReorderingPluginHost_WaitAsyncTimedOut_NoAcquire_NoDeadlock()
+    {
+        // Arrange
+        var host = Build(out var recorder);
+
+        // Act
+        host.ProcessEvent(SyncEventBuilder.EnterWithTargetCountAndCapacity(T1, RecordedEventType.SemaphoreCreate, S1, 1, 1));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.SemaphoreWaitAsync, S1));
+        host.ProcessEvent(SyncEventBuilder.ExitWithReturnedTarget(T1, RecordedEventType.SemaphoreWaitAsyncResult, Task1));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.TaskJoinStart, Task1));
+        host.ProcessEvent(SyncEventBuilder.ExitWithSuccess(T1, RecordedEventType.TaskJoinFinish, true)); // T1 consumes the permit
+
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T2, RecordedEventType.SemaphoreWaitAsync, S1));
+        host.ProcessEvent(SyncEventBuilder.ExitWithReturnedTarget(T2, RecordedEventType.SemaphoreWaitAsyncResult, Task2));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T2, RecordedEventType.TaskJoinStart, Task2));
+        host.ProcessEvent(SyncEventBuilder.ExitWithSuccess(T2, RecordedEventType.TaskJoinFinish, false)); // timed out, not deferred
+
+        Assert.Contains(recorder.Dispatched, e => ClassifyDispatched(e) == (T2, RecordedEventType.TaskJoinFinish));
+
+        host.ProcessEvent(SyncEventBuilder.EnterWithTargetAndCount(T1, RecordedEventType.SemaphoreRelease, S1, 1));
+        host.ProcessEvent(SyncEventBuilder.Exit(T1, RecordedEventType.SemaphoreReleaseResult));
+
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T3, RecordedEventType.SemaphoreWaitAsync, S1));
+        host.ProcessEvent(SyncEventBuilder.ExitWithReturnedTarget(T3, RecordedEventType.SemaphoreWaitAsyncResult, Task3));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T3, RecordedEventType.TaskJoinStart, Task3));
+        host.ProcessEvent(SyncEventBuilder.ExitWithSuccess(T3, RecordedEventType.TaskJoinFinish, true));
+
+        // Assert
+        Assert.Contains(recorder.Dispatched, e => ClassifyDispatched(e) == (T3, RecordedEventType.TaskJoinFinish));
+    }
+
+    [Fact]
+    public void ReorderingPluginHost_WaitAsyncCanceled_NoAcquire_NoDeadlock()
+    {
+        // Arrange
+        var host = Build(out var recorder);
+
+        // Act
+        host.ProcessEvent(SyncEventBuilder.EnterWithTargetCountAndCapacity(T1, RecordedEventType.SemaphoreCreate, S1, 1, 1));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.SemaphoreWaitAsync, S1));
+        host.ProcessEvent(SyncEventBuilder.ExitWithReturnedTarget(T1, RecordedEventType.SemaphoreWaitAsyncResult, Task1));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.TaskJoinStart, Task1));
+        host.ProcessEvent(SyncEventBuilder.ExitWithSuccess(T1, RecordedEventType.TaskJoinFinish, true)); // T1 consumes the permit
+
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T2, RecordedEventType.SemaphoreWaitAsync, S1));
+        host.ProcessEvent(SyncEventBuilder.ExitWithReturnedTarget(T2, RecordedEventType.SemaphoreWaitAsyncResult, Task2));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T2, RecordedEventType.TaskJoinStart, Task2));
+        host.ProcessEvent(SyncEventBuilder.Unwound(T2, RecordedEventType.TaskJoinFinish)); // canceled, not deferred
+
+        host.ProcessEvent(SyncEventBuilder.EnterWithTargetAndCount(T1, RecordedEventType.SemaphoreRelease, S1, 1));
+        host.ProcessEvent(SyncEventBuilder.Exit(T1, RecordedEventType.SemaphoreReleaseResult));
+
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T3, RecordedEventType.SemaphoreWaitAsync, S1));
+        host.ProcessEvent(SyncEventBuilder.ExitWithReturnedTarget(T3, RecordedEventType.SemaphoreWaitAsyncResult, Task3));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T3, RecordedEventType.TaskJoinStart, Task3));
+        host.ProcessEvent(SyncEventBuilder.ExitWithSuccess(T3, RecordedEventType.TaskJoinFinish, true));
+
+        // Assert
+        Assert.Contains(recorder.Dispatched, e => ClassifyDispatched(e) == (T3, RecordedEventType.TaskJoinFinish));
+    }
+
+    [Fact]
+    public void ReorderingPluginHost_WaitAsyncAcquireAndReleaseOnDifferentThreads_NoResidualPermits()
+    {
+        // Arrange
+        var host = Build(out _, out var logger);
+
+        host.ProcessEvent(SyncEventBuilder.EnterWithTargetCountAndCapacity(T1, RecordedEventType.SemaphoreCreate, S1, 1, 1));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T2, RecordedEventType.SemaphoreWaitAsync, S1));
+        host.ProcessEvent(SyncEventBuilder.ExitWithReturnedTarget(T2, RecordedEventType.SemaphoreWaitAsyncResult, Task1));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T2, RecordedEventType.TaskJoinStart, Task1));
+        host.ProcessEvent(SyncEventBuilder.ExitWithSuccess(T2, RecordedEventType.TaskJoinFinish, true)); // T2 acquires
+        host.ProcessEvent(SyncEventBuilder.EnterWithTargetAndCount(T3, RecordedEventType.SemaphoreRelease, S1, 1)); // T3 releases
+        host.ProcessEvent(SyncEventBuilder.Exit(T3, RecordedEventType.SemaphoreReleaseResult));
+
+        // Act
+        host.ProcessEvent(SyncEventBuilder.GarbageCollected(T1, S1));
+
+        // Assert
+        Assert.DoesNotContain(logger.Entries, e => e.Message.Contains("residual state"));
     }
 
     [Fact]
@@ -1101,7 +1245,7 @@ public class ReorderingPluginHostTests
     }
 
     [Fact]
-    public void ReorderingPluginHost_GarbageCollected_SemaphoreWithOutstandingPermits_LogsWarning()
+    public void ReorderingPluginHost_GarbageCollected_SemaphoreWithOutstandingPermits_NoWarning()
     {
         // Arrange
         var host = Build(out _, out var logger);
@@ -1114,7 +1258,29 @@ public class ReorderingPluginHostTests
 
         // Assert
         Assert.Equal(0, host.ShadowSemaphoreCount);
-        Assert.Contains(logger.Entries, e => e.Level == LogLevel.Warning && e.Message.Contains("Semaphore"));
+        Assert.DoesNotContain(logger.Entries, e => e.Message.Contains("garbage collected with residual state"));
+    }
+
+    [Fact]
+    public void ReorderingPluginHost_GarbageCollected_SemaphoreWithBlockedWaiter_LogsWarning()
+    {
+        // Arrange
+        var host = Build(out _, out var logger);
+
+        // Act
+        host.ProcessEvent(SyncEventBuilder.EnterWithTargetCountAndCapacity(T1, RecordedEventType.SemaphoreCreate, S1, 1, 1));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T1, RecordedEventType.SemaphoreAcquire, S1));
+        host.ProcessEvent(SyncEventBuilder.ExitWithSuccess(T1, RecordedEventType.SemaphoreAcquireResult, true));
+        host.ProcessEvent(SyncEventBuilder.EnterWithTarget(T2, RecordedEventType.SemaphoreAcquire, S1));
+        host.ProcessEvent(SyncEventBuilder.ExitWithSuccess(T2, RecordedEventType.SemaphoreAcquireResult, true)); // T2 blocks
+        host.ProcessEvent(SyncEventBuilder.GarbageCollected(TReaper, S1));
+
+        // Assert
+        Assert.Equal(0, host.ShadowSemaphoreCount);
+        Assert.Contains(logger.Entries, e =>
+            e.Level == LogLevel.Warning &&
+            e.Message.Contains("garbage collected with residual state") &&
+            e.Message.Contains("waiters=1"));
     }
 
     [Fact]

--- a/src/Tests/SharpDetect.PluginHost.Tests/SyncEventBuilder.cs
+++ b/src/Tests/SharpDetect.PluginHost.Tests/SyncEventBuilder.cs
@@ -107,6 +107,19 @@ internal static class SyncEventBuilder
             ByRefArgumentInfos: []));
     }
 
+    public static RecordedEvent ExitWithReturnedTarget(uint tid, RecordedEventType type, nuint returnedObjectId)
+    {
+        var ret = new byte[Unsafe.SizeOf<nuint>()];
+        MemoryMarshal.Write(ret, in returnedObjectId);
+        return new RecordedEvent(Meta(tid), new MethodExitWithArgumentsRecordedEvent(
+            ModuleId: Module,
+            MethodToken: Method,
+            Interpretation: (ushort)type,
+            ReturnValue: ret,
+            ByRefArgumentValues: [],
+            ByRefArgumentInfos: []));
+    }
+
     public static RecordedEvent ExitWithByRefSuccess(uint tid, RecordedEventType type, bool success)
     {
         var byRef = new byte[1];


### PR DESCRIPTION
This PR adds missing support for `WaitAsync` on `SemaphoreSlim`. Now we should support both synchronous and asynchronous semaphore methods