### PR TITLE
Performance: Add benchmark harness

### DIFF
--- a/src/CodeCoverage.runsettings
+++ b/src/CodeCoverage.runsettings
@@ -4,7 +4,7 @@
     <DataCollectors>
       <DataCollector friendlyName="XPlat code coverage">
         <Configuration>
-          <Exclude>[SharpDetect.E2ETests.Subject]*</Exclude>
+          <Exclude>[SharpDetect.E2ETests.Subject]*,[SharpDetect.Benchmarks]*</Exclude>
         </Configuration>
       </DataCollector>
     </DataCollectors>

--- a/src/Samples/PerfWorkload/AnalysisDescriptor.json
+++ b/src/Samples/PerfWorkload/AnalysisDescriptor.json
@@ -1,0 +1,16 @@
+{
+    "Target":
+    {
+        "Path": "../../Samples/PerfWorkload/bin/Debug/net10.0/PerfWorkload.dll",
+        "Args": "--iterations 1000000 --threads 8",
+        "RedirectInputOutput":
+        {
+            "SingleConsoleMode": true
+        }
+    },
+    "Analysis":
+    {
+        "PluginName": "FastTrack",
+        "RenderReport": false
+    }
+}

--- a/src/Samples/PerfWorkload/PerfWorkload.csproj
+++ b/src/Samples/PerfWorkload/PerfWorkload.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net10.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <None Update="AnalysisDescriptor.json">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </None>
+    </ItemGroup>
+
+</Project>

--- a/src/Samples/PerfWorkload/Program.cs
+++ b/src/Samples/PerfWorkload/Program.cs
@@ -1,0 +1,103 @@
+// Copyright 2026 Andrej Čižmárik and Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+using PerfWorkload;
+
+var iterations = WorkloadOptions.Parse(args, "--iterations", defaultValue: 1_000_000);
+var threadCount = WorkloadOptions.Parse(args, "--threads", defaultValue: 8);
+
+var workers = new Worker[threadCount];
+var threads = new Thread[threadCount];
+for (var i = 0; i < threadCount; i++)
+{
+    workers[i] = new Worker(iterations);
+    threads[i] = new Thread(workers[i].Run);
+}
+
+foreach (var thread in threads)
+    thread.Start();
+foreach (var thread in threads)
+    thread.Join();
+
+var checksum = workers.Sum(static w => w.Checksum)
+    + SharedState.LockGuardedCounter
+    + SharedState.SemaphoreGuardedCounter;
+Console.WriteLine($"PerfWorkload completed: threads={threadCount}, iterations={iterations}, checksum={checksum}.");
+
+internal static class SharedState
+{
+    public static long LockGuardedCounter;
+    public static long SemaphoreGuardedCounter;
+}
+
+internal sealed class Worker
+{
+    private static readonly Lock SharedLock = new();
+    private static readonly SemaphoreSlim SharedSemaphore = new(initialCount: 1, maxCount: 1);
+
+    private readonly int _iterations;
+    private int _first;
+    private int _second;
+
+    public Worker(int iterations)
+    {
+        _iterations = iterations;
+    }
+
+    public long Checksum { get; private set; }
+
+    public void Run()
+    {
+        for (var i = 0; i < _iterations; i++)
+            RunIteration(i);
+    }
+
+    private void RunIteration(int index)
+    {
+        WriteLocalFields(index);
+        Checksum += ReadLocalFields();
+        IncrementLockGuardedCounter();
+        IncrementSemaphoreGuardedCounter();
+
+        if ((index & 0xFF) == 0)
+            RunOnThreadPool();
+    }
+
+    private void WriteLocalFields(int value)
+    {
+        _first = value;
+        _second = value + 1;
+    }
+
+    private long ReadLocalFields()
+    {
+        return _first + _second;
+    }
+
+    private static void IncrementLockGuardedCounter()
+    {
+        lock (SharedLock)
+        {
+            SharedState.LockGuardedCounter++;
+        }
+    }
+
+    private static void IncrementSemaphoreGuardedCounter()
+    {
+        SharedSemaphore.Wait();
+        try
+        {
+            SharedState.SemaphoreGuardedCounter++;
+        }
+        finally
+        {
+            SharedSemaphore.Release();
+        }
+    }
+
+    private void RunOnThreadPool()
+    {
+        var task = Task.Run(static () => 1L);
+        Checksum += task.Result;
+    }
+}

--- a/src/Samples/PerfWorkload/WorkloadOptions.cs
+++ b/src/Samples/PerfWorkload/WorkloadOptions.cs
@@ -1,0 +1,27 @@
+// Copyright 2026 Andrej Čižmárik and Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+namespace PerfWorkload;
+
+internal static class WorkloadOptions
+{
+    public static int Parse(string[] args, string name, int defaultValue)
+    {
+        var tokens = args.SelectMany(static a => a.Split(' ', StringSplitOptions.RemoveEmptyEntries)).ToArray();
+        for (var index = 0; index < tokens.Length; index++)
+        {
+            if (tokens[index] != name)
+                continue;
+            
+            if (index == tokens.Length - 1 || !int.TryParse(tokens[index + 1], out var value) || value <= 0)
+            {
+                var actual = index == tokens.Length - 1 ? "<missing>" : tokens[index + 1];
+                throw new ArgumentException($"Option {name} requires a positive integer value, but got: {actual}.");
+            }
+
+            return value;
+        }
+
+        return defaultValue;
+    }
+}

--- a/src/SharpDetect.Worker/Services/AnalysisWorker.cs
+++ b/src/SharpDetect.Worker/Services/AnalysisWorker.cs
@@ -2,7 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Collections.Concurrent;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using CliWrap;
 using Microsoft.Extensions.Logging;
@@ -55,14 +57,30 @@ public sealed class AnalysisWorker : IAnalysisWorker
             _plugin.Configuration.SerializeToFile(configurationPath);
             _logger.LogTrace("Serialized analyzed method descriptors into file: \"{Path}\".", configurationPath);
 
+            var targetStartTimestamp = Stopwatch.GetTimestamp();
             var targetApplicationProcess = BuildTargetApplicationCommand().ExecuteAsync(cancellationToken);
             var rootPid = (uint)targetApplicationProcess.ProcessId;
+            AnalysisWorkerMetrics.TargetStarted(rootPid);
             _logger.LogInformation("Started process with PID: {Pid}.", rootPid);
 
-            ExecuteAnalysis(targetApplicationProcess.Task, rootPid, cancellationToken);
+            var targetDoneTimestamp = new StrongBox<long>(0L);
+            var targetExitTimestamp = targetApplicationProcess.Task.ContinueWith(
+                _ =>
+                {
+                    var timestamp = Stopwatch.GetTimestamp();
+                    Interlocked.CompareExchange(ref targetDoneTimestamp.Value, timestamp, 0L);
+                    return timestamp;
+                },
+                CancellationToken.None,
+                TaskContinuationOptions.ExecuteSynchronously,
+                TaskScheduler.Default);
+
+            ExecuteAnalysis(targetApplicationProcess.Task, rootPid, targetDoneTimestamp, cancellationToken);
             _logger.LogInformation("Terminating analysis of process with PID: {Pid}.", rootPid);
 
             var commandResult = await targetApplicationProcess;
+            AnalysisWorkerMetrics.TargetWallCompleted(
+                Stopwatch.GetElapsedTime(targetStartTimestamp, await targetExitTimestamp));
             if (commandResult.ExitCode != 0)
             {
                 var level = _arguments.Target.Kind == TargetKind.TestAssembly ? LogLevel.Information : LogLevel.Warning;
@@ -75,6 +93,7 @@ public sealed class AnalysisWorker : IAnalysisWorker
         }
         finally
         {
+            AnalysisWorkerMetrics.TargetExited();
             CleanupConfigurationFile(configurationPath);
             CleanupRegistrationQueueFile();
         }
@@ -151,11 +170,11 @@ public sealed class AnalysisWorker : IAnalysisWorker
         return envVars;
     }
 
-    private void ExecuteAnalysis(Task targetProcessTask, uint rootPid, CancellationToken cancellationToken)
+    private void ExecuteAnalysis(Task targetProcessTask, uint rootPid, StrongBox<long> targetDoneTimestamp, CancellationToken cancellationToken)
     {
         using var receiveCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         using var events = new BlockingCollection<RecordedEvent>(EventBufferCapacity);
-        var producer = new Thread(() => ProduceEvents(events, targetProcessTask, rootPid, receiveCts.Token))
+        var producer = new Thread(() => ProduceEvents(events, targetProcessTask, rootPid, targetDoneTimestamp, receiveCts.Token))
         {
             IsBackground = true,
             Name = "SharpDetect.EventReceiver"
@@ -168,20 +187,29 @@ public sealed class AnalysisWorker : IAnalysisWorker
         }
         finally
         {
+            var processTailEnd = Stopwatch.GetTimestamp();
             receiveCts.Cancel();
             producer.Join();
+
+            var exitTimestamp = Volatile.Read(ref targetDoneTimestamp.Value);
+            AnalysisWorkerMetrics.ProcessTailCompleted(exitTimestamp != 0
+                ? Stopwatch.GetElapsedTime(exitTimestamp, processTailEnd)
+                : TimeSpan.Zero);
 
             if (_pluginHost is IDisposable disposable)
                 disposable.Dispose();
         }
     }
 
