### PR TITLE
Performance improvements

### DIFF
--- a/src/Extensibility/SharpDetect.Plugins.DataRace.Common/AccessTracker.cs
+++ b/src/Extensibility/SharpDetect.Plugins.DataRace.Common/AccessTracker.cs
@@ -1,93 +1,120 @@
 // Copyright 2026 Andrej Čižmárik and Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+using System.Runtime.InteropServices;
 using SharpDetect.Core.Events.Profiler;
 using SharpDetect.Core.Plugins;
 
 namespace SharpDetect.Plugins.DataRace.Common;
 
-public sealed class AccessTracker(TimeProvider timeProvider, Func<ProcessThreadId, string?> threadNameResolver)
+public sealed class AccessTracker(Func<ProcessThreadId, string?> threadNameResolver)
 {
-    private readonly Dictionary<FieldId, AccessInfo> _staticLastAccessInfo = [];
-    private readonly Dictionary<FieldId, AccessInfo> _staticLastWriteAccessInfo = [];
-    private readonly Dictionary<(FieldId, ProcessTrackedObjectId), AccessInfo> _instanceLastAccessInfo = [];
-    private readonly Dictionary<(FieldId, ProcessTrackedObjectId), AccessInfo> _instanceLastWriteAccessInfo = [];
-    private readonly Dictionary<ProcessTrackedObjectId, HashSet<FieldId>> _objectFieldIndex = [];
+    private readonly Dictionary<FieldId, AccessSlots> _staticFieldSlots = [];
+    private readonly Dictionary<ProcessTrackedObjectId, Dictionary<FieldId, AccessSlots>> _instanceFieldSlots = [];
 
-    public AccessInfo? GetLastAccess(FieldId fieldId, ProcessTrackedObjectId? objectId)
+    private struct AccessSlots
     {
-        return objectId != null
-            ? _instanceLastAccessInfo.GetValueOrDefault((fieldId, objectId.Value))
-            : _staticLastAccessInfo.GetValueOrDefault(fieldId);
+        public AccessRecord Last;
+        public AccessRecord LastWrite;
+        public bool HasWrite;
     }
 
-    public AccessInfo? GetLastWriteAccess(FieldId fieldId, ProcessTrackedObjectId? objectId)
-    {
-        return objectId != null
-            ? _instanceLastWriteAccessInfo.GetValueOrDefault((fieldId, objectId.Value))
-            : _staticLastWriteAccessInfo.GetValueOrDefault(fieldId);
-    }
-
-    public void RecordAccess(FieldId fieldId, ProcessTrackedObjectId? objectId, AccessInfo accessInfo)
+    public bool TryGetLastAccess(FieldId fieldId, ProcessTrackedObjectId? objectId, out AccessRecord record)
     {
         if (objectId != null)
         {
-            var key = (fieldId, objectId.Value);
-            _instanceLastAccessInfo[key] = accessInfo;
-            if (accessInfo.AccessType == AccessType.Write)
-                _instanceLastWriteAccessInfo[key] = accessInfo;
-            TrackObjectField(objectId.Value, fieldId);
+            if (_instanceFieldSlots.TryGetValue(objectId.Value, out var fields) && fields.TryGetValue(fieldId, out var slots))
+            {
+                record = slots.Last;
+                return true;
+            }
         }
-        else
+        else if (_staticFieldSlots.TryGetValue(fieldId, out var slots))
         {
-            _staticLastAccessInfo[fieldId] = accessInfo;
-            if (accessInfo.AccessType == AccessType.Write)
-                _staticLastWriteAccessInfo[fieldId] = accessInfo;
+            record = slots.Last;
+            return true;
         }
+
+        record = default;
+        return false;
     }
 
-    public AccessInfo CreateAccessInfo(
+    public bool TryGetLastWriteAccess(FieldId fieldId, ProcessTrackedObjectId? objectId, out AccessRecord record)
+    {
+        if (objectId != null)
+        {
+            if (_instanceFieldSlots.TryGetValue(objectId.Value, out var fields) && fields.TryGetValue(fieldId, out var slots) && slots.HasWrite)
+            {
+                record = slots.LastWrite;
+                return true;
+            }
+        }
+        else if (_staticFieldSlots.TryGetValue(fieldId, out var slots) && slots.HasWrite)
+        {
+            record = slots.LastWrite;
+            return true;
+        }
+
+        record = default;
+        return false;
+    }
+
+    public AccessRecord RecordAccess(
+        FieldId fieldId,
+        ProcessTrackedObjectId? objectId,
         ProcessThreadId threadId,
         ModuleId moduleId,
         MdMethodDef methodToken,
         uint methodOffset,
         AccessType accessType)
     {
+        var record = new AccessRecord(threadId, moduleId, methodToken, methodOffset, accessType);
+        var isWrite = accessType == AccessType.Write;
+
+        if (objectId != null)
+        {
+            if (!_instanceFieldSlots.TryGetValue(objectId.Value, out var fields))
+            {
+                fields = [];
+                _instanceFieldSlots[objectId.Value] = fields;
+            }
+
+            ref var slots = ref CollectionsMarshal.GetValueRefOrAddDefault(fields, fieldId, out _);
+            slots.Last = record;
+            if (isWrite)
+            {
+                slots.LastWrite = record;
+                slots.HasWrite = true;
+            }
+        }
+        else
+        {
+            ref var slots = ref CollectionsMarshal.GetValueRefOrAddDefault(_staticFieldSlots, fieldId, out _);
+            slots.Last = record;
+            if (isWrite)
+            {
+                slots.LastWrite = record;
+                slots.HasWrite = true;
+            }
+        }
+
+        return record;
+    }
+    
+    public AccessInfo Materialize(in AccessRecord record)
+    {
         return new AccessInfo(
-            threadId,
-            threadNameResolver(threadId),
-            moduleId,
-            methodToken,
-            methodOffset,
-            accessType,
-            timeProvider.GetUtcNow().DateTime);
+            record.ProcessThreadId,
+            threadNameResolver(record.ProcessThreadId),
+            record.ModuleId,
+            record.MethodToken,
+            record.MethodOffset,
+            record.AccessType);
     }
 
     public void RemoveTrackedObjects(uint processId, ReadOnlySpan<TrackedObjectId> removedObjectIds)
     {
         foreach (var objectId in removedObjectIds)
-        {
-            var processObjectId = new ProcessTrackedObjectId(processId, objectId);
-            if (!_objectFieldIndex.Remove(processObjectId, out var fieldIds))
-                continue;
-
-            foreach (var fieldId in fieldIds)
-            {
-                _instanceLastAccessInfo.Remove((fieldId, processObjectId));
-                _instanceLastWriteAccessInfo.Remove((fieldId, processObjectId));
-            }
-        }
-    }
-
-    private void TrackObjectField(ProcessTrackedObjectId objectId, FieldId fieldId)
-    {
-        if (!_objectFieldIndex.TryGetValue(objectId, out var fieldIds))
-        {
-            fieldIds = [];
-            _objectFieldIndex[objectId] = fieldIds;
-        }
-
-        fieldIds.Add(fieldId);
+            _instanceFieldSlots.Remove(new ProcessTrackedObjectId(processId, objectId));
     }
 }
