### PR TITLE
Fix DUP instruction handling, tighten tests

### DIFF
--- a/src/SharpDetect.Profiler/LibIL/ILRewriter.cpp
+++ b/src/SharpDetect.Profiler/LibIL/ILRewriter.cpp
@@ -650,6 +650,12 @@ HRESULT ILRewriter::ComputeStackTypes()
                 pInstr->m_objOperandIsObjRef = stack[stack.size() - 2] == SlotObjRef;
         }
 
+        if (opcode == CEE_DUP)
+        {
+            stack.push_back(stack.empty() ? SlotOther : stack.back());
+            continue;
+        }
+
         // --- Pop ---
         int popCount = k_rgnStackPops[opcode];
         if (popCount == -1) // VarPop
@@ -719,21 +725,6 @@ HRESULT ILRewriter::ComputeStackTypes()
 
         // --- Push ---
         int pushCount = k_rgnStackPushes[opcode];
-
-        // Handle DUP specially: it duplicates the top, preserving type
-        if (opcode == CEE_DUP)
-        {
-            if (!stack.empty())
-            {
-                StackSlotKind top = stack.back();
-                stack.push_back(top);
-            }
-            else
-            {
-                stack.push_back(SlotOther);
-            }
-            continue;
-        }
 
         if (pushCount > 0)
         {

--- a/src/Tests/SharpDetect.E2ETests/EventMatchers.cs
+++ b/src/Tests/SharpDetect.E2ETests/EventMatchers.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using SharpDetect.Core.Events;
+using SharpDetect.Core.Events.Profiler;
 using SharpDetect.Core.Plugins;
 using SharpDetect.E2ETests.Utils;
 using SharpDetect.TemporalAsserts;
@@ -13,22 +14,52 @@ public static class EventMatchers
     public static AtomicPredicate<ulong, RecordedEventType> EventType(RecordedEventType type) =>
         new(evt => evt.Type == type, description: $"EventType({type})");
 
-    public static AtomicPredicate<ulong, RecordedEventType> VolatileFieldAccess(RecordedEventType type)
+    public static AtomicPredicate<ulong, RecordedEventType> FieldAccessInAssembly(
+        string assemblyName,
+        RecordedEventType type,
+        IMetadataResolver plugin,
+        bool? requireVolatile = null)
     {
         return new AtomicPredicate<ulong, RecordedEventType>(evt =>
         {
             if (evt.Type != type)
                 return false;
-        
-            return type switch
+
+            RecordedEventMetadata metadata;
+            ModuleId moduleId;
+            MdMethodDef methodToken;
+            bool isVolatile;
+            switch (type)
             {
-                RecordedEventType.StaticFieldRead => evt.Get<(RecordedEventMetadata, StaticFieldReadArgs)>().Item2.IsVolatile,
-                RecordedEventType.StaticFieldWrite => evt.Get<(RecordedEventMetadata, StaticFieldWriteArgs)>().Item2.IsVolatile,
-                RecordedEventType.InstanceFieldRead => evt.Get<(RecordedEventMetadata, InstanceFieldReadArgs)>().Item2.IsVolatile,
-                RecordedEventType.InstanceFieldWrite => evt.Get<(RecordedEventMetadata, InstanceFieldWriteArgs)>().Item2.IsVolatile,
-                _ => false
-            };
-        }, description: $"VolatileFieldAccess({type})");
+                case RecordedEventType.StaticFieldRead:
+                    (metadata, var sr) = evt.Get<(RecordedEventMetadata, StaticFieldReadArgs)>();
+                    (moduleId, methodToken, isVolatile) = (sr.ModuleId, sr.MethodToken, sr.IsVolatile);
+                    break;
+                case RecordedEventType.StaticFieldWrite:
+                    (metadata, var sw) = evt.Get<(RecordedEventMetadata, StaticFieldWriteArgs)>();
+                    (moduleId, methodToken, isVolatile) = (sw.ModuleId, sw.MethodToken, sw.IsVolatile);
+                    break;
+                case RecordedEventType.InstanceFieldRead:
+                    (metadata, var ir) = evt.Get<(RecordedEventMetadata, InstanceFieldReadArgs)>();
+                    (moduleId, methodToken, isVolatile) = (ir.ModuleId, ir.MethodToken, ir.IsVolatile);
+                    break;
+                case RecordedEventType.InstanceFieldWrite:
+                    (metadata, var iw) = evt.Get<(RecordedEventMetadata, InstanceFieldWriteArgs)>();
+                    (moduleId, methodToken, isVolatile) = (iw.ModuleId, iw.MethodToken, iw.IsVolatile);
+                    break;
+                default:
+                    return false;
+            }
+
+            if (requireVolatile is { } wantVolatile && isVolatile != wantVolatile)
+                return false;
+
+            var resolveResult = plugin.Resolve(metadata, moduleId, methodToken);
+            if (resolveResult.IsError)
+                return false;
+
+            return resolveResult.Value.Module?.Assembly?.Name?.String == assemblyName;
+        }, description: $"FieldAccessInAssembly({type} in {assemblyName}, volatile={requireVolatile?.ToString() ?? "any"})");
     }
 
     public static AtomicPredicate<ulong, RecordedEventType> MethodEnter(string methodName, IMetadataResolver plugin)