-    private void ProduceEvents(BlockingCollection<RecordedEvent> events, Task targetProcessTask, uint rootPid, CancellationToken cancellationToken)
+    private void ProduceEvents(BlockingCollection<RecordedEvent> events, Task targetProcessTask, uint rootPid, StrongBox<long> targetDoneTimestamp, CancellationToken cancellationToken)
     {
         try
         {
-            foreach (var currentEvent in ReceiveEvents(targetProcessTask, rootPid, cancellationToken))
+            foreach (var currentEvent in ReceiveEvents(targetProcessTask, rootPid, targetDoneTimestamp, cancellationToken))
+            {
+                AnalysisWorkerMetrics.EventReceived(currentEvent.EventArgs);
                 events.Add(currentEvent, cancellationToken);
+            }
         }
         catch (OperationCanceledException)
         {
@@ -202,6 +230,7 @@ public sealed class AnalysisWorker : IAnalysisWorker
                 if (currentEvent.EventArgs is ProfilerDestroyRecordedEvent && currentEvent.Metadata.Pid == rootPid)
                     return;
 
+                AnalysisWorkerMetrics.EventProcessed();
                 if (_pluginHost.ProcessEvent(currentEvent) == RecordedEventState.Failed)
                 {
                     LogFailureAndTerminateAnalysis();
@@ -215,15 +244,37 @@ public sealed class AnalysisWorker : IAnalysisWorker
         }
     }
 
-    private IEnumerable<RecordedEvent> ReceiveEvents(Task targetProcessTask, uint rootPid, CancellationToken cancellationToken)
+    private IEnumerable<RecordedEvent> ReceiveEvents(Task targetProcessTask, uint rootPid, StrongBox<long> targetDoneTimestamp, CancellationToken cancellationToken)
     {
         var receivers = new Dictionary<uint, IProfilerEventReceiver>();
+        var drainStartTimestamp = 0L;
+        var lastDrainedEventTimestamp = 0L;
+
+        void TrackDrainedEvent()
+        {
+            if (drainStartTimestamp == 0)
+                return;
+
+            lastDrainedEventTimestamp = Stopwatch.GetTimestamp();
+            AnalysisWorkerMetrics.EventDrained();
+        }
+
         try
         {
             var consecutiveEmptyPolls = 0;
             while (!cancellationToken.IsCancellationRequested)
             {
                 DiscoverProcesses(receivers);
+
+                if (drainStartTimestamp == 0)
+                {
+                    var doneTimestamp = Volatile.Read(ref targetDoneTimestamp.Value);
+                    if (doneTimestamp != 0)
+                    {
+                        drainStartTimestamp = doneTimestamp;
+                        lastDrainedEventTimestamp = doneTimestamp;
+                    }
+                }
 
                 var receivedAny = false;
                 foreach (var (pid, receiver) in receivers)
@@ -234,6 +285,7 @@ public sealed class AnalysisWorker : IAnalysisWorker
                     for (var i = 0; i < MaxBatchPerReceiver && receiver.TryReceiveNotification(out var childEvent); i++)
                     {
                         receivedAny = true;
+                        TrackDrainedEvent();
                         yield return childEvent;
                     }
                 }
@@ -243,10 +295,14 @@ public sealed class AnalysisWorker : IAnalysisWorker
                     for (var i = 0; i < MaxBatchPerReceiver && rootReceiver.TryReceiveNotification(out var rootEvent); i++)
                     {
                         receivedAny = true;
+                        TrackDrainedEvent();
                         yield return rootEvent;
 
                         if (rootEvent.EventArgs is ProfilerDestroyRecordedEvent && rootEvent.Metadata.Pid == rootPid)
+                        {
+                            Interlocked.CompareExchange(ref targetDoneTimestamp.Value, Stopwatch.GetTimestamp(), 0L);
                             yield break;
+                        }
                     }
                 }
 
@@ -264,6 +320,9 @@ public sealed class AnalysisWorker : IAnalysisWorker
         }
         finally
         {
+            if (drainStartTimestamp != 0)
+                AnalysisWorkerMetrics.DrainCompleted(Stopwatch.GetElapsedTime(drainStartTimestamp, lastDrainedEventTimestamp));
+
             foreach (var receiver in receivers.Values)
                 (receiver as IDisposable)?.Dispose();
         }

--- a/src/SharpDetect.Worker/Services/AnalysisWorkerMetrics.cs
+++ b/src/SharpDetect.Worker/Services/AnalysisWorkerMetrics.cs
@@ -1,0 +1,113 @@
+// Copyright 2026 Andrej Čižmárik and Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Collections.Frozen;
+using System.Diagnostics.Metrics;
+using System.Reflection;
+using MessagePack;
+using SharpDetect.Core.Events;
+
+namespace SharpDetect.Worker.Services;
+
+public static class AnalysisWorkerMetrics
+{
+    public const string MeterName = "SharpDetect.Worker";
+    public const string EventsReceivedInstrument = "sharpdetect.worker.events.received";
+    public const string EventsReceivedByTypeInstrument = "sharpdetect.worker.events.received.by_type";
+    public const string EventsProcessedInstrument = "sharpdetect.worker.events.processed";
+    public const string DrainEventsInstrument = "sharpdetect.worker.drain.events";
+    public const string DrainDurationInstrument = "sharpdetect.worker.drain.duration";
+    public const string ProcessTailDurationInstrument = "sharpdetect.worker.process.tail.duration";
+    public const string TargetWallDurationInstrument = "sharpdetect.worker.target.wall.duration";
+    public const string TargetPidInstrument = "sharpdetect.worker.target.pid";
+    private const string EventTypeTagName = "event.type";
+
+    private static readonly Meter Meter = new(MeterName);
+    private static readonly ObservableCounter<long> ReceivedByTypeCounter;
+    private static readonly Lazy<FrozenDictionary<Type, MutableCount>> ReceivedEventsByType = new(
+        static () => typeof(IRecordedEventArgs)
+            .GetCustomAttributes<UnionAttribute>()
+            .DistinctBy(static union => union.SubType)
+            .ToFrozenDictionary(static union => union.SubType, static _ => new MutableCount()),
+        LazyThreadSafetyMode.ExecutionAndPublication);
+    
+    private sealed class MutableCount
+    {
+        public long Value;
+    }
+
+    private static long _receivedEvents;
+    private static long _processedEvents;
+    private static long _drainedEvents;
+    private static double _drainDurationSeconds;
+    private static double _processTailDurationSeconds;
+    private static double _targetWallDurationSeconds;
+    private static long _targetPid;
+
+    static AnalysisWorkerMetrics()
+    {
+        Meter.CreateObservableCounter(EventsReceivedInstrument, static () => Volatile.Read(ref _receivedEvents),
+            unit: "{event}", description: "Total events received from the profiler.");
+        ReceivedByTypeCounter = Meter.CreateObservableCounter(EventsReceivedByTypeInstrument, ObserveReceivedEventsByType,
+            unit: "{event}", description: "Events received from the profiler, by recorded-event type.");
+        Meter.CreateObservableCounter(EventsProcessedInstrument, static () => Volatile.Read(ref _processedEvents),
+            unit: "{event}", description: "Events handed over to the plugin host.");
+        Meter.CreateObservableCounter(DrainEventsInstrument, static () => Volatile.Read(ref _drainedEvents),
+            unit: "{event}", description: "Events received after the target process exited.");
+        Meter.CreateObservableCounter(DrainDurationInstrument, static () => Volatile.Read(ref _drainDurationSeconds),
+            unit: "s", description: "Cumulative time between target process exit and the last drained event.");
+        Meter.CreateObservableCounter(ProcessTailDurationInstrument, static () => Volatile.Read(ref _processTailDurationSeconds),
+            unit: "s", description: "Cumulative time between target process exit and the end of event processing.");
+        Meter.CreateObservableCounter(TargetWallDurationInstrument, static () => Volatile.Read(ref _targetWallDurationSeconds),
+            unit: "s", description: "Cumulative wall-clock lifetime of the target process, from launch to exit.");
+        Meter.CreateObservableGauge(TargetPidInstrument, static () => Volatile.Read(ref _targetPid),
+            description: "PID of the currently running target process (0 when none).");
+    }
+
+    public static long CurrentTargetPid => Volatile.Read(ref _targetPid);
+
+    internal static void EventReceived(IRecordedEventArgs eventArgs)
+    {
+        _receivedEvents++;
+        if (!ReceivedByTypeCounter.Enabled)
+            return;
+
+        if (ReceivedEventsByType.Value.TryGetValue(eventArgs.GetType(), out var count))
+            count.Value++;
+    }
+
+    internal static void EventProcessed()
+        => _processedEvents++;
+
+    internal static void EventDrained()
+        => _drainedEvents++;
+
+    internal static void DrainCompleted(TimeSpan duration)
+        => _drainDurationSeconds += duration.TotalSeconds;
+
+    internal static void ProcessTailCompleted(TimeSpan duration)
+        => _processTailDurationSeconds += duration.TotalSeconds;
+
+    internal static void TargetWallCompleted(TimeSpan duration)
+        => _targetWallDurationSeconds += duration.TotalSeconds;
+
+    internal static void TargetStarted(uint pid)
+        => Volatile.Write(ref _targetPid, pid);
+
+    internal static void TargetExited()
+        => Volatile.Write(ref _targetPid, 0);
+
+    private static IEnumerable<Measurement<long>> ObserveReceivedEventsByType()
+    {
+        foreach (var (type, count) in ReceivedEventsByType.Value)
+        {
+            var value = Volatile.Read(ref count.Value);
+            if (value > 0)
+            {
+                yield return new Measurement<long>(
+                    value,
+                    new KeyValuePair<string, object?>(EventTypeTagName, type.Name));
+            }
+        }
+    }
+}

--- a/src/SharpDetect.slnx
+++ b/src/SharpDetect.slnx
@@ -29,6 +29,7 @@
     <File Path="../.github/workflows/release.yml" />
   </Folder>
   <Folder Name="/Samples/">
+    <Project Path="Samples/PerfWorkload/PerfWorkload.csproj" />
     <Project Path="Samples/SimpleDataRace/SimpleDataRace.csproj" />
     <Project Path="Samples/SimpleDeadlock/SimpleDeadlock.csproj" />
   </Folder>
@@ -41,6 +42,9 @@
     <Project Path="Tests/SharpDetect.Plugins.DataRace.Common.Tests/SharpDetect.Plugins.DataRace.Common.Tests.csproj" />
     <Project Path="Tests/SharpDetect.Reporting.Tests/SharpDetect.Reporting.Tests.csproj" />
     <Project Path="Tests/SharpDetect.TemporalAsserts/SharpDetect.TemporalAsserts.csproj" />
+  </Folder>
+  <Folder Name="/Tools/">
+    <Project Path="Tools/SharpDetect.Benchmarks/SharpDetect.Benchmarks.csproj" />
   </Folder>
   <Project Path="SharpDetect.Cli/SharpDetect.Cli.csproj" />
   <Project Path="SharpDetect.Communication/SharpDetect.Communication.csproj" />

--- a/src/Tools/SharpDetect.Benchmarks/Commands/BenchmarkCommand.cs
+++ b/src/Tools/SharpDetect.Benchmarks/Commands/BenchmarkCommand.cs
@@ -1,0 +1,72 @@
+// Copyright 2026 Andrej Čižmárik and Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+using CliFx;
+using CliFx.Binding;
+using CliFx.Infrastructure;
+using SharpDetect.Benchmarks.Configuration;
+using SharpDetect.Benchmarks.Handlers;
+
+namespace SharpDetect.Benchmarks.Commands;
+
+[Command(Description = "Measures a performance baseline for the current commit against provided workload")]
+public sealed partial class BenchmarkCommand : ICommand
+{
+    [CommandOption("workload", Description = "Path to workload DLL")]
+    public required string WorkloadPath { get; set; }
+
+    [CommandOption("iterations", Description = "Workload iterations per thread")]
+    private int Iterations { get; set; } = 125_000;
+
+    [CommandOption("threads", Description = "Workload thread count")]
+    private int Threads { get; set; } = 4;
+
+    [CommandOption("warmup", Description = "Number of discarded warmup runs per measured configuration")]
+    private int Warmup { get; set; } = 1;
+
+    [CommandOption("runs", Description = "Number of repetitions of each measured configuration")]
+    private int Runs { get; set; } = 5;
+
+    [CommandOption("output", Description = "Directory for the baseline JSON (default: <repository root>/docs/benchmarks)")]
+    private string? OutputDirectory { get; set; }
+
+    public async ValueTask ExecuteAsync(IConsole console)
+    {
+        var options = ValidateOptions(WorkloadPath, Iterations, Threads, Warmup, Runs, OutputDirectory);
+        var handler = new BenchmarkCommandHandler(options);
+        var cancellationToken = console.RegisterCancellationHandler();
+        await handler.ExecuteAsync(console, cancellationToken);
+    }
+
+    private static BenchmarkOptions ValidateOptions(
+        string workloadPath,
+        int iterations,
+        int threads,
+        int warmup,
+        int runs,
+        string? outputDirectory)
+    {
+        var fullWorkloadPath = Path.GetFullPath(workloadPath);
+        if (!File.Exists(fullWorkloadPath))
+            throw new CommandException($"Workload not found: {fullWorkloadPath}.");
+
+        RequirePositive(iterations, "--iterations");
+        RequirePositive(threads, "--threads");
+        RequireNonNegative(warmup, "--warmup");
+        RequirePositive(runs, "--runs");
+
+        return new BenchmarkOptions(fullWorkloadPath, iterations, threads, warmup, runs, outputDirectory);
+    }
+
+    private static void RequirePositive(int value, string name)
+    {
+        if (value <= 0)
+            throw new CommandException($"{name} must be greater than zero, but was {value}.");
+    }
+
+    private static void RequireNonNegative(int value, string name)
+    {
+        if (value < 0)
+            throw new CommandException($"{name} must not be negative, but was {value}.");
+    }
+}

--- a/src/Tools/SharpDetect.Benchmarks/Configuration/BenchmarkOptions.cs
+++ b/src/Tools/SharpDetect.Benchmarks/Configuration/BenchmarkOptions.cs
@@ -1,0 +1,12 @@
+// Copyright 2026 Andrej Čižmárik and Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+namespace SharpDetect.Benchmarks.Configuration;
+
+internal sealed record BenchmarkOptions(
+    string WorkloadPath,
+    int Iterations,
+    int Threads,
+    int Warmup,
+    int Runs,
+    string? OutputDirectory);

--- a/src/Tools/SharpDetect.Benchmarks/Handlers/BenchmarkCommandHandler.cs
+++ b/src/Tools/SharpDetect.Benchmarks/Handlers/BenchmarkCommandHandler.cs
@@ -1,0 +1,247 @@
+// Copyright 2026 Andrej Čižmárik and Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Diagnostics;
+using CliFx;
+using CliFx.Infrastructure;
+using CliWrap;
+using CliWrap.Buffered;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using SharpDetect.Benchmarks.Configuration;
+using SharpDetect.Benchmarks.Measurements;
+using SharpDetect.Benchmarks.Models;
+using SharpDetect.Benchmarks.Reporting;
+using SharpDetect.Core.Plugins;
+using SharpDetect.Plugins.DataRace.FastTrack;
+using SharpDetect.Worker;
+using SharpDetect.Worker.Commands.Run;
+using SharpDetect.Worker.Configuration;
+using SharpDetect.Worker.Services;
+
+namespace SharpDetect.Benchmarks.Handlers;
+
+internal sealed class BenchmarkCommandHandler(BenchmarkOptions options)
+{
+    public async Task ExecuteAsync(IConsole console, CancellationToken cancellationToken)
+    {
+        var git = await GitInfo.ResolveAsync();
+        await console.Output.WriteLineAsync($"SharpDetect benchmark: " +
+                                            $"commit={git.Label} " +
+                                            $"configuration={BuildInfo.Configuration} " +
+                                            $"iterations={options.Iterations} " +
+                                            $"threads={options.Threads} " +
+                                            $"warmup={options.Warmup} " +
+                                            $"runs={options.Runs}");
+
+        var bareRuns = await RepeatAsync(
+            console,
+            label: "bare",
+            RunBareWorkloadAsync,
+            static run =>
+                $"wall={run.WallSeconds:F2}s " +
+                $"cpu={run.Resources.CpuSeconds:F2}s",
+            cancellationToken);
+
+        using var listener = new WorkerMetricsListener();
+        var instrumentedRuns = await RepeatAsync(
+            console,
+            label: "instrumented",
+            token => RunInstrumentedWorkloadAsync(listener, token),
+            static run =>
+                $"wall={run.WallSeconds:F2}s " +
+                $"targetWall={run.Metrics.TargetWallSeconds:F2}s " +
+                $"events={run.Metrics.EventsReceived} " +
+                $"drainTail={run.Metrics.DrainSeconds:F3}s " +
+                $"targetCpu={run.TargetResources.CpuSeconds:F2}s",
+            cancellationToken);
+
+        var report = BaselineReportBuilder.Build(git, options, bareRuns, instrumentedRuns);
+        var (baselinePath, latestPath) = await WriteReportAsync(report, git, cancellationToken);
+
+        BaselineSummaryRenderer.Render(console, report);
+        await console.Output.WriteLineAsync();
+        await console.Output.WriteLineAsync($"Baseline written to: {baselinePath}");
+        await console.Output.WriteLineAsync($"Latest baseline:     {latestPath}");
+    }
+
+    private async Task<List<TRun>> RepeatAsync<TRun>(
+        IConsole console,
+        string label,
+        Func<CancellationToken, Task<TRun>> runAsync,
+        Func<TRun, string> describe,
+        CancellationToken cancellationToken)
+    {
+        for (var index = 0; index < options.Warmup; index++)
+        {
+            var warmupRun = await runAsync(cancellationToken);
+            await console.Output.WriteLineAsync($"  {label} warmup {index + 1}/{options.Warmup}: {describe(warmupRun)} (discarded)");
+        }
+
+        var runs = new List<TRun>(options.Runs);
+        for (var index = 0; index < options.Runs; index++)
+        {
+            var run = await runAsync(cancellationToken);
+            runs.Add(run);
+            await console.Output.WriteLineAsync($"  {label} run {index + 1}/{options.Runs}: {describe(run)}");
+        }
+
+        return runs;
+    }
+
+    private async Task<BareRunResult> RunBareWorkloadAsync(CancellationToken cancellationToken)
+    {
+        var cpu = ChildCpuAccounting.Begin();
+        var startTimestamp = Stopwatch.GetTimestamp();
+        var execution = Cli.Wrap("dotnet")
+            .WithArguments([
+                options.WorkloadPath,
+                "--iterations", options.Iterations.ToString(),
+                "--threads", options.Threads.ToString()])
+            .WithValidation(CommandResultValidation.None)
+            .ExecuteBufferedAsync(cancellationToken);
+
+        var samples = await SampleWhileAsync(
+            () => execution.ProcessId,
+            () => execution.Task,
+            cancellationToken);
+        var wallSeconds = Stopwatch.GetElapsedTime(startTimestamp).TotalSeconds;
+
+        var result = await execution.Task;
+        if (result.ExitCode != 0)
+        {
+            throw new InvalidOperationException(
+                $"Bare workload run failed with exit code: {result.ExitCode}. Stderr: {result.StandardError}");
+        }
+
+        var run = new BareRunResult(wallSeconds, cpu.Complete(samples.Target));
+        EnsureSane("bare", RunValidation.Validate(run));
+        return run;
+    }
+
+    private async Task<AnalyzedRunResult> RunInstrumentedWorkloadAsync(
+        WorkerMetricsListener listener,
+        CancellationToken cancellationToken)
+    {
+        var metricsBefore = listener.Poll();
+        var gcBefore = GcSnapshot.Capture();
+        var analysis = await ExecuteAnalysisAsync(cancellationToken);
+        var gc = GcSnapshot.Capture().Since(gcBefore);
+
+        var run = new AnalyzedRunResult(
+            analysis.WallSeconds,
+            MetricsSnapshot.Delta(metricsBefore, listener.Poll()),
+            gc.AllocatedMegabytes,
+            gc.Gen0,
+            gc.Gen1,
+            gc.Gen2,
+            analysis.TargetResources,
+            analysis.HostPeakRssMB,
+            analysis.ReportedIssues);
+        EnsureSane("instrumented", RunValidation.Validate(run));
+        return run;
+    }
+
+    private async Task<AnalysisExecution> ExecuteAnalysisAsync(CancellationToken cancellationToken)
+    {
+        var provider = BuildAnalysisServiceProvider();
+        try
+        {
+            var worker = provider.GetRequiredService<IAnalysisWorker>();
+            var cpu = ChildCpuAccounting.Begin();
+            var startTimestamp = Stopwatch.GetTimestamp();
+            var samples = await SampleWhileAsync(
+                static () => AnalysisWorkerMetrics.CurrentTargetPid,
+                () => worker.ExecuteAsync(cancellationToken).AsTask(),
+                cancellationToken);
+            var wallSeconds = Stopwatch.GetElapsedTime(startTimestamp).TotalSeconds;
+
+            var plugin = provider.GetRequiredService<IPlugin>();
+            return new AnalysisExecution(
+                wallSeconds,
+                cpu.Complete(samples.Target),
+                samples.HostPeakRssMegabytes,
+                ReportedIssues: plugin.CreateDiagnostics().GetAllReports().Count());
+        }
+        finally
+        {
+            (provider as IDisposable)?.Dispose();
+        }
+    }
+
+    private static async Task<RunResourceSamples> SampleWhileAsync(
+        Func<long> getPid,
+        Func<Task> workAsync,
+        CancellationToken cancellationToken)
+    {
+        using var samplerCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        var samplerTask = ProcessResourceSampler.SampleUntilCancelledAsync(getPid, samplerCancellation.Token);
+        try
+        {
+            await workAsync();
+        }
+        finally
+        {
+            await samplerCancellation.CancelAsync();
+        }
+
+        return await samplerTask;
+    }
+
+    private static void EnsureSane(string label, IReadOnlyList<string> violations)
+    {
+        if (violations.Count == 0)
+            return;
+
+        var report = string.Join(Environment.NewLine, violations.Select(static v => $"  - {v}"));
+        throw new CommandException(
+            $"Sanity check failed for the {label} run — refusing to write a baseline:{Environment.NewLine}{report}");
+    }
+
+    private async Task<(string BaselinePath, string LatestPath)> WriteReportAsync(
+        BaselineReport report,
+        GitInfo git,
+        CancellationToken cancellationToken)
+    {
+        var outputDirectory = Path.GetFullPath(options.OutputDirectory ??
+            Path.Combine(git.RepositoryRoot ?? Environment.CurrentDirectory, "docs", "benchmarks"));
+        Directory.CreateDirectory(outputDirectory);
+
+        var baselinePath = Path.Combine(outputDirectory, $"{git.Label}.json");
+        var latestPath = Path.Combine(outputDirectory, "latest.json");
+        var json = report.Serialize();
+        await File.WriteAllTextAsync(baselinePath, json, cancellationToken);
+        await File.WriteAllTextAsync(latestPath, json, cancellationToken);
+
+        return (baselinePath, latestPath);
+    }
+
+    private IServiceProvider BuildAnalysisServiceProvider()
+    {
+        var arguments = new RunCommandArgs(
+            Runtime: null,
+            Target: new TargetConfigurationArgs(
+                path: options.WorkloadPath,
+                args: $"--iterations {options.Iterations} --threads {options.Threads}"),
+            Analysis: new AnalysisPluginConfigurationArgs(
+                pluginName: "FastTrack",
+                renderReport: false,
+                logLevel: LogLevel.Warning));
+
+        return new AnalysisServiceProviderBuilder(arguments)
+            .WithTimeProvider(TimeProvider.System)
+            .WithPlugin(typeof(FastTrackPlugin))
+            .ConfigureLogging(logging =>
+            {
+                logging.AddConsole();
+                logging.SetMinimumLevel(LogLevel.Warning);
+            })
+            .Build();
+    }
+
+    private sealed record AnalysisExecution(
+        double WallSeconds,
+        ProcessResourceSample TargetResources,
+        double HostPeakRssMB,
+        int ReportedIssues);
+}

--- a/src/Tools/SharpDetect.Benchmarks/Measurements/ChildCpuAccounting.cs
+++ b/src/Tools/SharpDetect.Benchmarks/Measurements/ChildCpuAccounting.cs
@@ -1,0 +1,43 @@
+// Copyright 2026 Andrej Čižmárik and Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Globalization;
+using System.Runtime.Versioning;
+using SharpDetect.Benchmarks.Models;
+
+namespace SharpDetect.Benchmarks.Measurements;
+
+internal readonly struct ChildCpuAccounting
+{
+    public static string Mode => OperatingSystem.IsLinux() ? "exact-reaped-children" : "post-exit-process-times";
+    // USER_HZ is a fixed kernel ABI constant for /proc timing fields
+    private const double UserHz = 100.0;
+
+    private readonly double _baselineSeconds;
+
+    private ChildCpuAccounting(double baselineSeconds)
+    {
+        _baselineSeconds = baselineSeconds;
+    }
+
+    public static ChildCpuAccounting Begin()
+        => new(OperatingSystem.IsLinux() ? ReadReapedChildrenCpuSeconds() : 0);
+
+    public ProcessResourceSample Complete(ProcessResourceSample sampled)
+        => OperatingSystem.IsLinux()
+            ? sampled with { CpuSeconds = ReadReapedChildrenCpuSeconds() - _baselineSeconds }
+            : sampled;
+
+    [SupportedOSPlatform("linux")]
+    private static double ReadReapedChildrenCpuSeconds()
+        => ParseReapedChildrenTicks(File.ReadAllText("/proc/self/stat")) / UserHz;
+
+    internal static long ParseReapedChildrenTicks(string statLine)
+    {
+        // Format: "pid (comm) state ppid ..."
+        var afterComm = statLine[(statLine.LastIndexOf(')') + 1)..];
+        var fields = afterComm.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        return long.Parse(fields[13], CultureInfo.InvariantCulture)
+            + long.Parse(fields[14], CultureInfo.InvariantCulture);
+    }
+}

--- a/src/Tools/SharpDetect.Benchmarks/Measurements/ProcessResourceSampler.cs
+++ b/src/Tools/SharpDetect.Benchmarks/Measurements/ProcessResourceSampler.cs
@@ -1,0 +1,135 @@
+// Copyright 2026 Andrej Čižmárik and Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Diagnostics;
+using System.Runtime.Versioning;
+using SharpDetect.Benchmarks.Models;
+
+namespace SharpDetect.Benchmarks.Measurements;
+
+internal static class ProcessResourceSampler
+{
+    public static readonly TimeSpan PollInterval = TimeSpan.FromMilliseconds(50);
+
+    public static async Task<RunResourceSamples> SampleUntilCancelledAsync(
+        Func<long> getPid,
+        CancellationToken cancellationToken)
+    {
+        Process? target = null;
+        var lastTargetSample = default(ProcessResourceSample);
+        var hostPeakRssMegabytes = 0.0;
+        try
+        {
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                hostPeakRssMegabytes = Math.Max(hostPeakRssMegabytes, Environment.WorkingSet / (1024.0 * 1024.0));
+
+                target ??= TryAttach(getPid());
+                if (target is not null && TrySample(target, out var sample))
+                    lastTargetSample = sample;
+
+                try
+                {
+                    await Task.Delay(PollInterval, cancellationToken);
+                }
+                catch (OperationCanceledException)
+                {
+                    break;
+                }
+            }
+
+            if (target is not null && OperatingSystem.IsWindows() && TryReadCpuAfterExit(target, out var cpuSeconds))
+                lastTargetSample = lastTargetSample with { CpuSeconds = cpuSeconds };
+
+            return new RunResourceSamples(lastTargetSample, hostPeakRssMegabytes);
+        }
+        finally
+        {
+            target?.Dispose();
+        }
+    }
+
+    private static Process? TryAttach(long pid)
+    {
+        if (pid <= 0)
+            return null;
+
+        try
+        {
+            var process = Process.GetProcessById((int)pid);
+            if (OperatingSystem.IsWindows())
+                _ = process.SafeHandle;
+            return process;
+        }
+        catch (Exception)
+        {
+            // The process exited before we could attach
+            return null;
+        }
+    }
+
+    private static bool TrySample(Process process, out ProcessResourceSample sample)
+    {
+        sample = default;
+        try
+        {
+            process.Refresh();
+            if (process.HasExited)
+                return false;
+
+            double peakRssMegabytes;
+            if (OperatingSystem.IsLinux())
+            {
+                if (!TryReadLinuxPeakRssMegabytes(process.Id, out peakRssMegabytes))
+                    return false;
+            }
+            else
+            {
+                peakRssMegabytes = process.PeakWorkingSet64 / (1024.0 * 1024.0);
+            }
+
+            sample = new ProcessResourceSample(process.TotalProcessorTime.TotalSeconds, peakRssMegabytes);
+            return true;
+        }
+        catch (Exception)
+        {
+            // Most likely, the process exited mid-sample
+            return false;
+        }
+    }
+
+    [SupportedOSPlatform("windows")]
+    private static bool TryReadCpuAfterExit(Process process, out double cpuSeconds)
+    {
+        try
+        {
+            // GetProcessTimes stays valid on an exited process while the acquired handle is open
+            cpuSeconds = process.TotalProcessorTime.TotalSeconds;
+            return true;
+        }
+        catch (Exception)
+        {
+            cpuSeconds = 0;
+            return false;
+        }
+    }
+
+    [SupportedOSPlatform("linux")]
+    private static bool TryReadLinuxPeakRssMegabytes(int pid, out double peakRssMegabytes)
+    {
+        // Format: "VmHWM:    123456 kB"
+        // Note the line disappears once the process exited
+        foreach (var line in File.ReadLines($"/proc/{pid}/status"))
+        {
+            if (!line.StartsWith("VmHWM:", StringComparison.Ordinal))
+                continue;
+            
+            var parts = line.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+            peakRssMegabytes = ulong.Parse(parts[1]) / 1024.0;
+            return true;
+        }
+
+        peakRssMegabytes = 0;
+        return false;
+    }
+}