-

--- a/src/Extensibility/SharpDetect.Plugins.DataRace.Common/DataRaceInfo.cs
+++ b/src/Extensibility/SharpDetect.Plugins.DataRace.Common/DataRaceInfo.cs
@@ -18,8 +18,14 @@ public sealed record AccessInfo(
     ModuleId ModuleId,
     MdMethodDef MethodToken,
     uint MethodOffset,
-    AccessType AccessType,
-    DateTime Timestamp);
+    AccessType AccessType);
+
+public readonly record struct AccessRecord(
+    ProcessThreadId ProcessThreadId,
+    ModuleId ModuleId,
+    MdMethodDef MethodToken,
+    uint MethodOffset,
+    AccessType AccessType);
 
 public sealed record DataRaceInfo(
     uint ProcessId,

--- a/src/Extensibility/SharpDetect.Plugins.DataRace.Eraser/EraserDetector.cs
+++ b/src/Extensibility/SharpDetect.Plugins.DataRace.Eraser/EraserDetector.cs
@@ -31,7 +31,7 @@ internal sealed class EraserDetector
         _timeProvider = timeProvider;
 
         _threadLockSetTracker = new ThreadLockSetTracker(_lockSetTable);
-        _accessTracker = new AccessTracker(timeProvider, threadNameResolver);
+        _accessTracker = new AccessTracker(threadNameResolver);
         _fieldResolver = new FieldResolver(metadataContext, logger);
         _stateMachine = new EraserStateMachine(_lockSetTable);
     }
@@ -123,22 +123,21 @@ internal sealed class EraserDetector
         var transitionResult = _stateMachine.ComputeTransition(threadId, shadow, threadLockSet, isWrite);
         _shadowMemory.Update(fieldId, objectId, transitionResult.NewShadow);
         var accessType = isWrite ? AccessType.Write : AccessType.Read;
-        var currentAccess = _accessTracker.CreateAccessInfo(threadId, moduleId, methodToken, methodOffset, accessType);
-        var lastRelevantAccess = isWrite 
-            ? _accessTracker.GetLastAccess(fieldId, objectId) 
-            : _accessTracker.GetLastWriteAccess(fieldId, objectId);
-        _accessTracker.RecordAccess(fieldId, objectId, currentAccess);
-        if (!transitionResult.IsRaceDetected || 
-            lastRelevantAccess == null || 
+        var hasLastRelevant = isWrite
+            ? _accessTracker.TryGetLastAccess(fieldId, objectId, out var lastRelevantAccess)
+            : _accessTracker.TryGetLastWriteAccess(fieldId, objectId, out lastRelevantAccess);
+        var currentAccess = _accessTracker.RecordAccess(fieldId, objectId, threadId, moduleId, methodToken, methodOffset, accessType);
+        if (!transitionResult.IsRaceDetected ||
+            !hasLastRelevant ||
             lastRelevantAccess.ProcessThreadId == threadId)
             return null;
-        
+
         return new DataRaceInfo(
             threadId.ProcessId,
             fieldId,
             objectId,
-            currentAccess,
-            lastRelevantAccess,
+            _accessTracker.Materialize(currentAccess),
+            _accessTracker.Materialize(lastRelevantAccess),
             Timestamp: _timeProvider.GetUtcNow().DateTime);
     }
 }

--- a/src/Extensibility/SharpDetect.Plugins.DataRace.FastTrack/FastTrackDetector.cs
+++ b/src/Extensibility/SharpDetect.Plugins.DataRace.FastTrack/FastTrackDetector.cs
@@ -21,8 +21,8 @@ internal sealed class FastTrackDetector
     private readonly Dictionary<ProcessTrackedObjectId, VectorClock> _lockClocks = [];
     private readonly Dictionary<ProcessTrackedObjectId, Queue<VectorClock>> _semaphoreClocks = [];
     private readonly Dictionary<ProcessTrackedObjectId, VectorClock> _taskClocks = [];
-    private readonly Dictionary<(FieldId, ProcessTrackedObjectId?), VectorClock> _volatileClocks = [];
-    private readonly Dictionary<ProcessTrackedObjectId, HashSet<FieldId>> _volatileClocksObjectIndex = [];
+    private readonly Dictionary<FieldId, VectorClock> _staticVolatileClocks = [];
+    private readonly Dictionary<ProcessTrackedObjectId, Dictionary<FieldId, VectorClock>> _instanceVolatileClocks = [];
     private readonly Dictionary<ProcessTrackedObjectId, ObjectEscapeState> _escapeStates = [];
     private readonly record struct ObjectEscapeState(ProcessThreadId Instantiator, bool Escaped);
     
@@ -35,7 +35,7 @@ internal sealed class FastTrackDetector
     {
         _configuration = configuration;
         _timeProvider = timeProvider;
-        _accessTracker = new AccessTracker(timeProvider, threadNameResolver);
+        _accessTracker = new AccessTracker(threadNameResolver);
         _fieldResolver = new FieldResolver(metadataContext, logger);
         _methodResolver = new MethodResolver(metadataContext, logger);
     }
@@ -70,16 +70,7 @@ internal sealed class FastTrackDetector
             _semaphoreClocks.Remove(processObjectId);
             _taskClocks.Remove(processObjectId);
             _escapeStates.Remove(processObjectId);
-        }
-
-        foreach (var objectId in removedObjectIds)
-        {
-            var processObjectId = new ProcessTrackedObjectId(processId, objectId);
-            if (!_volatileClocksObjectIndex.Remove(processObjectId, out var fieldIds))
-                continue;
-
-            foreach (var fieldId in fieldIds)
-                _volatileClocks.Remove((fieldId, processObjectId));
+            _instanceVolatileClocks.Remove(processObjectId);
         }
     }
     
@@ -208,11 +199,10 @@ internal sealed class FastTrackDetector
             return;
 
         var fieldId = new FieldId(threadId.ProcessId, moduleId, fieldToken, fieldDef!);
-        var key = (fieldId, objectId);
         var threadVc = GetOrCreateThreadClock(threadId);
         var volatileVc = GetOrCreateVolatileClock(fieldId, objectId);
         volatileVc.Join(threadVc);
-        _volatileClocks[key] = threadVc.Clone();
+        GetVolatileClockMap(objectId)[fieldId] = threadVc.Clone();
         threadVc.Increment(threadId);
     }
 