--- a/src/Tests/SharpDetect.E2ETests/FieldAccessTests.cs
+++ b/src/Tests/SharpDetect.E2ETests/FieldAccessTests.cs
@@ -18,6 +18,7 @@ namespace SharpDetect.E2ETests;
 public class FieldAccessTests(ITestOutputHelper testOutput)
 {
     public const string CollectionName = "E2E_FieldAccessTests";
+    private const string SubjectAssemblyName = "SharpDetect.E2ETests.Subject";
     [Theory]
     [MemberData(nameof(SdkVersions.All), MemberType = typeof(SdkVersions))]
     public Task StaticField_ValueType_Read(string sdk)
@@ -251,7 +252,7 @@ public class FieldAccessTests(ITestOutputHelper testOutput)
         var analysisWorker = services.GetRequiredService<IAnalysisWorker>();
         var events = new TestEventsEnumerable(plugin);
         var assert = EventuallyMethodEnter(args.Target.Args!, plugin)
-            .Then(EventuallyEventType(eventType))
+            .Then(EventuallyFieldAccessInAssembly(SubjectAssemblyName, eventType, plugin))
             .Then(EventuallyMethodExit(args.Target.Args!, plugin));
 
         // Execute
@@ -298,7 +299,7 @@ public class FieldAccessTests(ITestOutputHelper testOutput)
         var analysisWorker = services.GetRequiredService<IAnalysisWorker>();
         var events = new TestEventsEnumerable(plugin);
         var assert = EventuallyMethodEnter(args.Target.Args!, plugin)
-            .Then(EventuallyVolatileFieldAccess(eventType))
+            .Then(EventuallyFieldAccessInAssembly(SubjectAssemblyName, eventType, plugin, requireVolatile: true))
             .Then(EventuallyMethodExit(args.Target.Args!, plugin));
 
         // Execute

--- a/src/Tests/SharpDetect.E2ETests/TemporalAssertionBuilders.cs
+++ b/src/Tests/SharpDetect.E2ETests/TemporalAssertionBuilders.cs
@@ -14,9 +14,13 @@ public static class TemporalAssertionBuilders
         return new(EventMatchers.EventType(type));
     }
 
-    public static EventuallyOperator<ulong, RecordedEventType> EventuallyVolatileFieldAccess(RecordedEventType type)
+    public static EventuallyOperator<ulong, RecordedEventType> EventuallyFieldAccessInAssembly(
+        string assemblyName,
+        RecordedEventType type,
+        IMetadataResolver plugin,
+        bool? requireVolatile = null)
     {
-        return new(EventMatchers.VolatileFieldAccess(type));
+        return new(EventMatchers.FieldAccessInAssembly(assemblyName, type, plugin, requireVolatile));
     }
 
     public static EventuallyOperator<ulong, RecordedEventType> EventuallyMethodEnter(


### PR DESCRIPTION
This PR fixes a bug in IL rewriter, which caused incorrect handling for `DUP` instruction. This caused issues when instrumenting instance field accesses whose instance was pushed with `DUP`. Also tightened tests to ensure we are actually receiving field access event from the test assembly.