--- a/src/Tools/SharpDetect.Benchmarks/Measurements/RunValidation.cs
+++ b/src/Tools/SharpDetect.Benchmarks/Measurements/RunValidation.cs
@@ -1,0 +1,63 @@
+// Copyright 2026 Andrej Čižmárik and Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+using SharpDetect.Benchmarks.Models;
+using SharpDetect.Core.Events;
+
+namespace SharpDetect.Benchmarks.Measurements;
+
+internal static class RunValidation
+{
+    private const double WallToleranceSeconds = 0.05;
+    
+    private static readonly Type[] ExpectedEventTypes =
+    [
+        typeof(ProfilerInitializeRecordedEvent),
+        typeof(ModuleLoadRecordedEvent),
+        typeof(JitCompilationRecordedEvent),
+        typeof(MethodEnterWithArgumentsRecordedEvent),
+        typeof(MethodExitWithArgumentsRecordedEvent),
+        typeof(MethodExitRecordedEvent),
+        typeof(ThreadCreateRecordedEvent),
+        typeof(FieldAccessInstrumentationRecordedEvent),
+        typeof(MethodBodyRewriteRecordedEvent),
+    ];
+
+    public static IReadOnlyList<string> Validate(BareRunResult run)
+    {
+        var violations = new List<string>();
+        if (run.WallSeconds <= 0)
+            violations.Add($"bare wall time is {run.WallSeconds:F4} s");
+        if (run.Resources.CpuSeconds <= 0)
+            violations.Add($"bare target CPU is {run.Resources.CpuSeconds:F4} s");
+
+        return violations;
+    }
+
+    public static IReadOnlyList<string> Validate(AnalyzedRunResult run)
+    {
+        var violations = new List<string>();
+        if (run.Metrics.EventsReceived <= 0)
+            violations.Add("no events were received from the profiler.");
+        if (run.Metrics.EventsProcessed != run.Metrics.EventsReceived)
+            violations.Add($"events processed ({run.Metrics.EventsProcessed}) != events received ({run.Metrics.EventsReceived})");
+        if (run.Metrics.TargetWallSeconds <= 0)
+            violations.Add("target wall time was not measured (0)");
+        if (run.Metrics.TargetWallSeconds > run.WallSeconds + WallToleranceSeconds)
+            violations.Add($"target wall ({run.Metrics.TargetWallSeconds:F4} s) exceeds the whole analysis wall ({run.WallSeconds:F4} s)");
+        if (run.Metrics.ProcessTailSeconds <= 0)
+            violations.Add("process tail was not measured (0)");
+        if (run.TargetResources.CpuSeconds <= 0)
+            violations.Add($"instrumented target CPU is {run.TargetResources.CpuSeconds:F4} s");
+        if (run.ReportedIssues != 0)
+            violations.Add($"analysis reported {run.ReportedIssues} issue(s) on a race-free workload");
+
+        foreach (var expectedType in ExpectedEventTypes)
+        {
+            if (!run.Metrics.ReceivedByType.ContainsKey(expectedType.Name))
+                violations.Add($"expected event type {expectedType.Name} was never received");
+        }
+
+        return violations;
+    }
+}