@@ -241,28 +231,25 @@ internal sealed class FastTrackDetector
             shadow.LastWriteKind == WriteKind.Regular)
         {
             // Write-read race detected: last write does not happen-before this read
-            var accessType = AccessType.Read;
-            var currentAccess = _accessTracker.CreateAccessInfo(threadId, moduleId, methodToken, methodOffset, accessType);
-            var lastAccess = _accessTracker.GetLastWriteAccess(fieldId, objectId);
-            _accessTracker.RecordAccess(fieldId, objectId, currentAccess);
+            var hasLastWrite = _accessTracker.TryGetLastWriteAccess(fieldId, objectId, out var lastWrite);
+            var currentAccess = _accessTracker.RecordAccess(fieldId, objectId, threadId, moduleId, methodToken, methodOffset, AccessType.Read);
             UpdateReadState(threadId, shadow, threadVc);
 
-            if (lastAccess != null && lastAccess.ProcessThreadId != threadId)
+            if (hasLastWrite && lastWrite.ProcessThreadId != threadId)
             {
                 return new DataRaceInfo(
                     threadId.ProcessId,
                     fieldId,
                     objectId,
-                    currentAccess,
-                    lastAccess,
+                    _accessTracker.Materialize(currentAccess),
+                    _accessTracker.Materialize(lastWrite),
                     _timeProvider.GetUtcNow().DateTime);
             }
 
             return null;
         }
 
-        var readAccess = _accessTracker.CreateAccessInfo(threadId, moduleId, methodToken, methodOffset, AccessType.Read);
-        _accessTracker.RecordAccess(fieldId, objectId, readAccess);
+        _accessTracker.RecordAccess(fieldId, objectId, threadId, moduleId, methodToken, methodOffset, AccessType.Read);
         UpdateReadState(threadId, shadow, threadVc);
         return null;
     }
@@ -291,20 +278,19 @@ internal sealed class FastTrackDetector
             shadow.WriteEpoch.ThreadId != threadId &&
             !shadow.WriteEpoch.HappensBefore(threadVc))
         {
-            var currentAccess = _accessTracker.CreateAccessInfo(threadId, moduleId, methodToken, methodOffset, AccessType.Write);
-            var lastAccess = _accessTracker.GetLastWriteAccess(fieldId, objectId);
-            _accessTracker.RecordAccess(fieldId, objectId, currentAccess);
+            var hasLastWrite = _accessTracker.TryGetLastWriteAccess(fieldId, objectId, out var lastWrite);
+            var currentAccess = _accessTracker.RecordAccess(fieldId, objectId, threadId, moduleId, methodToken, methodOffset, AccessType.Write);
             shadow.SetWrite(currentEpoch, writeKind);
             shadow.SetRead(Epoch.None);
 
-            if (lastAccess != null && lastAccess.ProcessThreadId != threadId)
+            if (hasLastWrite && lastWrite.ProcessThreadId != threadId)
             {
                 return new DataRaceInfo(
                     threadId.ProcessId,
                     fieldId,
                     objectId,
-                    currentAccess,
-                    lastAccess,
+                    _accessTracker.Materialize(currentAccess),
+                    _accessTracker.Materialize(lastWrite),
                     _timeProvider.GetUtcNow().DateTime);
             }
 
@@ -314,28 +300,26 @@ internal sealed class FastTrackDetector
         var readWriteRace = CheckReadWriteRace(threadId, shadow, threadVc);
         if (readWriteRace != null)
         {
-            var currentAccess = _accessTracker.CreateAccessInfo(threadId, moduleId, methodToken, methodOffset, AccessType.Write);
-            var lastAccess = _accessTracker.GetLastAccess(fieldId, objectId);
-            _accessTracker.RecordAccess(fieldId, objectId, currentAccess);
+            var hasLastAccess = _accessTracker.TryGetLastAccess(fieldId, objectId, out var lastAccess);
+            var currentAccess = _accessTracker.RecordAccess(fieldId, objectId, threadId, moduleId, methodToken, methodOffset, AccessType.Write);
             shadow.SetWrite(currentEpoch, writeKind);
             shadow.SetRead(Epoch.None);
 
-            if (lastAccess != null && lastAccess.ProcessThreadId != threadId)
+            if (hasLastAccess && lastAccess.ProcessThreadId != threadId)
             {
                 return new DataRaceInfo(
                     threadId.ProcessId,
                     fieldId,
                     objectId,
-                    currentAccess,
-                    lastAccess,
+                    _accessTracker.Materialize(currentAccess),
+                    _accessTracker.Materialize(lastAccess),
                     _timeProvider.GetUtcNow().DateTime);
             }
 
             return null;
         }
 
-        var writeAccess = _accessTracker.CreateAccessInfo(threadId, moduleId, methodToken, methodOffset, AccessType.Write);
-        _accessTracker.RecordAccess(fieldId, objectId, writeAccess);
+        _accessTracker.RecordAccess(fieldId, objectId, threadId, moduleId, methodToken, methodOffset, AccessType.Write);
         shadow.SetWrite(currentEpoch, writeKind);
         shadow.SetRead(Epoch.None);
         return null;
@@ -467,25 +451,28 @@ internal sealed class FastTrackDetector
 
     private VectorClock GetOrCreateVolatileClock(FieldId fieldId, ProcessTrackedObjectId? objectId)
     {
-        var key = (fieldId, objectId);
-        if (!_volatileClocks.TryGetValue(key, out var vc))
+        var clocks = GetVolatileClockMap(objectId);
+        if (!clocks.TryGetValue(fieldId, out var vc))
         {
             vc = new VectorClock();
-            _volatileClocks[key] = vc;
-
-            if (objectId is { } objId)
-            {
-                if (!_volatileClocksObjectIndex.TryGetValue(objId, out var fieldIds))
-                {
-                    fieldIds = [];
-                    _volatileClocksObjectIndex[objId] = fieldIds;
-                }
-
-                fieldIds.Add(fieldId);
-            }
+            clocks[fieldId] = vc;
         }
 
         return vc;
+    }
+
+    private Dictionary<FieldId, VectorClock> GetVolatileClockMap(ProcessTrackedObjectId? objectId)
+    {
+        if (objectId is not { } objId)
+            return _staticVolatileClocks;
+
+        if (!_instanceVolatileClocks.TryGetValue(objId, out var clocks))
+        {
+            clocks = [];
+            _instanceVolatileClocks[objId] = clocks;
+        }
+
+        return clocks;
     }
 }
 

