### PR TITLE
Fix false-positive data race on .(c)ctor writes 

### DIFF
--- a/src/Extensibility/SharpDetect.Plugins.DataRace.FastTrack/FastTrackDetector.cs
+++ b/src/Extensibility/SharpDetect.Plugins.DataRace.FastTrack/FastTrackDetector.cs
@@ -275,7 +275,9 @@ internal sealed class FastTrackDetector
         var currentEpoch = threadVc.GetEpoch(threadId);
         var writeKind = ClassifyWrite(threadId, moduleId, methodToken, fieldFlags, objectId);
 
-        if (!shadow.WriteEpoch.IsNone &&
+        var isInstantiationWrite = writeKind == WriteKind.Instantiation;
+        if (!isInstantiationWrite &&
+            !shadow.WriteEpoch.IsNone &&
             shadow.WriteEpoch.ThreadId != threadId &&
             !shadow.WriteEpoch.HappensBefore(threadVc))
         {
@@ -298,7 +300,7 @@ internal sealed class FastTrackDetector
             return null;
         }
 
-        var readWriteRace = CheckReadWriteRace(threadId, shadow, threadVc);
+        var readWriteRace = isInstantiationWrite ? null : CheckReadWriteRace(threadId, shadow, threadVc);
         if (readWriteRace != null)
         {
             var hasLastAccess = _accessTracker.TryGetLastAccess(fieldId, objectId, out var lastAccess);

--- a/src/Tests/SharpDetect.E2ETests.Subject/Entrypoint.cs
+++ b/src/Tests/SharpDetect.E2ETests.Subject/Entrypoint.cs
@@ -521,6 +521,9 @@ namespace SharpDetect.E2ETests.Subject
                 case nameof(Test_NoDataRace_GenericType_Static_DifferentInstantiations_WriteWrite_NoRace):
                     Test_NoDataRace_GenericType_Static_DifferentInstantiations_WriteWrite_NoRace();
                     break;
+                case nameof(Test_NoDataRace_GenericType_StaticInitializer_DifferentInstantiations_WriteWrite_NoRace):
+                    Test_NoDataRace_GenericType_StaticInitializer_DifferentInstantiations_WriteWrite_NoRace();
+                    break;
                 case nameof(Test_NoDataRace_SemaphoreSlim_ProtectedWriteRead):
                     Test_NoDataRace_SemaphoreSlim_ProtectedWriteRead();
                     break;

--- a/src/Tests/SharpDetect.E2ETests.Subject/Helpers/GenericTypeWithStaticInitializer.cs
+++ b/src/Tests/SharpDetect.E2ETests.Subject/Helpers/GenericTypeWithStaticInitializer.cs
@@ -1,0 +1,14 @@
+// Copyright 2026 Andrej Čižmárik and Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+namespace SharpDetect.E2ETests.Subject.Helpers.DataRaces
+{
+    public class GenericTypeWithStaticInitializer<T>
+    {
+        public static HashSet<string> Values = new(StringComparer.OrdinalIgnoreCase)
+        {
+            "first",
+            "second"
+        };
+    }
+}

--- a/src/Tests/SharpDetect.E2ETests.Subject/SimpleTests.cs
+++ b/src/Tests/SharpDetect.E2ETests.Subject/SimpleTests.cs
@@ -1359,6 +1359,13 @@ namespace SharpDetect.E2ETests.Subject
             Task.WaitAll(task1, task2);
         }
 
+        public static void Test_NoDataRace_GenericType_StaticInitializer_DifferentInstantiations_WriteWrite_NoRace()
+        {
+            var task1 = Task.Run(() => { _ = GenericTypeWithStaticInitializer<int>.Values.Count; });
+            var task2 = Task.Run(() => { _ = GenericTypeWithStaticInitializer<string>.Values.Count; });
+            Task.WaitAll(task1, task2);
+        }
+
         public static void Test_NoDataRace_SemaphoreSlim_ProtectedWriteRead()
         {
             var sem = new SemaphoreSlim(1, 1);

--- a/src/Tests/SharpDetect.E2ETests/DataRacePluginTests.cs
+++ b/src/Tests/SharpDetect.E2ETests/DataRacePluginTests.cs
@@ -220,6 +220,11 @@ public class DataRacePluginTests(ITestOutputHelper testOutput)
         => AssertDoesNotDetectDataRace("Test_NoDataRace_GenericType_Static_DifferentInstantiations_WriteWrite_NoRace", sdk, plugin);
 
     [Theory]
+    [MemberData(nameof(SdkVersions.AllWithFastTrackOnly), MemberType = typeof(SdkVersions))]
+    public Task NoDataRace_GenericType_StaticInitializer_DifferentInstantiations_WriteWrite_NoRace(string sdk, string plugin)
+        => AssertDoesNotDetectDataRace("Test_NoDataRace_GenericType_StaticInitializer_DifferentInstantiations_WriteWrite_NoRace", sdk, plugin);
+
+    [Theory]
     [MemberData(nameof(SdkVersions.Net10WithBothDataRacePlugins), MemberType = typeof(SdkVersions))]
     public async Task CanRenderReport(string sdk, string pluginFullTypeName)
     {


### PR DESCRIPTION
This PR fixes a bug where some writes in .(c)ctor were incorrectly classified 