--- a/src/Tools/SharpDetect.Benchmarks/Measurements/WorkerMetricsListener.cs
+++ b/src/Tools/SharpDetect.Benchmarks/Measurements/WorkerMetricsListener.cs
@@ -1,0 +1,62 @@
+// Copyright 2026 Andrej Čižmárik and Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Diagnostics.Metrics;
+using SharpDetect.Benchmarks.Models;
+using SharpDetect.Worker.Services;
+
+namespace SharpDetect.Benchmarks.Measurements;
+
+internal sealed class WorkerMetricsListener : IDisposable
+{
+    private readonly MeterListener _listener;
+    private readonly Lock _lock = new();
+    private readonly Dictionary<string, double> _counters = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, double> _gauges = new(StringComparer.Ordinal);
+
+    public WorkerMetricsListener()
+    {
+        _listener = new MeterListener
+        {
+            InstrumentPublished = static (instrument, listener) =>
+            {
+                if (instrument.Meter.Name == AnalysisWorkerMetrics.MeterName)
+                    listener.EnableMeasurementEvents(instrument);
+            }
+        };
+
+        _listener.SetMeasurementEventCallback<long>((instrument, measurement, tags, _)
+            => Record(instrument, measurement, tags));
+        _listener.SetMeasurementEventCallback<double>((instrument, measurement, tags, _)
+            => Record(instrument, measurement, tags));
+        _listener.Start();
+    }
+
+    public MetricsSnapshot Poll()
+    {
+        lock (_lock)
+        {
+            _listener.RecordObservableInstruments();
+            return new MetricsSnapshot(
+                Counters: new Dictionary<string, double>(_counters, StringComparer.Ordinal),
+                Gauges: new Dictionary<string, double>(_gauges, StringComparer.Ordinal));
+        }
+    }
+
+    private void Record(Instrument instrument, double measurement, ReadOnlySpan<KeyValuePair<string, object?>> tags)
+    {
+        var store = instrument is ObservableGauge<long> or ObservableGauge<double>
+            ? _gauges
+            : _counters;
+
+        store[BuildKey(instrument, tags)] = measurement;
+    }
+
+    private static string BuildKey(Instrument instrument, ReadOnlySpan<KeyValuePair<string, object?>> tags)
+        => tags.IsEmpty ? instrument.Name : $"{instrument.Name}/{tags[0].Value}";
+
+    public void Dispose()
+    {
+        _listener.Dispose();
+    }
+}