--- a/src/Extensibility/SharpDetect.Plugins.DataRace.FastTrack/ShadowMemory.cs
+++ b/src/Extensibility/SharpDetect.Plugins.DataRace.FastTrack/ShadowMemory.cs
@@ -10,8 +10,8 @@ namespace SharpDetect.Plugins.DataRace.FastTrack;
 internal sealed class ShadowMemory
 {
     private readonly Dictionary<FieldId, ShadowVariable> _staticShadowWords = [];
-    private readonly Dictionary<(FieldId, ProcessTrackedObjectId), ShadowVariable> _instanceShadowWords = [];
-    private readonly Dictionary<ProcessTrackedObjectId, HashSet<FieldId>> _objectFieldIndex = [];
+    private readonly Dictionary<ProcessTrackedObjectId, Dictionary<FieldId, ShadowVariable>> _instanceShadowWords = [];
+    private int _instanceCount;
 
     public ShadowVariable GetOrCreateVirgin(FieldId fieldId, ProcessTrackedObjectId? objectId)
     {
@@ -32,13 +32,18 @@ internal sealed class ShadowMemory
 
     private ShadowVariable GetOrCreateInstance(FieldId fieldId, ProcessTrackedObjectId objectId)
     {
-        var key = (fieldId, objectId);
-        if (_instanceShadowWords.TryGetValue(key, out var shadow))
+        if (!_instanceShadowWords.TryGetValue(objectId, out var fields))
+        {
+            fields = [];
+            _instanceShadowWords[objectId] = fields;
+        }
+
+        if (fields.TryGetValue(fieldId, out var shadow))
             return shadow;
 
         shadow = ShadowVariable.CreateVirgin();
-        _instanceShadowWords[key] = shadow;
-        TrackObjectField(objectId, fieldId);
+        fields[fieldId] = shadow;
+        _instanceCount++;
         return shadow;
     }
 
@@ -47,26 +52,10 @@ internal sealed class ShadowMemory
         foreach (var objectId in removedObjectIds)
         {
             var processObjectId = new ProcessTrackedObjectId(processId, objectId);
-            if (!_objectFieldIndex.Remove(processObjectId, out var fieldIds))
-                continue;
-
-            foreach (var fieldId in fieldIds)
-                _instanceShadowWords.Remove((fieldId, processObjectId));
+            if (_instanceShadowWords.Remove(processObjectId, out var fields))
+                _instanceCount -= fields.Count;
         }
     }
 
-    public int Count => _staticShadowWords.Count + _instanceShadowWords.Count;
-
-    private void TrackObjectField(ProcessTrackedObjectId objectId, FieldId fieldId)
-    {
-        if (!_objectFieldIndex.TryGetValue(objectId, out var fieldIds))
-        {
-            fieldIds = [];
-            _objectFieldIndex[objectId] = fieldIds;
-        }
-
-        fieldIds.Add(fieldId);
-    }
+    public int Count => _staticShadowWords.Count + _instanceCount;
 }
-
-

--- a/src/Extensibility/SharpDetect.Plugins.Descriptors/MethodRewritingDescriptor.cs
+++ b/src/Extensibility/SharpDetect.Plugins.Descriptors/MethodRewritingDescriptor.cs
@@ -9,4 +9,5 @@ public record MethodRewritingDescriptor(
     CapturedArgumentDescriptor[]? Arguments,
     CapturedValueDescriptor? ReturnValue,
     ushort? MethodEnterInterpretation,
-    ushort? MethodExitInterpretation);
+    ushort? MethodExitInterpretation,
+    bool EmitExitEvent = true);

--- a/src/Extensibility/SharpDetect.Plugins.Descriptors/Methods/FieldAccessDescriptors.cs
+++ b/src/Extensibility/SharpDetect.Plugins.Descriptors/Methods/FieldAccessDescriptors.cs
@@ -35,7 +35,8 @@ public static class FieldAccessDescriptors
                 ],
                 ReturnValue: null,
                 MethodEnterInterpretation: (ushort)RecordedEventType.StaticFieldRead,
-                MethodExitInterpretation: (ushort)RecordedEventType.StaticFieldRead));
+                MethodExitInterpretation: null,
+                EmitExitEvent: false));
         
         ReadInstanceField = new MethodDescriptor(
             MethodName: "ReadInstanceField",
@@ -60,7 +61,8 @@ public static class FieldAccessDescriptors
                 ],
                 ReturnValue: null,
                 MethodEnterInterpretation: (ushort)RecordedEventType.InstanceFieldRead,
-                MethodExitInterpretation: (ushort)RecordedEventType.InstanceFieldRead));
+                MethodExitInterpretation: null,
+                EmitExitEvent: false));
 
         WriteStaticField = new MethodDescriptor(
             MethodName: "WriteStaticField",
@@ -80,7 +82,8 @@ public static class FieldAccessDescriptors
                 ],
                 ReturnValue: null,
                 MethodEnterInterpretation: (ushort)RecordedEventType.StaticFieldWrite,
-                MethodExitInterpretation: (ushort)RecordedEventType.StaticFieldWrite));
+                MethodExitInterpretation: null,
+                EmitExitEvent: false));
         
         WriteInstanceField = new MethodDescriptor(
             MethodName: "WriteInstanceField",
@@ -105,7 +108,8 @@ public static class FieldAccessDescriptors
                 ],
                 ReturnValue: null,
                 MethodEnterInterpretation: (ushort)RecordedEventType.InstanceFieldWrite,
-                MethodExitInterpretation: (ushort)RecordedEventType.InstanceFieldWrite));
+                MethodExitInterpretation: null,
+                EmitExitEvent: false));
     }
 
     public static IEnumerable<MethodDescriptor> GetAllMethods()

--- a/src/SharpDetect.Core/Plugins/PluginBase.cs
+++ b/src/SharpDetect.Core/Plugins/PluginBase.cs
@@ -159,7 +159,8 @@ public abstract class PluginBase : RecordedEventActionVisitorBase, IDisposable
     protected override void Visit(RecordedEventMetadata metadata, MethodEnterRecordedEvent args)
     {
         var id = new ProcessThreadId(metadata.Pid, metadata.Tid);
-        _callstacks[id].Push(args.ModuleId, args.MethodToken);
+        if (TracksCallstackFrame(args.Interpretation))
+            _callstacks[id].Push(args.ModuleId, args.MethodToken);
         Reporter.IncrementMethodEnterExitCounter();
         base.Visit(metadata, args);
     }
@@ -167,7 +168,8 @@ public abstract class PluginBase : RecordedEventActionVisitorBase, IDisposable
     protected override void Visit(RecordedEventMetadata metadata, MethodEnterWithArgumentsRecordedEvent args)
     {
         var id = new ProcessThreadId(metadata.Pid, metadata.Tid);
-        _callstacks[id].Push(args.ModuleId, args.MethodToken);
+        if (TracksCallstackFrame(args.Interpretation))
+            _callstacks[id].Push(args.ModuleId, args.MethodToken);
         Reporter.IncrementMethodEnterExitCounter();
         base.Visit(metadata, args);
     }