--- a/src/Tools/SharpDetect.Benchmarks/Models/AnalyzedRunResult.cs
+++ b/src/Tools/SharpDetect.Benchmarks/Models/AnalyzedRunResult.cs
@@ -1,0 +1,15 @@
+// Copyright 2026 Andrej Čižmárik and Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+namespace SharpDetect.Benchmarks.Models;
+
+internal sealed record AnalyzedRunResult(
+    double WallSeconds,
+    MetricsSnapshot Metrics,
+    double AllocatedMB,
+    int Gen0,
+    int Gen1,
+    int Gen2,
+    ProcessResourceSample TargetResources,
+    double HostPeakRssMB,
+    int ReportedIssues);

--- a/src/Tools/SharpDetect.Benchmarks/Models/BareRunResult.cs
+++ b/src/Tools/SharpDetect.Benchmarks/Models/BareRunResult.cs
@@ -1,0 +1,8 @@
+// Copyright 2026 Andrej Čižmárik and Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+namespace SharpDetect.Benchmarks.Models;
+
+internal sealed record BareRunResult(
+    double WallSeconds,
+    ProcessResourceSample Resources);

--- a/src/Tools/SharpDetect.Benchmarks/Models/BuildInfo.cs
+++ b/src/Tools/SharpDetect.Benchmarks/Models/BuildInfo.cs
@@ -1,0 +1,12 @@
+// Copyright 2026 Andrej Čižmárik and Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Reflection;
+
+namespace SharpDetect.Benchmarks.Models;
+
+internal static class BuildInfo
+{
+    public static string Configuration { get; } = typeof(BuildInfo).Assembly
+        .GetCustomAttribute<AssemblyConfigurationAttribute>()?.Configuration ?? "unknown";
+}

--- a/src/Tools/SharpDetect.Benchmarks/Models/GarbageCollectorInfo.cs
+++ b/src/Tools/SharpDetect.Benchmarks/Models/GarbageCollectorInfo.cs
@@ -1,0 +1,6 @@
+// Copyright 2026 Andrej Čižmárik and Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+namespace SharpDetect.Benchmarks.Models;
+
+internal sealed record GarbageCollectorInfo(long Gen0, long Gen1, long Gen2);

--- a/src/Tools/SharpDetect.Benchmarks/Models/GcSnapshot.cs
+++ b/src/Tools/SharpDetect.Benchmarks/Models/GcSnapshot.cs
@@ -1,0 +1,23 @@
+// Copyright 2026 Andrej Čižmárik and Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+namespace SharpDetect.Benchmarks.Models;
+
+internal readonly record struct GcSnapshot(long AllocatedBytes, int Gen0, int Gen1, int Gen2)
+{
+    public double AllocatedMegabytes => AllocatedBytes / (1024.0 * 1024.0);
+
+    public static GcSnapshot Capture()
+        => new(
+            GC.GetTotalAllocatedBytes(precise: true),
+            GC.CollectionCount(0),
+            GC.CollectionCount(1),
+            GC.CollectionCount(2));
+
+    public GcSnapshot Since(GcSnapshot before)
+        => new(
+            AllocatedBytes - before.AllocatedBytes,
+            Gen0 - before.Gen0,
+            Gen1 - before.Gen1,
+            Gen2 - before.Gen2);
+}

--- a/src/Tools/SharpDetect.Benchmarks/Models/GitInfo.cs
+++ b/src/Tools/SharpDetect.Benchmarks/Models/GitInfo.cs
@@ -1,0 +1,47 @@
+// Copyright 2026 Andrej Čižmárik and Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+using CliWrap;
+using CliWrap.Buffered;
+
+namespace SharpDetect.Benchmarks.Models;
+
+internal sealed record GitInfo(
+    string Commit,
+    string ShortCommit,
+    string CommitDate,
+    string Branch,
+    bool Dirty,
+    string? RepositoryRoot)
+{
+    public string Label => Dirty ? $"{ShortCommit}-dirty" : ShortCommit;
+
+    public static async Task<GitInfo> ResolveAsync()
+    {
+        try
+        {
+            var commit = await RunGitAsync("rev-parse HEAD") ?? "unknown";
+            var shortCommit = await RunGitAsync("rev-parse --short HEAD") ?? "unknown";
+            var commitDate = await RunGitAsync("log -1 --format=%cI") ?? "unknown";
+            var branch = await RunGitAsync("rev-parse --abbrev-ref HEAD") ?? "unknown";
+            var dirty = !string.IsNullOrWhiteSpace(await RunGitAsync("status --porcelain -uno"));
+            var repositoryRoot = await RunGitAsync("rev-parse --show-toplevel");
+            return new GitInfo(commit, shortCommit, commitDate, branch, dirty, repositoryRoot);
+        }
+        catch (Exception)
+        {
+            return new GitInfo("unknown", "unknown", "unknown", "unknown", Dirty: false, RepositoryRoot: null);
+        }
+    }
+
+    private static async Task<string?> RunGitAsync(string arguments)
+    {
+        var result = await Cli.Wrap("git")
+            .WithArguments(arguments)
+            .WithWorkingDirectory(AppContext.BaseDirectory)
+            .WithValidation(CommandResultValidation.None)
+            .ExecuteBufferedAsync();
+
+        return result.ExitCode == 0 ? result.StandardOutput.Trim() : null;
+    }
+}

--- a/src/Tools/SharpDetect.Benchmarks/Models/MachineInfo.cs
+++ b/src/Tools/SharpDetect.Benchmarks/Models/MachineInfo.cs
@@ -1,0 +1,6 @@
+// Copyright 2026 Andrej Čižmárik and Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+namespace SharpDetect.Benchmarks.Models;
+
+internal sealed record MachineInfo(string Os, int Cores, string Rid, string CpuAccounting);

--- a/src/Tools/SharpDetect.Benchmarks/Models/MetricsSnapshot.cs
+++ b/src/Tools/SharpDetect.Benchmarks/Models/MetricsSnapshot.cs
@@ -1,0 +1,41 @@
+// Copyright 2026 Andrej Čižmárik and Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+using SharpDetect.Worker.Services;
+
+namespace SharpDetect.Benchmarks.Models;
+
+internal sealed record MetricsSnapshot(
+    IReadOnlyDictionary<string, double> Counters,
+    IReadOnlyDictionary<string, double> Gauges)
+{
+    private const string ReceivedByTypePrefix = AnalysisWorkerMetrics.EventsReceivedByTypeInstrument + "/";
+    public long EventsReceived => (long)Counters.GetValueOrDefault(AnalysisWorkerMetrics.EventsReceivedInstrument);
+    public long EventsProcessed => (long)Counters.GetValueOrDefault(AnalysisWorkerMetrics.EventsProcessedInstrument);
+    public long DrainEvents => (long)Counters.GetValueOrDefault(AnalysisWorkerMetrics.DrainEventsInstrument);
+    public double DrainSeconds => Counters.GetValueOrDefault(AnalysisWorkerMetrics.DrainDurationInstrument);
+    public double ProcessTailSeconds => Counters.GetValueOrDefault(AnalysisWorkerMetrics.ProcessTailDurationInstrument);
+    public double TargetWallSeconds => Counters.GetValueOrDefault(AnalysisWorkerMetrics.TargetWallDurationInstrument);
+    public long TargetPid => (long)Gauges.GetValueOrDefault(AnalysisWorkerMetrics.TargetPidInstrument);
+
+    public IReadOnlyDictionary<string, long> ReceivedByType
+        => Counters
+            .Where(static pair => pair.Key.StartsWith(ReceivedByTypePrefix, StringComparison.Ordinal))
+            .ToDictionary(
+                static pair => pair.Key[ReceivedByTypePrefix.Length..],
+                static pair => (long)pair.Value,
+                StringComparer.Ordinal);
+
+    public static MetricsSnapshot Delta(MetricsSnapshot before, MetricsSnapshot after)
+    {
+        var counters = new Dictionary<string, double>(StringComparer.Ordinal);
+        foreach (var (key, value) in after.Counters)
+        {
+            var delta = value - before.Counters.GetValueOrDefault(key);
+            if (delta > 0)
+                counters[key] = delta;
+        }
+
+        return new MetricsSnapshot(counters, after.Gauges);
+    }
+}

--- a/src/Tools/SharpDetect.Benchmarks/Models/ProcessResourceSample.cs
+++ b/src/Tools/SharpDetect.Benchmarks/Models/ProcessResourceSample.cs
@@ -1,0 +1,6 @@
+// Copyright 2026 Andrej Čižmárik and Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+namespace SharpDetect.Benchmarks.Models;
+
+internal readonly record struct ProcessResourceSample(double CpuSeconds, double PeakRssMegabytes);

--- a/src/Tools/SharpDetect.Benchmarks/Models/RunResourceSamples.cs
+++ b/src/Tools/SharpDetect.Benchmarks/Models/RunResourceSamples.cs
@@ -1,0 +1,6 @@
+// Copyright 2026 Andrej Čižmárik and Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+namespace SharpDetect.Benchmarks.Models;
+
+internal readonly record struct RunResourceSamples(ProcessResourceSample Target, double HostPeakRssMegabytes);

--- a/src/Tools/SharpDetect.Benchmarks/Models/TargetMetrics.cs
+++ b/src/Tools/SharpDetect.Benchmarks/Models/TargetMetrics.cs
@@ -1,0 +1,13 @@
+// Copyright 2026 Andrej Čižmárik and Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+namespace SharpDetect.Benchmarks.Models;
+
+internal sealed record TargetMetrics(
+    ValueSpread AnalyzedTargetWallSeconds,
+    ValueSpread AnalyzedTargetCpuSeconds,
+    double AnalyzedTargetPeakRssMB,
+    ValueSpread BareTargetWallSeconds,
+    ValueSpread BareTargetCpuSeconds,
+    double? AnalyzedTargetOverheadFactor,
+    double? AnalyzedTargetCpuOverheadFactor);