@@ -175,16 +177,27 @@ public abstract class PluginBase : RecordedEventActionVisitorBase, IDisposable
     protected override void Visit(RecordedEventMetadata metadata, MethodExitRecordedEvent args)
     {
         var id = new ProcessThreadId(metadata.Pid, metadata.Tid);
-        _callstacks[id].Pop();
+        if (TracksCallstackFrame(args.Interpretation))
+            _callstacks[id].Pop();
         base.Visit(metadata, args);
     }
 
     protected override void Visit(RecordedEventMetadata metadata, MethodExitWithArgumentsRecordedEvent args)
     {
         var id = new ProcessThreadId(metadata.Pid, metadata.Tid);
-        _callstacks[id].Pop();
+        if (TracksCallstackFrame(args.Interpretation))
+            _callstacks[id].Pop();
         base.Visit(metadata, args);
     }
+
+    private static bool TracksCallstackFrame(ushort interpretation) => (RecordedEventType)interpretation switch
+    {
+        RecordedEventType.StaticFieldRead
+            or RecordedEventType.StaticFieldWrite
+            or RecordedEventType.InstanceFieldRead
+            or RecordedEventType.InstanceFieldWrite => false,
+        _ => true
+    };
     
     protected override void Visit(RecordedEventMetadata metadata, FieldAccessInstrumentationRecordedEvent args)
     {

--- a/src/SharpDetect.Profiler/LibDescriptors/MethodRewritingDescriptor.cpp
+++ b/src/SharpDetect.Profiler/LibDescriptors/MethodRewritingDescriptor.cpp
@@ -7,6 +7,7 @@ void Profiler::to_json(nlohmann::json& json, const MethodRewritingDescriptor& de
 {
     json["injectHooks"] = descriptor.injectHooks;
     json["injectManagedWrapper"] = descriptor.injectManagedWrapper;
+    json["emitExitEvent"] = descriptor.emitExitEvent;
     json["arguments"] = descriptor.arguments;
     if (descriptor.returnValue.has_value())
         json["returnValue"] = descriptor.returnValue.value();
@@ -21,6 +22,13 @@ void Profiler::from_json(const nlohmann::json& json, MethodRewritingDescriptor& 
     descriptor.injectHooks = json.at("injectHooks");
     descriptor.injectManagedWrapper = json.at("injectManagedWrapper");
     descriptor.arguments = json.at("arguments");
+
+    auto const emitExitEventIt = json.find("emitExitEvent");
+    if (emitExitEventIt != json.cend() && !emitExitEventIt->is_null())
+        descriptor.emitExitEvent = *emitExitEventIt;
+    else
+        descriptor.emitExitEvent = TRUE;
+        
     auto const returnValueIt = json.find("returnValue");
 
     if (returnValueIt != json.cend() && !returnValueIt->is_null())

--- a/src/SharpDetect.Profiler/LibDescriptors/MethodRewritingDescriptor.h
+++ b/src/SharpDetect.Profiler/LibDescriptors/MethodRewritingDescriptor.h
@@ -23,6 +23,7 @@ namespace Profiler
 		std::optional<CapturedValueDescriptor> returnValue;
 		std::optional<USHORT> methodEnterInterpretation;
 		std::optional<USHORT> methodExitInterpretation;
+		BOOL emitExitEvent;
 	};
 
     void to_json(nlohmann::json& json, const MethodRewritingDescriptor& descriptor);

--- a/src/SharpDetect.Profiler/SharpDetect.Concurrency.Profiler/CorProfiler.cpp
+++ b/src/SharpDetect.Profiler/SharpDetect.Concurrency.Profiler/CorProfiler.cpp
@@ -60,12 +60,13 @@ EXTERN_C void TailcallNaked(FunctionIDOrClientID functionIDOrClientID, COR_PRF_E
 
 UINT_PTR STDMETHODCALLTYPE FunctionMapper(const FunctionID funcId, void* clientData, BOOL* pbHookFunction)
 {
-    // Inject hooks only for methods where we explicitly requested them
-    auto const descriptor = ProfilerInstance->FindMethodDescriptor(funcId);
-    auto const shouldInjectHooks = descriptor != nullptr && descriptor->rewritingDescriptor.injectHooks;
-    *pbHookFunction = shouldInjectHooks;
+    // Resolve the per-function ELT decision once during JIT compilation
+    // Enter/Exit hooks use precomputed decision
+    auto const decision = ProfilerInstance->GetEltDecision(funcId, pbHookFunction);
+    if (decision == nullptr)
+        return funcId;
 
-    return funcId;
+    return reinterpret_cast<UINT_PTR>(decision);
 }
 
 HRESULT STDMETHODCALLTYPE Profiler::CorProfiler::Initialize(IUnknown* pICorProfilerInfoUnk)
@@ -410,61 +411,87 @@ static BOOL HasIndirects(const Profiler::MethodDescriptor& descriptor)
     return indirectIt != descriptor.rewritingDescriptor.arguments.cend();
 }
 
+const Profiler::EltDecision* Profiler::CorProfiler::GetEltDecision(const FunctionID functionId, BOOL* pbHookFunction)
+{
+    *pbHookFunction = FALSE;
+
+    ModuleID moduleId;
+    mdMethodDef methodDef;
+    if (FAILED(_corProfilerInfo->GetFunctionInfo(functionId, nullptr, &moduleId, &methodDef)))
+        return nullptr;
+
+    // Inject hooks only for methods where we explicitly requested them
+    const auto descriptorPointer = _methodDescriptorRegistry.TryGet(moduleId, methodDef);
+    const auto shouldInjectHooks = descriptorPointer != nullptr && descriptorPointer->rewritingDescriptor.injectHooks;
+    if (!shouldInjectHooks)
+        return nullptr;
+
+    *pbHookFunction = TRUE;
+
+    auto guard = std::lock_guard(_eltDecisionMutex);
+    if (const auto it = _eltDecisionLookup.find(functionId); it != _eltDecisionLookup.cend())
+        return it->second;
+
+    constexpr auto originalMethodEnterEvent = static_cast<USHORT>(LibIPC::RecordedEventType::MethodEnter);
+    constexpr auto originalMethodEnterWithArgumentsEvent = static_cast<USHORT>(LibIPC::RecordedEventType::MethodEnterWithArguments);
+    constexpr auto originalMethodExitEvent = static_cast<USHORT>(LibIPC::RecordedEventType::MethodExit);
+    constexpr auto originalMethodExitWithArgumentsEvent = static_cast<USHORT>(LibIPC::RecordedEventType::MethodExitWithArguments);
+
+    const auto enterMappings = _rewriteRegistry.FindMethodEnterMappings(
+        moduleId, methodDef, originalMethodEnterEvent, originalMethodEnterWithArgumentsEvent);
+    const auto exitMappings = _rewriteRegistry.FindMethodExitMappings(
+        moduleId, methodDef, originalMethodExitEvent, originalMethodExitWithArgumentsEvent);
+
+    const auto& descriptor = *descriptorPointer.get();
+    EltDecision decision{};
+    decision.functionId = functionId;
+    decision.moduleId = moduleId;
+    decision.methodDef = methodDef;
+    decision.descriptor = descriptorPointer.get();
+    decision.enterEventId = enterMappings.hasEvent ? enterMappings.eventMapping : originalMethodEnterEvent;
+    decision.enterWithArgsEventId = enterMappings.hasWithArgsEvent ? enterMappings.withArgsEventMapping : originalMethodEnterWithArgumentsEvent;
+    decision.exitEventId = exitMappings.hasEvent ? exitMappings.eventMapping : originalMethodExitEvent;
+    decision.exitWithArgsEventId = exitMappings.hasWithArgsEvent ? exitMappings.withArgsEventMapping : originalMethodExitWithArgumentsEvent;
+    decision.hasArguments = !descriptor.rewritingDescriptor.arguments.empty();
+    decision.hasReturnValue = descriptor.rewritingDescriptor.returnValue.has_value();
+    decision.hasIndirects = HasIndirects(descriptor);
+
+    _eltDecisions.push_back(decision);
+    const auto* stored = &_eltDecisions.back();
+    _eltDecisionLookup.emplace(functionId, stored);
+    return stored;
+}
+
 HRESULT Profiler::CorProfiler::EnterMethod(const FunctionIDOrClientID functionOrClientId, const COR_PRF_ELT_INFO eltInfo)
 {
     if (_terminating)
         return S_OK;
 
-    ModuleID moduleId;
-    mdMethodDef methodDef;
-    auto const functionId = functionOrClientId.functionID;
-    HRESULT hr = _corProfilerInfo->GetFunctionInfo(functionId, nullptr, &moduleId, &methodDef);
-    if (FAILED(hr))
-    {
-        LOG_F(ERROR, "Could not resolve functionId %" UINT_PTR_FORMAT " to a method. Error: 0x%x", functionId, hr);
-        return E_FAIL;
-    }
+    const auto* decision = reinterpret_cast<const EltDecision*>(functionOrClientId.clientID);
+    if (decision == nullptr)
+        return S_OK;
 
-    // Check if event mapping is available
-    constexpr auto originalMethodEnterEvent = static_cast<USHORT>(LibIPC::RecordedEventType::MethodEnter);
-    constexpr auto originalMethodEnterWithArgumentsEvent = static_cast<USHORT>(LibIPC::RecordedEventType::MethodEnterWithArguments);
-    auto const [hasCustomMethodEnterEvent, customMethodEnterEvent,
-                hasCustomMethodEnterWithArgumentsEvent, customMethodEnterWithArgumentsEvent] =
-        _rewriteRegistry.FindMethodEnterMappings(
-            moduleId,
-            methodDef,
-            originalMethodEnterEvent,
-            originalMethodEnterWithArgumentsEvent);
+    const auto moduleId = decision->moduleId;
+    const auto methodDef = decision->methodDef;
 
-    const auto descriptorPointer = _methodDescriptorRegistry.TryGet(moduleId, methodDef);
-    if (!descriptorPointer)
+    if (decision->descriptor == nullptr || !decision->hasArguments)
     {
         // Notify about method enter without arguments
         _client.Send(LibIPC::Helpers::CreateMethodEnterMsg(
             CreateMetadataMsg(),
             moduleId,
             methodDef,
-            hasCustomMethodEnterEvent ? customMethodEnterEvent : originalMethodEnterEvent));
+            decision->enterEventId));
         return S_OK;
     }
 
     // Retrieve information about arguments
-    const auto& descriptor = *descriptorPointer.get();
-    if (descriptor.rewritingDescriptor.arguments.empty())
-    {
-        // Notify about method enter without arguments
-        _client.Send(LibIPC::Helpers::CreateMethodEnterMsg(
-            CreateMetadataMsg(),
-            moduleId,
-            methodDef,
-            hasCustomMethodEnterEvent ? customMethodEnterEvent : originalMethodEnterEvent));
-        return S_OK;
-    }
+    const auto& descriptor = *decision->descriptor;
 
     // Retrieve arguments data
     COR_PRF_FRAME_INFO frameInfo { };
     ULONG argumentsLength = 0;
-    hr = _corProfilerInfo->GetFunctionEnter3Info(functionId, eltInfo, &frameInfo, &argumentsLength, nullptr);
+    HRESULT hr = _corProfilerInfo->GetFunctionEnter3Info(decision->functionId, eltInfo, &frameInfo, &argumentsLength, nullptr);
     if (hr != HRESULT_FROM_WIN32(ERROR_INSUFFICIENT_BUFFER))
     {
         LOG_F(ERROR, "Could not retrieve arguments info for method %d. Error: 0x%x", methodDef, hr);
@@ -472,15 +499,16 @@ HRESULT Profiler::CorProfiler::EnterMethod(const FunctionIDOrClientID functionOr
     }
 
     std::vector<UINT_PTR> indirects;
-    const auto rawArgumentInfos = std::unique_ptr<BYTE[]>(new BYTE[argumentsLength]);
-    hr = _corProfilerInfo->GetFunctionEnter3Info(functionId, eltInfo, &frameInfo, &argumentsLength, reinterpret_cast<COR_PRF_FUNCTION_ARGUMENT_INFO *>(rawArgumentInfos.get()));
+    thread_local std::vector<BYTE> rawArgumentInfos;
+    rawArgumentInfos.resize(argumentsLength);
+    hr = _corProfilerInfo->GetFunctionEnter3Info(decision->functionId, eltInfo, &frameInfo, &argumentsLength, reinterpret_cast<COR_PRF_FUNCTION_ARGUMENT_INFO *>(rawArgumentInfos.data()));
     if (FAILED(hr))
     {
         LOG_F(ERROR, "Could not retrieve arguments data for method %d. Error: 0x%x.", methodDef, hr);
         return E_FAIL;
     }
 
-    const auto& argumentInfos = *reinterpret_cast<COR_PRF_FUNCTION_ARGUMENT_INFO *>(rawArgumentInfos.get());
+    const auto& argumentInfos = *reinterpret_cast<COR_PRF_FUNCTION_ARGUMENT_INFO *>(rawArgumentInfos.data());
     std::vector<BYTE> argumentValues;
     std::vector<BYTE> argumentOffsets;
 
@@ -513,9 +541,7 @@ HRESULT Profiler::CorProfiler::EnterMethod(const FunctionIDOrClientID functionOr
         CreateMetadataMsg(),
         moduleId,
         methodDef,
-        hasCustomMethodEnterWithArgumentsEvent
-            ? customMethodEnterWithArgumentsEvent
-            : originalMethodEnterWithArgumentsEvent,
+        decision->enterWithArgsEventId,
         std::move(argumentValues),
         std::move(argumentOffsets)));
     return S_OK;
@@ -526,58 +552,33 @@ HRESULT Profiler::CorProfiler::LeaveMethod(const FunctionIDOrClientID functionOr
     if (_terminating)
         return S_OK;
 
-    ModuleID moduleId;
-    mdMethodDef methodDef;
-    auto const functionId = functionOrClientId.functionID;
-    HRESULT hr = _corProfilerInfo->GetFunctionInfo(functionId, nullptr, &moduleId, &methodDef);
-    if (FAILED(hr))
-    {
-        LOG_F(ERROR, "Could not resolve functionId %" UINT_PTR_FORMAT " to a method. Error: 0x%x", functionId, hr);
-        return E_FAIL;
-    }
+    const auto* decision = reinterpret_cast<const EltDecision*>(functionOrClientId.clientID);
+    if (decision == nullptr)
+        return S_OK;
 
-    // Check if event mapping is available
-    constexpr auto originalMethodExitEvent = static_cast<USHORT>(LibIPC::RecordedEventType::MethodExit);
-    constexpr auto originalMethodExitWithArgumentsEvent = static_cast<USHORT>(LibIPC::RecordedEventType::MethodExitWithArguments);
-    auto const [hasCustomMethodExitEvent, customMethodExitEvent,
-                hasCustomMethodExitWithArgumentsEvent, customMethodExitWithArgumentsEvent] =
-        _rewriteRegistry.FindMethodExitMappings(
-            moduleId,
-            methodDef,
-            originalMethodExitEvent,
-            originalMethodExitWithArgumentsEvent);
+    const auto moduleId = decision->moduleId;
+    const auto methodDef = decision->methodDef;
 
-    const auto descriptorPointer = _methodDescriptorRegistry.TryGet(moduleId, methodDef);
-    if (!descriptorPointer)
+    if (decision->descriptor == nullptr || (!decision->hasReturnValue && !decision->hasIndirects))
     {
         // Notify about method leave without arguments
         _client.Send(LibIPC::Helpers::CreateMethodExitMsg(
             CreateMetadataMsg(),
             moduleId,
             methodDef,
-            hasCustomMethodExitEvent ? customMethodExitEvent : originalMethodExitEvent));
+            decision->exitEventId));
         return S_OK;
     }
 
     // Retrieve information about arguments
-    const auto& descriptor = *descriptorPointer.get();
-    auto const hasIndirects = HasIndirects(descriptor);
-    auto const hasReturnValue = descriptor.rewritingDescriptor.returnValue.has_value();
-    if (!hasReturnValue && !hasIndirects)
-    {
-        // Notify about method leave without arguments
-        _client.Send(LibIPC::Helpers::CreateMethodExitMsg(
-            CreateMetadataMsg(),
-            moduleId,
-            methodDef,
-            hasCustomMethodExitEvent ? customMethodExitEvent : originalMethodExitEvent));
-        return S_OK;
-    }
+    const auto& descriptor = *decision->descriptor;
+    auto const hasIndirects = decision->hasIndirects;
+    auto const hasReturnValue = decision->hasReturnValue;
 
     // Retrieve return value data
     COR_PRF_FRAME_INFO frameInfo;
     COR_PRF_FUNCTION_ARGUMENT_RANGE returnValueInfo;
-    hr = _corProfilerInfo->GetFunctionLeave3Info(functionId, eltInfo, &frameInfo, &returnValueInfo);
+    HRESULT hr = _corProfilerInfo->GetFunctionLeave3Info(decision->functionId, eltInfo, &frameInfo, &returnValueInfo);
     if (FAILED(hr))
     {
         LOG_F(ERROR, "Could not retrieve return value info for method %d. Error: 0x%x", methodDef, hr);
@@ -641,9 +642,7 @@ HRESULT Profiler::CorProfiler::LeaveMethod(const FunctionIDOrClientID functionOr
         CreateMetadataMsg(),
         moduleId,
         methodDef,
-        hasCustomMethodExitWithArgumentsEvent
-            ? customMethodExitWithArgumentsEvent
-            : originalMethodExitWithArgumentsEvent,
+        decision->exitWithArgsEventId,
         std::move(returnValue),
         std::move(argumentValues),
         std::move(argumentOffsets)));

--- a/src/SharpDetect.Profiler/SharpDetect.Concurrency.Profiler/CorProfiler.cpp
+++ b/src/SharpDetect.Profiler/SharpDetect.Concurrency.Profiler/CorProfiler.cpp
@@ -455,6 +455,7 @@ const Profiler::EltDecision* Profiler::CorProfiler::GetEltDecision(const Functio
     decision.hasArguments = !descriptor.rewritingDescriptor.arguments.empty();
     decision.hasReturnValue = descriptor.rewritingDescriptor.returnValue.has_value();
     decision.hasIndirects = HasIndirects(descriptor);
+    decision.emitExitEvent = descriptor.rewritingDescriptor.emitExitEvent;
 
     _eltDecisions.push_back(decision);
     const auto* stored = &_eltDecisions.back();
@@ -553,7 +554,7 @@ HRESULT Profiler::CorProfiler::LeaveMethod(const FunctionIDOrClientID functionOr
         return S_OK;
 
     const auto* decision = reinterpret_cast<const EltDecision*>(functionOrClientId.clientID);
-    if (decision == nullptr)
+    if (decision == nullptr || !decision->emitExitEvent)
         return S_OK;
 
     const auto moduleId = decision->moduleId;

--- a/src/SharpDetect.Profiler/SharpDetect.Concurrency.Profiler/CorProfiler.h
+++ b/src/SharpDetect.Profiler/SharpDetect.Concurrency.Profiler/CorProfiler.h
@@ -4,6 +4,9 @@
 #pragma once
 
 #include <atomic>
+#include <deque>
+#include <mutex>
+#include <unordered_map>
 #include <vector>
 #include <shared_mutex>
 
@@ -25,6 +28,21 @@
 
 namespace Profiler
 {
+	struct EltDecision
+	{
+		FunctionID functionId;
+		ModuleID moduleId;
+		mdMethodDef methodDef;
+		const MethodDescriptor* descriptor;
+		USHORT enterEventId;
+		USHORT enterWithArgsEventId;
+		USHORT exitEventId;
+		USHORT exitWithArgsEventId;
+		bool hasArguments;
+		bool hasReturnValue;
+		bool hasIndirects;
+	};
+
 	class CorProfiler final : public LibProfiler::CorProfilerBase, public LibIPC::ICommandHandler
 	{
 	public:
@@ -49,6 +67,7 @@ namespace Profiler
 		HRESULT LeaveMethod(FunctionIDOrClientID functionId, COR_PRF_ELT_INFO eltInfo);
 		HRESULT TailcallMethod(FunctionIDOrClientID functionId, COR_PRF_ELT_INFO eltInfo);
 		[[nodiscard]] std::shared_ptr<MethodDescriptor> FindMethodDescriptor(FunctionID functionId);
+		[[nodiscard]] const EltDecision* GetEltDecision(FunctionID functionId, BOOL* pbHookFunction);
 
 	private:
 		HRESULT AbortAttach(const std::string& reason);
@@ -70,5 +89,9 @@ namespace Profiler
 		RewriteRegistry _rewriteRegistry;
 		ArgumentCapture _argumentCapture;
 		TypeInjector _typeInjector;
+
+		std::deque<EltDecision> _eltDecisions;
+		std::unordered_map<FunctionID, const EltDecision*> _eltDecisionLookup;
+		std::mutex _eltDecisionMutex;
 	};
 }

--- a/src/SharpDetect.Profiler/SharpDetect.Concurrency.Profiler/CorProfiler.h
+++ b/src/SharpDetect.Profiler/SharpDetect.Concurrency.Profiler/CorProfiler.h
@@ -41,6 +41,7 @@ namespace Profiler
 		bool hasArguments;
 		bool hasReturnValue;
 		bool hasIndirects;
+		bool emitExitEvent;
 	};
 
 	class CorProfiler final : public LibProfiler::CorProfilerBase, public LibIPC::ICommandHandler

--- a/src/SharpDetect.Profiler/SharpDetect.Concurrency.Profiler/RewriteRegistry.cpp
+++ b/src/SharpDetect.Profiler/SharpDetect.Concurrency.Profiler/RewriteRegistry.cpp
@@ -11,7 +11,7 @@ void Profiler::RewriteRegistry::AddStub(const ModuleID moduleId, const mdMethodD
 
 BOOL Profiler::RewriteRegistry::IsStub(const ModuleID moduleId, const mdMethodDef methodDef)
 {
-	auto guard = std::unique_lock(_methodStubsMutex);
+	auto guard = std::shared_lock(_methodStubsMutex);
 	return _methodStubs.contains(std::make_pair(moduleId, methodDef));
 }
 

--- a/src/SharpDetect.Profiler/SharpDetect.Concurrency.Profiler/RewriteRegistry.h
+++ b/src/SharpDetect.Profiler/SharpDetect.Concurrency.Profiler/RewriteRegistry.h
@@ -67,7 +67,7 @@ namespace Profiler
 		std::mutex _injectedMethodsMutex;
 
 		std::unordered_map<MethodId, BOOL, MethodIdHasher> _methodStubs;
-		std::mutex _methodStubsMutex;
+		std::shared_mutex _methodStubsMutex;
 
 		CustomEventsLookup _customEventOnMethodEntryLookup;
 		CustomEventsLookup _customEventOnMethodExitLookup;

--- a/src/SharpDetect.Worker/Services/AnalysisWorker.cs
+++ b/src/SharpDetect.Worker/Services/AnalysisWorker.cs
@@ -1,6 +1,7 @@
 // Copyright 2026 Andrej Čižmárik and Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 using CliWrap;
@@ -15,6 +16,7 @@ namespace SharpDetect.Worker.Services;
 public sealed class AnalysisWorker : IAnalysisWorker
 {
     private static readonly TimeSpan ProfilerEventReceiveTimeout = TimeSpan.FromMilliseconds(50);
+    private const int EventBufferCapacity = 1000;
     private readonly RunCommandArgs _arguments;
     private readonly IPlugin _plugin;
     private readonly IPluginHost _pluginHost;
@@ -139,9 +141,51 @@ public sealed class AnalysisWorker : IAnalysisWorker
 
     private void ExecuteAnalysis(Task targetProcessTask, uint rootPid, CancellationToken cancellationToken)
     {
+        using var receiveCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        using var events = new BlockingCollection<RecordedEvent>(EventBufferCapacity);
+        var producer = new Thread(() => ProduceEvents(events, targetProcessTask, rootPid, receiveCts.Token))
+        {
+            IsBackground = true,
+            Name = "SharpDetect.EventReceiver"
+        };
+        producer.Start();
+
+        try
+        {
+            ProcessEvents(events, rootPid, cancellationToken);
+        }
+        finally
+        {
+            receiveCts.Cancel();
+            producer.Join();
+
+            if (_pluginHost is IDisposable disposable)
+                disposable.Dispose();
+        }
+    }
+
+    private void ProduceEvents(BlockingCollection<RecordedEvent> events, Task targetProcessTask, uint rootPid, CancellationToken cancellationToken)
+    {
         try
         {
             foreach (var currentEvent in ReceiveEvents(targetProcessTask, rootPid, cancellationToken))
+                events.Add(currentEvent, cancellationToken);
+        }
+        catch (OperationCanceledException)
+        {
+            // Expected when the consumer finishes (or analysis is cancelled) while we wait for buffer capacity.
+        }
+        finally
+        {
+            events.CompleteAdding();
+        }
+    }
+
+    private void ProcessEvents(BlockingCollection<RecordedEvent> events, uint rootPid, CancellationToken cancellationToken)
+    {
+        try
+        {
+            foreach (var currentEvent in events.GetConsumingEnumerable(cancellationToken))
             {
                 if (currentEvent.EventArgs is ProfilerDestroyRecordedEvent && currentEvent.Metadata.Pid == rootPid)
                     return;
@@ -153,10 +197,9 @@ public sealed class AnalysisWorker : IAnalysisWorker
                 }
             }
         }
-        finally
+        catch (OperationCanceledException)
         {
-            if (_pluginHost is IDisposable disposable)
-                disposable.Dispose();
+            // Analysis cancelled while waiting for the next event.
         }
     }
 


### PR DESCRIPTION
This PR brings the following improvements:

- Reduce shadow memory consumption by optimizing access tracker
   - We no longer track accesses in a large flat dictionary - instead these are hierarchical
   - This helps on AspNetCore apps to not burden LOH and not spend significant time in GC
- Add deserialization worker that preprocesses events from profiler for main worker
- Simplify Enter/Exit hook routines
   - Moved more logic into JIT compilation time and hooks just use that data
   - This helps make hooks faster as it is the hottest path in profiler
- Remove some unnecessary events
   - Some events were emitted essentially twice (method enter + method exit)
   - This was mainly problematic for field accesses - essentially we cut events in half for them