--- a/src/Tools/SharpDetect.Benchmarks/Models/ValueSpread.cs
+++ b/src/Tools/SharpDetect.Benchmarks/Models/ValueSpread.cs
@@ -1,0 +1,39 @@
+// Copyright 2026 Andrej Čižmárik and Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+namespace SharpDetect.Benchmarks.Models;
+
+internal sealed record ValueSpread(double Median, double Min, double Max)
+{
+    public static ValueSpread From(IEnumerable<double> values)
+    {
+        var sorted = values.Order().ToArray();
+        if (sorted.Length == 0)
+            return new ValueSpread(0, 0, 0);
+
+        return new ValueSpread(
+            Round(MedianOfSorted(sorted)),
+            Round(sorted[0]),
+            Round(sorted[^1]));
+    }
+
+    public static double MedianOf(IEnumerable<double> values)
+    {
+        var sorted = values.Order().ToArray();
+        return sorted.Length == 0 ? 0 : MedianOfSorted(sorted);
+    }
+
+    public static long MedianOf(IEnumerable<long> values)
+        => (long)Math.Round(MedianOf(values.Select(static v => (double)v)));
+
+    private static double MedianOfSorted(IReadOnlyList<double> sorted)
+    {
+        var middle = sorted.Count / 2;
+        return sorted.Count % 2 == 1
+            ? sorted[middle]
+            : (sorted[middle - 1] + sorted[middle]) / 2.0;
+    }
+
+    private static double Round(double value)
+        => Math.Round(value, 4);
+}

--- a/src/Tools/SharpDetect.Benchmarks/Models/WorkloadInfo.cs
+++ b/src/Tools/SharpDetect.Benchmarks/Models/WorkloadInfo.cs
@@ -1,0 +1,6 @@
+// Copyright 2026 Andrej Čižmárik and Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+namespace SharpDetect.Benchmarks.Models;
+
+internal sealed record WorkloadInfo(string Sample, int Threads, int Iterations);

--- a/src/Tools/SharpDetect.Benchmarks/Program.cs
+++ b/src/Tools/SharpDetect.Benchmarks/Program.cs
@@ -1,0 +1,26 @@
+// Copyright 2026 Andrej Čižmárik and Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+using CliFx;
+using SharpDetect.Worker.Configuration;
+
+namespace SharpDetect.Benchmarks;
+
+public static class Program
+{
+    private const string ProgramTitle = "SharpDetect.Benchmarks";
+    private const string ProgramDescription = "Performance baseline establishing harness for SharpDetect";
+    private const string ExecutableName = "sharpdetect-benchmarks";
+
+    public static async Task<int> Main()
+    {
+        EnvironmentUtils.Initialize();
+        var builder = new CommandLineApplicationBuilder()
+            .AddCommandsFromThisAssembly()
+            .SetTitle(ProgramTitle)
+            .SetDescription(ProgramDescription)
+            .SetExecutableName(ExecutableName);
+
+        return await builder.Build().RunAsync();
+    }
+}

--- a/src/Tools/SharpDetect.Benchmarks/Reporting/BaselineMetrics.cs
+++ b/src/Tools/SharpDetect.Benchmarks/Reporting/BaselineMetrics.cs
@@ -1,0 +1,22 @@
+// Copyright 2026 Andrej Čižmárik and Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+using SharpDetect.Benchmarks.Models;
+
+namespace SharpDetect.Benchmarks.Reporting;
+
+internal sealed record BaselineMetrics(
+    ValueSpread WallSeconds,
+    ValueSpread ProcessingSeconds,
+    long EventsReceived,
+    long EventsProcessed,
+    long ReportedIssues,
+    ValueSpread ThroughputPerSec,
+    ValueSpread DrainTailSeconds,
+    long DrainTailEvents,
+    ValueSpread ProcessTailSeconds,
+    ValueSpread HostAllocatedMB,
+    ValueSpread HostPeakRssMB,
+    GarbageCollectorInfo HostGcInfo,
+    TargetMetrics Target,
+    IReadOnlyDictionary<string, long> EventsByType);

--- a/src/Tools/SharpDetect.Benchmarks/Reporting/BaselineReport.cs
+++ b/src/Tools/SharpDetect.Benchmarks/Reporting/BaselineReport.cs
@@ -1,0 +1,33 @@
+// Copyright 2026 Andrej Čižmárik and Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using SharpDetect.Benchmarks.Models;
+
+namespace SharpDetect.Benchmarks.Reporting;
+
+internal sealed record BaselineReport(
+    string Commit,
+    string CommitDate,
+    string Branch,
+    bool DirtyWorkingTree,
+    string CreatedAt,
+    MachineInfo Machine,
+    string Configuration,
+    WorkloadInfo Workload,
+    int Warmup,
+    int Runs,
+    IReadOnlyList<string> Warnings,
+    BaselineMetrics Metrics)
+{
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        WriteIndented = true
+    };
+
+    public string Serialize()
+        => JsonSerializer.Serialize(this, SerializerOptions);
+}

--- a/src/Tools/SharpDetect.Benchmarks/Reporting/BaselineReportBuilder.cs
+++ b/src/Tools/SharpDetect.Benchmarks/Reporting/BaselineReportBuilder.cs
@@ -1,0 +1,105 @@
+// Copyright 2026 Andrej Čižmárik and Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Collections.Immutable;
+using System.Runtime.InteropServices;
+using SharpDetect.Benchmarks.Configuration;
+using SharpDetect.Benchmarks.Measurements;
+using SharpDetect.Benchmarks.Models;
+
+namespace SharpDetect.Benchmarks.Reporting;
+
+internal static class BaselineReportBuilder
+{
+    private const double SpreadWarningThreshold = 1.2;
+
+    public static BaselineReport Build(
+        GitInfo git,
+        BenchmarkOptions options,
+        IReadOnlyList<BareRunResult> bareRuns,
+        IReadOnlyList<AnalyzedRunResult> instrumentedRuns)
+    {
+        var wallSeconds = ValueSpread.From(instrumentedRuns.Select(static r => r.WallSeconds));
+        var processingSeconds = ValueSpread.From(instrumentedRuns.Select(ProcessingSecondsOf));
+        var throughputPerSec = ValueSpread.From(instrumentedRuns.Select(static r => r.Metrics.EventsReceived / ProcessingSecondsOf(r)));
+        var bareWallSeconds = ValueSpread.From(bareRuns.Select(static r => r.WallSeconds));
+        var targetWallSeconds = ValueSpread.From(instrumentedRuns.Select(static r => r.Metrics.TargetWallSeconds));
+        var targetCpuSeconds = ValueSpread.From(instrumentedRuns.Select(static r => r.TargetResources.CpuSeconds));
+        var bareCpuSeconds = ValueSpread.From(bareRuns.Select(static r => r.Resources.CpuSeconds));
+
+        var warnings = new List<string>();
+        AddSpreadWarning(warnings, "throughputPerSec", throughputPerSec);
+        AddSpreadWarning(warnings, "targetWallSeconds", targetWallSeconds);
+        AddSpreadWarning(warnings, "bareTargetWallSeconds", bareWallSeconds);
+
+        return new BaselineReport(
+            Commit: git.Commit,
+            CommitDate: git.CommitDate,
+            Branch: git.Branch,
+            DirtyWorkingTree: git.Dirty,
+            CreatedAt: DateTime.UtcNow.ToString("o"),
+            Machine: new MachineInfo(
+                Os: RuntimeInformation.OSDescription,
+                Cores: Environment.ProcessorCount,
+                Rid: RuntimeInformation.RuntimeIdentifier,
+                CpuAccounting: ChildCpuAccounting.Mode),
+            Configuration: BuildInfo.Configuration,
+            Workload: new WorkloadInfo("PerfWorkload", options.Threads, options.Iterations),
+            Warmup: options.Warmup,
+            Runs: options.Runs,
+            Warnings: warnings,
+            Metrics: new BaselineMetrics(
+                WallSeconds: wallSeconds,
+                ProcessingSeconds: processingSeconds,
+                EventsReceived: ValueSpread.MedianOf(instrumentedRuns.Select(static r => r.Metrics.EventsReceived)),
+                EventsProcessed: ValueSpread.MedianOf(instrumentedRuns.Select(static r => r.Metrics.EventsProcessed)),
+                ReportedIssues: ValueSpread.MedianOf(instrumentedRuns.Select(static r => (long)r.ReportedIssues)),
+                ThroughputPerSec: throughputPerSec,
+                DrainTailSeconds: ValueSpread.From(instrumentedRuns.Select(static r => r.Metrics.DrainSeconds)),
+                DrainTailEvents: ValueSpread.MedianOf(instrumentedRuns.Select(static r => r.Metrics.DrainEvents)),
+                ProcessTailSeconds: ValueSpread.From(instrumentedRuns.Select(static r => r.Metrics.ProcessTailSeconds)),
+                HostAllocatedMB: ValueSpread.From(instrumentedRuns.Select(static r => r.AllocatedMB)),
+                HostPeakRssMB: ValueSpread.From(instrumentedRuns.Select(static r => r.HostPeakRssMB)),
+                HostGcInfo: new GarbageCollectorInfo(
+                    ValueSpread.MedianOf(instrumentedRuns.Select(static r => (long)r.Gen0)),
+                    ValueSpread.MedianOf(instrumentedRuns.Select(static r => (long)r.Gen1)),
+                    ValueSpread.MedianOf(instrumentedRuns.Select(static r => (long)r.Gen2))),
+                Target: new TargetMetrics(
+                    AnalyzedTargetWallSeconds: targetWallSeconds,
+                    AnalyzedTargetCpuSeconds: targetCpuSeconds,
+                    AnalyzedTargetPeakRssMB: Math.Round(ValueSpread.MedianOf(instrumentedRuns.Select(static r => r.TargetResources.PeakRssMegabytes)), 1),
+                    BareTargetWallSeconds: bareWallSeconds,
+                    BareTargetCpuSeconds: bareCpuSeconds,
+                    AnalyzedTargetOverheadFactor: Ratio(targetWallSeconds.Median, bareWallSeconds.Median),
+                    AnalyzedTargetCpuOverheadFactor: Ratio(targetCpuSeconds.Median, bareCpuSeconds.Median)),
+                EventsByType: BuildEventsByType(instrumentedRuns)));
+    }
+
+    private static double ProcessingSecondsOf(AnalyzedRunResult run)
+        => run.WallSeconds - run.Metrics.ProcessTailSeconds;
+
+    private static double? Ratio(double instrumented, double bare)
+        => bare > 0 ? Math.Round(instrumented / bare, 2) : null;
+
+    private static void AddSpreadWarning(List<string> warnings, string metricName, ValueSpread spread)
+    {
+        if (spread.Min <= 0 || spread.Max / spread.Min <= SpreadWarningThreshold)
+            return;
+
+        warnings.Add(
+            $"{metricName} is unstable across runs: max/min = {Math.Round(spread.Max / spread.Min, 2)} " +
+            $"(> {SpreadWarningThreshold}) — noisy machine or insufficient warmup");
+    }
+
+    private static ImmutableDictionary<string, long> BuildEventsByType(IReadOnlyList<AnalyzedRunResult> instrumentedRuns)
+    {
+        var receivedByTypePerRun = instrumentedRuns.Select(static r => r.Metrics.ReceivedByType).ToArray();
+        return receivedByTypePerRun
+            .SelectMany(static byType => byType.Keys)
+            .Distinct(StringComparer.Ordinal)
+            .Select(type => (Type: type, Count: ValueSpread.MedianOf(
+                receivedByTypePerRun.Select(byType => byType.GetValueOrDefault(type)))))
+            .OrderByDescending(static entry => entry.Count)
+            .ToImmutableDictionary(static entry => entry.Type, static entry => entry.Count);
+    }
+}

--- a/src/Tools/SharpDetect.Benchmarks/Reporting/BaselineSummaryRenderer.cs
+++ b/src/Tools/SharpDetect.Benchmarks/Reporting/BaselineSummaryRenderer.cs
@@ -1,0 +1,43 @@
+// Copyright 2026 Andrej Čižmárik and Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+using CliFx.Infrastructure;
+
+namespace SharpDetect.Benchmarks.Reporting;
+
+internal static class BaselineSummaryRenderer
+{
+    public static void Render(IConsole console, BaselineReport report)
+    {
+        var metrics = report.Metrics;
+        var output = console.Output;
+        output.WriteLine();
+        output.WriteLine("=== Baseline summary ===");
+        output.WriteLine($"{"wall (s, incl. shutdown)",-26} median={metrics.WallSeconds.Median} min={metrics.WallSeconds.Min} max={metrics.WallSeconds.Max}");
+        output.WriteLine($"{"processing (s)",-26} median={metrics.ProcessingSeconds.Median} min={metrics.ProcessingSeconds.Min} max={metrics.ProcessingSeconds.Max}");
+        output.WriteLine($"{"events received",-26} {metrics.EventsReceived}");
+        output.WriteLine($"{"events processed",-26} {metrics.EventsProcessed}");
+        output.WriteLine($"{"reported issues",-26} {metrics.ReportedIssues}");
+        output.WriteLine($"{"throughput (events/s)",-26} median={metrics.ThroughputPerSec.Median:F0}");
+        output.WriteLine($"{"drain tail (s)",-26} median={metrics.DrainTailSeconds.Median} max={metrics.DrainTailSeconds.Max}");
+        output.WriteLine($"{"drain tail (events)",-26} {metrics.DrainTailEvents}");
+        output.WriteLine($"{"process tail (s)",-26} median={metrics.ProcessTailSeconds.Median} max={metrics.ProcessTailSeconds.Max}");
+        output.WriteLine($"{"host alloc (MB)",-26} median={metrics.HostAllocatedMB.Median:F1} (worker + harness)");
+        output.WriteLine($"{"host peak RSS (MB)",-26} median={metrics.HostPeakRssMB.Median:F1} (worker + harness)");
+        output.WriteLine($"{"host GC gen0/1/2",-26} {metrics.HostGcInfo.Gen0}/{metrics.HostGcInfo.Gen1}/{metrics.HostGcInfo.Gen2}");
+        output.WriteLine($"{"target wall (s)",-26} median={metrics.Target.AnalyzedTargetWallSeconds.Median} (bare {metrics.Target.BareTargetWallSeconds.Median})");
+        output.WriteLine($"{"target cpu (s)",-26} median={metrics.Target.AnalyzedTargetCpuSeconds.Median} (bare {metrics.Target.BareTargetCpuSeconds.Median}, {report.Machine.CpuAccounting})");
+        output.WriteLine($"{"target peak RSS (MB)",-26} {metrics.Target.AnalyzedTargetPeakRssMB}");
+        output.WriteLine($"{"overhead factor (wall)",-26} {FormatFactor(metrics.Target.AnalyzedTargetOverheadFactor)}");
+        output.WriteLine($"{"overhead factor (cpu)",-26} {FormatFactor(metrics.Target.AnalyzedTargetCpuOverheadFactor)}");
+        output.WriteLine("top event types:");
+        foreach (var (type, count) in metrics.EventsByType.OrderByDescending(e => e.Value).Take(10))
+            output.WriteLine($"  {type,-48} {count}");
+
+        foreach (var warning in report.Warnings)
+            output.WriteLine($"WARNING: {warning}");
+    }
+
+    private static string FormatFactor(double? factor)
+        => factor is { } value ? $"{value}x" : "n/a";
+}

--- a/src/Tools/SharpDetect.Benchmarks/SharpDetect.Benchmarks.csproj
+++ b/src/Tools/SharpDetect.Benchmarks/SharpDetect.Benchmarks.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="CliFx" />
+    <PackageReference Include="CliWrap" />
+    <PackageReference Include="Microsoft.Extensions.Logging" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Extensibility\SharpDetect.Plugins\SharpDetect.Plugins.csproj" />
+    <ProjectReference Include="..\..\SharpDetect.Worker\SharpDetect.Worker.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/build.cake
+++ b/src/build.cake
@@ -169,6 +169,37 @@ Task("Tests")
     });
 });
 
+Task("Validate-Benchmark-Configuration")
+    .Does(() =>
+{
+    if (!configuration.Equals("Release", StringComparison.OrdinalIgnoreCase) && !HasArgument("allow-debug-benchmark"))
+        throw new Exception("Benchmark baselines must be measured with --configuration=Release (pass --allow-debug-benchmark to override).");
+});
+
+Task("Benchmark")
+    .IsDependentOn("Validate-Benchmark-Configuration")
+    .IsDependentOn("Build-Local-Environment")
+    .Does(() =>
+{
+    var benchmarkArguments = new ProcessArgumentBuilder()
+        .Append("--workload")
+        .AppendQuoted(MakeAbsolute(File($"./Samples/PerfWorkload/bin/{configuration}/{sdk}/PerfWorkload.dll")).FullPath);
+
+    foreach (var name in new[] { "iterations", "threads", "warmup", "runs", "output" })
+    {
+        if (HasArgument(name))
+            benchmarkArguments.Append($"--{name}").AppendQuoted(Argument<string>(name));
+    }
+
+    DotNetRun("./Tools/SharpDetect.Benchmarks/SharpDetect.Benchmarks.csproj",
+        benchmarkArguments,
+        new DotNetRunSettings
+        {
+            Configuration = configuration,
+            NoBuild = true
+        });
+});
+
 Task("Coverage-Report")
     .Does(() =>
 {


### PR DESCRIPTION
This PR adds infrastructure to measure and track SharpDetect's analysis performance across commits.

- New project `Samples/PerfWorkload`
    - Configurable workload - target for benchmark 
- New project `Tools/SharpDetect.Benchmarks`
    - Harness that runs target and measures resources spent
    - Harness generates JSON reports to compare state across different commits
- New cake target `Benchmark`
    - Runs built-in `PerfWorkload` using the harness
    - Requires `--configuration Release`