### PR TITLE
Performance: Batch event pipeline and encode hot events in a fixed layout

### DIFF
--- a/src/SharpDetect.Communication/Services/ProfilerEventReceiver.cs
+++ b/src/SharpDetect.Communication/Services/ProfilerEventReceiver.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Buffers;
-using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.Logging;
 using SharpDetect.Core.Communication;
 using SharpDetect.Core.Events;
@@ -16,10 +15,12 @@ namespace SharpDetect.Communication.Services;
 
 internal sealed class ProfilerEventReceiver : IProfilerEventReceiver, IDisposable
 {
-    private readonly IRecordedEventParser _recordedEventParser;
+    private readonly EventBatchReader _reader;
     private readonly ILogger<IProfilerEventReceiver> _logger;
     private readonly Consumer _consumer;
     private readonly string? _queueFilePath;
+    private QueueMessage _pendingMessage;
+    private bool _hasPendingMessage;
     private bool _disposed;
 
     public ProfilerEventReceiver(
@@ -29,84 +30,77 @@ internal sealed class ProfilerEventReceiver : IProfilerEventReceiver, IDisposabl
     {
         var semaphore = InterProcessSemaphore.CreateOrOpen(options.SemaphoreName, isOwner: true);
         _consumer = new Consumer(options, semaphore, ArrayPool<byte>.Shared);
-        _recordedEventParser = recordedEventParser;
+        _reader = new EventBatchReader(recordedEventParser);
         _logger = logger;
         _queueFilePath = options.File;
-        
+
         _logger.LogInformation("Started event receiver of IPC queue with name: \"{Name}\", file: \"{File}\", capacity: {Capacity} bytes.",
             options.Name,
             options.File,
             options.Capacity);
     }
-    
-    public bool TryReceiveNotification([NotNullWhen(true)] out RecordedEvent? recordedEvent)
+
+    public int TryReceiveNotifications(Span<RecordedEvent> destination, out int failedRecordsCount)
+    {
+        ArgumentOutOfRangeException.ThrowIfZero(destination.Length);
+        failedRecordsCount = 0;
+
+        if (!_hasPendingMessage && !TryDequeueMessage())
+            return 0;
+
+        var result = _reader.ReadInto(destination);
+        if (!_reader.HasPendingRecords)
+            ReleasePendingMessage();
+
+        if (result.Corrupted)
+            _logger.LogError("Discarding the remainder of a malformed profiler event batch.");
+
+        if (result.FailedRecords > 0)
+        {
+            failedRecordsCount = result.FailedRecords;
+            _logger.LogError(
+                result.LastFailure,
+                "Discarded {FailedRecords} unparsable profiler event(s); the most recent failure is attached.",
+                result.FailedRecords);
+        }
+
+        return result.Count;
+    }
+
+    private bool TryDequeueMessage()
     {
         var result = _consumer.TryDequeue();
         if (result.IsError)
-        {
-            recordedEvent = null;
             return false;
-        }
 
-        if (!TryParseEvent(result.Value, _recordedEventParser, out var parsedEvent))
-        {
-            recordedEvent = null;
-            return false;
-        }
-
-        recordedEvent = parsedEvent;
+        _pendingMessage = result.Value;
+        _hasPendingMessage = true;
+        _reader.SetBatch(_pendingMessage.Memory);
         return true;
     }
 
-    public bool TryReceiveNotification(TimeSpan timeout, [NotNullWhen(true)] out RecordedEvent? recordedEvent)
+    private void ReleasePendingMessage()
     {
-        var result = _consumer.TryDequeue(timeout);
-        if (result.IsError)
-        {
-            recordedEvent = null;
-            return false;
-        }
+        if (!_hasPendingMessage)
+            return;
 
-        if (!TryParseEvent(result.Value, _recordedEventParser, out var parsedEvent))
-        {
-            recordedEvent = null;
-            return false;
-        }
+        var message = _pendingMessage;
+        _pendingMessage = default;
+        _hasPendingMessage = false;
 
-        recordedEvent = parsedEvent;
-        return true;
-    }
-    
-    private bool TryParseEvent(
-        QueueMessage message,
-        IRecordedEventParser parser,
-        [NotNullWhen(true)] out RecordedEvent? recordedEvent)
-    {
-        try
-        {
-            recordedEvent = parser.Parse(message.Memory);
-            return true;
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Unhandled exception while parsing recorded event.");
-            recordedEvent = null;
-            return false;
-        }
-        finally
-        {
-            message.Dispose();
-        }
+        _reader.Reset();
+        message.Dispose();
     }
 
     public void Dispose()
     {
         if (_disposed)
             return;
-        
+
         _disposed = true;
+        ReleasePendingMessage();
         _consumer.Dispose();
-        
+
         if (_queueFilePath is not null && File.Exists(_queueFilePath))
         {
             try

--- a/src/SharpDetect.Communication/Services/ProfilerEventReceiver.cs
+++ b/src/SharpDetect.Communication/Services/ProfilerEventReceiver.cs
@@ -25,12 +25,13 @@ internal sealed class ProfilerEventReceiver : IProfilerEventReceiver, IDisposabl
 
     public ProfilerEventReceiver(
         ConsumerMemoryMappedQueueOptions options,
+        uint pid,
         IRecordedEventParser recordedEventParser,
         ILogger<IProfilerEventReceiver> logger)
     {
         var semaphore = InterProcessSemaphore.CreateOrOpen(options.SemaphoreName, isOwner: true);
         _consumer = new Consumer(options, semaphore, ArrayPool<byte>.Shared);
-        _reader = new EventBatchReader(recordedEventParser);
+        _reader = new EventBatchReader(recordedEventParser, pid);
         _logger = logger;
         _queueFilePath = options.File;
 

--- a/src/SharpDetect.Communication/Services/ProfilerEventReceiverProvider.cs
+++ b/src/SharpDetect.Communication/Services/ProfilerEventReceiverProvider.cs
@@ -26,6 +26,6 @@ internal sealed class ProfilerEventReceiverProvider : IProfilerEventReceiverProv
             _baseOptions.Capacity,
             $"{_baseOptions.SemaphoreName}.{pid}");
 
-        return ActivatorUtilities.CreateInstance<ProfilerEventReceiver>(_serviceProvider, perPidOptions);
+        return ActivatorUtilities.CreateInstance<ProfilerEventReceiver>(_serviceProvider, perPidOptions, pid);
     }
 }

--- a/src/SharpDetect.Core/Communication/EventBatchProtocol.cs
+++ b/src/SharpDetect.Core/Communication/EventBatchProtocol.cs
@@ -1,0 +1,37 @@
+// Copyright 2026 Andrej Čižmárik and Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Buffers.Binary;
+
+namespace SharpDetect.Core.Communication;
+
+public static class EventBatchProtocol
+{
+    public const int RecordHeaderSize = sizeof(int);
+    
+    public static EventBatchRecordStatus TryReadRecord(
+        ReadOnlyMemory<byte> batch,
+        ref int offset,
+        out ReadOnlyMemory<byte> record)
+    {
+        record = default;
+
+        if (offset < 0 || offset > batch.Length)
+            return EventBatchRecordStatus.Corrupted;
+
+        if (offset == batch.Length)
+            return EventBatchRecordStatus.EndOfBatch;
+
+        var remaining = batch.Length - offset;
+        if (remaining < RecordHeaderSize)
+            return EventBatchRecordStatus.Corrupted;
+
+        var size = BinaryPrimitives.ReadInt32LittleEndian(batch.Span.Slice(offset, RecordHeaderSize));
+        if (size < 0 || size > remaining - RecordHeaderSize)
+            return EventBatchRecordStatus.Corrupted;
+
+        record = batch.Slice(offset + RecordHeaderSize, size);
+        offset += RecordHeaderSize + size;
+        return EventBatchRecordStatus.Record;
+    }
+}

--- a/src/SharpDetect.Core/Communication/EventBatchProtocol.cs
+++ b/src/SharpDetect.Core/Communication/EventBatchProtocol.cs
@@ -12,6 +12,27 @@ public static class EventBatchProtocol
     public static EventBatchRecordStatus TryReadRecord(
         ReadOnlyMemory<byte> batch,
         ref int offset,
+        out byte format,
+        out ReadOnlyMemory<byte> payload)
+    {
+        format = default;
+        payload = default;
+
+        var status = TryReadRecord(batch, ref offset, out var record);
+        if (status != EventBatchRecordStatus.Record)
+            return status;
+
+        if (record.IsEmpty)
+            return EventBatchRecordStatus.Corrupted;
+
+        format = record.Span[0];
+        payload = record[1..];
+        return EventBatchRecordStatus.Record;
+    }
+
+    public static EventBatchRecordStatus TryReadRecord(
+        ReadOnlyMemory<byte> batch,
+        ref int offset,
         out ReadOnlyMemory<byte> record)
     {
         record = default;

--- a/src/SharpDetect.Core/Communication/EventBatchReadResult.cs
+++ b/src/SharpDetect.Core/Communication/EventBatchReadResult.cs
@@ -1,0 +1,10 @@
+// Copyright 2026 Andrej Čižmárik and Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+namespace SharpDetect.Core.Communication;
+
+public readonly record struct EventBatchReadResult(
+    int Count,
+    int FailedRecords,
+    bool Corrupted,
+    Exception? LastFailure);

--- a/src/SharpDetect.Core/Communication/EventBatchReader.cs
+++ b/src/SharpDetect.Core/Communication/EventBatchReader.cs
@@ -6,12 +6,20 @@ using SharpDetect.Core.Serialization;
 
 namespace SharpDetect.Core.Communication;
 
-public sealed class EventBatchReader(IRecordedEventParser parser)
+public sealed class EventBatchReader
 {
+    private readonly IRecordedEventParser _parser;
+    private readonly uint _pid;
     private ReadOnlyMemory<byte> _batch;
     private int _offset;
     private bool _exhausted = true;
     public bool HasPendingRecords => !_exhausted;
+
+    public EventBatchReader(IRecordedEventParser parser, uint pid)
+    {
+        _parser = parser;
+        _pid = pid;
+    }
     
     public void SetBatch(ReadOnlyMemory<byte> batch)
     {
@@ -35,7 +43,7 @@ public sealed class EventBatchReader(IRecordedEventParser parser)
 
         while (count < destination.Length && !_exhausted)
         {
-            var status = EventBatchProtocol.TryReadRecord(_batch, ref _offset, out var record);
+            var status = EventBatchProtocol.TryReadRecord(_batch, ref _offset, out var format, out var record);
             if (status != EventBatchRecordStatus.Record)
             {
                 _exhausted = true;
@@ -46,9 +54,26 @@ public sealed class EventBatchReader(IRecordedEventParser parser)
                     lastFailure);
             }
 
+            if (format != FixedEventFormat.MsgPackFormat)
+            {
+                if (FixedEventFormat.TryRead(format, record.Span, out var threadId, out var eventArgs))
+                {
+                    destination[count] = new RecordedEvent(new RecordedEventMetadata(_pid, threadId), eventArgs);
+                    count++;
+                }
+                else
+                {
+                    failedRecords++;
+                    lastFailure = new InvalidDataException(
+                        $"Malformed fixed-layout event record (format {format}, {record.Length} bytes).");
+                }
+
+                continue;
+            }
+
             try
             {
-                destination[count] = parser.Parse(record);
+                destination[count] = _parser.Parse(record);
                 count++;
             }
             catch (Exception ex)

--- a/src/SharpDetect.Core/Communication/EventBatchReader.cs
+++ b/src/SharpDetect.Core/Communication/EventBatchReader.cs
@@ -1,0 +1,63 @@
+// Copyright 2026 Andrej Čižmárik and Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+using SharpDetect.Core.Events;
+using SharpDetect.Core.Serialization;
+
+namespace SharpDetect.Core.Communication;
+
+public sealed class EventBatchReader(IRecordedEventParser parser)
+{
+    private ReadOnlyMemory<byte> _batch;
+    private int _offset;
+    private bool _exhausted = true;
+    public bool HasPendingRecords => !_exhausted;
+    
+    public void SetBatch(ReadOnlyMemory<byte> batch)
+    {
+        _batch = batch;
+        _offset = 0;
+        _exhausted = false;
+    }
+    
+    public void Reset()
+    {
+        _batch = default;
+        _offset = 0;
+        _exhausted = true;
+    }
+    
+    public EventBatchReadResult ReadInto(Span<RecordedEvent> destination)
+    {
+        var count = 0;
+        var failedRecords = 0;
+        Exception? lastFailure = null;
+
+        while (count < destination.Length && !_exhausted)
+        {
+            var status = EventBatchProtocol.TryReadRecord(_batch, ref _offset, out var record);
+            if (status != EventBatchRecordStatus.Record)
+            {
+                _exhausted = true;
+                return new EventBatchReadResult(
+                    count,
+                    failedRecords,
+                    Corrupted: status == EventBatchRecordStatus.Corrupted,
+                    lastFailure);
+            }
+
+            try
+            {
+                destination[count] = parser.Parse(record);
+                count++;
+            }
+            catch (Exception ex)
+            {
+                failedRecords++;
+                lastFailure = ex;
+            }
+        }
+
+        return new EventBatchReadResult(count, failedRecords, Corrupted: false, lastFailure);
+    }
+}

--- a/src/SharpDetect.Core/Communication/EventBatchRecordStatus.cs
+++ b/src/SharpDetect.Core/Communication/EventBatchRecordStatus.cs
@@ -1,0 +1,11 @@
+// Copyright 2026 Andrej Čižmárik and Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+namespace SharpDetect.Core.Communication;
+
+public enum EventBatchRecordStatus
+{
+    Record,
+    EndOfBatch,
+    Corrupted
+}

--- a/src/SharpDetect.Core/Communication/FixedEventFormat.cs
+++ b/src/SharpDetect.Core/Communication/FixedEventFormat.cs
@@ -1,0 +1,124 @@
+// Copyright 2026 Andrej Čižmárik and Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Buffers.Binary;
+using System.Diagnostics.CodeAnalysis;
+using SharpDetect.Core.Events;
+using SharpDetect.Core.Events.Profiler;
+
+namespace SharpDetect.Core.Communication;
+
+public static class FixedEventFormat
+{
+    public const byte MsgPackFormat = 0;
+
+    /// <summary>
+    /// [u64 threadId][u64 moduleId][u32 methodToken][u16 interpretation]
+    /// The process id and command id are not on the wire
+    /// </summary>
+    public const int HeaderSize = 22;
+
+    private const int BlobLengthSize = sizeof(uint);
+    private const uint AbsentBlob = 0xFFFFFFFFu;
+
+    public static bool TryRead(
+        byte format,
+        ReadOnlySpan<byte> payload,
+        out ThreadId threadId,
+        [NotNullWhen(true)] out IRecordedEventArgs? eventArgs)
+    {
+        threadId = default;
+        eventArgs = null;
+
+        if (payload.Length < HeaderSize)
+            return false;
+
+        var rawThreadId = BinaryPrimitives.ReadUInt64LittleEndian(payload);
+        var moduleId = new ModuleId((nuint)BinaryPrimitives.ReadUInt64LittleEndian(payload[8..]));
+        var methodToken = new MdMethodDef(BinaryPrimitives.ReadInt32LittleEndian(payload[16..]));
+        var interpretation = BinaryPrimitives.ReadUInt16LittleEndian(payload[20..]);
+        var body = payload[HeaderSize..];
+
+        switch ((RecordedEventType)format)
+        {
+            case RecordedEventType.MethodEnter:
+            {
+                if (body.Length != 0)
+                    return false;
+                
+                eventArgs = new MethodEnterRecordedEvent(moduleId, methodToken, interpretation);
+                break;
+            }
+
+            case RecordedEventType.MethodExit:
+            {
+                if (body.Length != 0)
+                    return false;
+                
+                eventArgs = new MethodExitRecordedEvent(moduleId, methodToken, interpretation);
+                break;
+            }
+            
+            case RecordedEventType.MethodEnterWithArguments:
+            {
+                if (!TryReadBlobs(body, out var argumentValues, out var argumentInfos, out var stackFrames))
+                    return false;
+
+                eventArgs = new MethodEnterWithArgumentsRecordedEvent(
+                    moduleId, methodToken, interpretation, argumentValues, argumentInfos, stackFrames);
+                break;
+            }
+
+            case RecordedEventType.MethodExitWithArguments:
+            {
+                if (!TryReadBlobs(body, out var returnValue, out var byRefValues, out var byRefInfos)
+                    || byRefInfos is null)
+                {
+                    return false;
+                }
+
+                eventArgs = new MethodExitWithArgumentsRecordedEvent(
+                    moduleId, methodToken, interpretation, returnValue, byRefValues, byRefInfos);
+                break;
+            }
+
+            default:
+                return false;
+        }
+
+        threadId = new ThreadId((nuint)rawThreadId);
+        return true;
+    }
+    
+    private static bool TryReadBlobs(
+        ReadOnlySpan<byte> body,
+        [NotNullWhen(true)] out byte[]? first,
+        [NotNullWhen(true)] out byte[]? second,
+        out byte[]? third)
+    {
+        first = null;
+        second = null;
+        third = null;
+
+        const int lengthsSize = 3 * BlobLengthSize;
+        if (body.Length < lengthsSize)
+            return false;
+
+        var firstLength = BinaryPrimitives.ReadUInt32LittleEndian(body);
+        var secondLength = BinaryPrimitives.ReadUInt32LittleEndian(body[BlobLengthSize..]);
+        var thirdLength = BinaryPrimitives.ReadUInt32LittleEndian(body[(2 * BlobLengthSize)..]);
+        var thirdIsAbsent = thirdLength == AbsentBlob;
+        if (thirdIsAbsent)
+            thirdLength = 0;
+
+        var blobs = body[lengthsSize..];
+        var declared = (long)firstLength + secondLength + thirdLength;
+        if (declared != blobs.Length)
+            return false;
+
+        first = [.. blobs[..(int)firstLength]];
+        second = [.. blobs.Slice((int)firstLength, (int)secondLength)];
+        third = thirdIsAbsent ? null : [.. blobs.Slice((int)(firstLength + secondLength), (int)thirdLength)];
+        return true;
+    }
+}

--- a/src/SharpDetect.Core/Communication/IProfilerEventReceiver.cs
+++ b/src/SharpDetect.Core/Communication/IProfilerEventReceiver.cs
@@ -1,13 +1,11 @@
 // Copyright 2026 Andrej Čižmárik and Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-using System.Diagnostics.CodeAnalysis;
 using SharpDetect.Core.Events;
 
 namespace SharpDetect.Core.Communication;
 
 public interface IProfilerEventReceiver
 {
-    bool TryReceiveNotification([NotNullWhen(true)] out RecordedEvent? recordedEvent);
-    bool TryReceiveNotification(TimeSpan timeout, [NotNullWhen(true)] out RecordedEvent? recordedEvent);
+    int TryReceiveNotifications(Span<RecordedEvent> destination, out int failedRecordsCount);
 }

--- a/src/SharpDetect.Profiler/LibIPC.Tests/EventDispatcherTests.cpp
+++ b/src/SharpDetect.Profiler/LibIPC.Tests/EventDispatcherTests.cpp
@@ -22,6 +22,13 @@ namespace
 		{
 			std::lock_guard guard(_mutex);
 			_records.emplace_back(buffer.begin(), buffer.end());
+			++_unflushedRecords;
+		}
+
+		void Flush() override
+		{
+			std::lock_guard guard(_mutex);
+			_unflushedRecords = 0;
 		}
 
 		std::vector<std::vector<char>> Records()
@@ -30,9 +37,16 @@ namespace
 			return _records;
 		}
 
+		std::size_t UnflushedRecords()
+		{
+			std::lock_guard guard(_mutex);
+			return _unflushedRecords;
+		}
+
 	private:
 		std::mutex _mutex;
 		std::vector<std::vector<char>> _records;
+		std::size_t _unflushedRecords = 0;
 	};
 
 	std::vector<char> MakePayload(const std::int32_t a, const std::int32_t b, const std::size_t totalSize = 8)
@@ -117,6 +131,23 @@ TEST_CASE("EventDispatcher routes oversized records through overflow in sequence
 	CHECK(FieldA(records[1]) == 1);
 	CHECK(FieldA(records[2]) == 2);
 	CHECK(records[1].size() == 300 * 1024);
+}
+
+TEST_CASE("EventDispatcher leaves no record unflushed in the sink")
+{
+	RecordingSink sink;
+	EventDispatcher dispatcher(sink, 8 * 1024 * 1024);
+	dispatcher.Start();
+
+	for (std::int32_t i = 0; i < 100; ++i)
+	{
+		const auto payload = MakePayload(i, 0);
+		dispatcher.Enqueue(payload.data(), payload.size());
+	}
+	dispatcher.Stop();
+
+	CHECK(sink.Records().size() == 100);
+	CHECK(sink.UnflushedRecords() == 0);
 }
 
 TEST_CASE("EventDispatcher loses nothing and preserves per-thread order under contention")

--- a/src/SharpDetect.Profiler/LibIPC/CMakeLists.txt
+++ b/src/SharpDetect.Profiler/LibIPC/CMakeLists.txt
@@ -2,6 +2,7 @@ set(SOURCES
 	"Client.cpp"
 	"CommandDispatcher.cpp"
 	"EventDispatcher.cpp"
+	"FixedEvents.cpp"
 	"IpqConsumer.cpp"
 	"IpqLibrary.cpp"
 	"IpqProducer.cpp"

--- a/src/SharpDetect.Profiler/LibIPC/Client.cpp
+++ b/src/SharpDetect.Profiler/LibIPC/Client.cpp
@@ -91,7 +91,10 @@ void LibIPC::Client::Shutdown()
 		Helpers::CreateMetadataMsg(LibProfiler::PAL_GetCurrentPid(), 0));
 	msgpack::sbuffer sbuf;
 	msgpack::pack(sbuf, destroyMsg);
-	std::vector<char> buffer(sbuf.data(), sbuf.data() + sbuf.size());
+	std::vector<char> buffer;
+	buffer.reserve(sizeof(BYTE) + sbuf.size());
+	buffer.push_back(static_cast<char>(FixedEvents::MsgPackFormat));
+	buffer.insert(buffer.end(), sbuf.data(), sbuf.data() + sbuf.size());
 	_producer->Send(buffer);
 	_producer->Flush();
 }

--- a/src/SharpDetect.Profiler/LibIPC/Client.cpp
+++ b/src/SharpDetect.Profiler/LibIPC/Client.cpp
@@ -93,4 +93,5 @@ void LibIPC::Client::Shutdown()
 	msgpack::pack(sbuf, destroyMsg);
 	std::vector<char> buffer(sbuf.data(), sbuf.data() + sbuf.size());
 	_producer->Send(buffer);
+	_producer->Flush();
 }

--- a/src/SharpDetect.Profiler/LibIPC/Client.h
+++ b/src/SharpDetect.Profiler/LibIPC/Client.h
@@ -11,6 +11,7 @@
 #include "cor.h"
 #include "CommandDispatcher.h"
 #include "EventDispatcher.h"
+#include "FixedEvents.h"
 #include "IpqConsumer.h"
 #include "IpqLibrary.h"
 #include "IpqProducer.h"
@@ -37,7 +38,7 @@ namespace LibIPC
 		void Send(msgpack::type::tuple<Types...>&& data)
 		{
 			thread_local msgpack::sbuffer buffer;
-			buffer.clear();
+			PrepareMsgPackBuffer(buffer);
 			msgpack::pack(buffer, data);
 			_events->Enqueue(buffer.data(), buffer.size());
 		}
@@ -46,9 +47,14 @@ namespace LibIPC
 		void SendPriority(msgpack::type::tuple<Types...>&& data)
 		{
 			thread_local msgpack::sbuffer buffer;
-			buffer.clear();
+			PrepareMsgPackBuffer(buffer);
 			msgpack::pack(buffer, data);
 			_events->EnqueuePriority(buffer.data(), buffer.size());
+		}
+
+		void SendRaw(const char* data, const std::size_t size)
+		{
+			_events->Enqueue(data, size);
 		}
 
 		void SetCommandHandler(ICommandHandler* handler)
@@ -58,6 +64,13 @@ namespace LibIPC
 		[[nodiscard]] bool IsCommandReceivingEnabled() const { return _commandReceivingEnabled; }
 
 	private:
+		static void PrepareMsgPackBuffer(msgpack::sbuffer& buffer)
+		{
+			constexpr auto format = static_cast<char>(FixedEvents::MsgPackFormat);
+			buffer.clear();
+			buffer.write(&format, sizeof(format));
+		}
+
 		bool _commandReceivingEnabled;
 		std::atomic_bool _shutdownCompleted;
 		std::unique_ptr<IpqLibrary> _library;

--- a/src/SharpDetect.Profiler/LibIPC/EventDispatcher.cpp
+++ b/src/SharpDetect.Profiler/LibIPC/EventDispatcher.cpp
@@ -125,6 +125,7 @@ bool LibIPC::EventDispatcher::DrainAvailableEvents()
 
 		if (minSequence == std::numeric_limits<UINT64>::max())
 		{
+			_sink.Flush();
 			_lanes.PruneClosed();
 			return progress;
 		}
@@ -132,6 +133,7 @@ bool LibIPC::EventDispatcher::DrainAvailableEvents()
 		if (minSequence > _nextSequenceToEmit)
 		{
 			// A producer claimed the next sequence but has not published it yet
+			_sink.Flush();
 			if (gapStart == std::chrono::steady_clock::time_point { })
 				gapStart = std::chrono::steady_clock::now();
 

--- a/src/SharpDetect.Profiler/LibIPC/EventSink.h
+++ b/src/SharpDetect.Profiler/LibIPC/EventSink.h
@@ -12,5 +12,6 @@ namespace LibIPC
 	public:
 		virtual ~IEventSink() = default;
 		virtual void Send(std::vector<char>& buffer) = 0;
+		virtual void Flush() = 0;
 	};
 }

--- a/src/SharpDetect.Profiler/LibIPC/FixedEvents.cpp
+++ b/src/SharpDetect.Profiler/LibIPC/FixedEvents.cpp
@@ -1,0 +1,110 @@
+// Copyright 2026 Andrej Čižmárik and Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstring>
+
+#include "FixedEvents.h"
+
+namespace
+{
+	void AppendBytes(std::vector<char>& buffer, const void* data, const std::size_t size)
+	{
+		if (size == 0)
+			return;
+
+		const auto offset = buffer.size();
+		buffer.resize(offset + size);
+		std::memcpy(buffer.data() + offset, data, size);
+	}
+
+	template<typename T>
+	void Append(std::vector<char>& buffer, const T value)
+	{
+		AppendBytes(buffer, &value, sizeof(T));
+	}
+
+	void AppendBlob(std::vector<char>& buffer, const LibIPC::ByteSpanView blob)
+	{
+		AppendBytes(buffer, blob.data, blob.size);
+	}
+
+	UINT32 BlobLength(const LibIPC::ByteSpanView blob)
+	{
+		return static_cast<UINT32>(blob.size);
+	}
+
+	void WriteHeader(
+		std::vector<char>& buffer,
+		const LibIPC::RecordedEventType type,
+		const UINT64 threadId,
+		const UINT64 moduleId,
+		const UINT32 methodToken,
+		const USHORT interpretation)
+	{
+		buffer.clear();
+		Append(buffer, static_cast<BYTE>(type));
+		Append(buffer, threadId);
+		Append(buffer, moduleId);
+		Append(buffer, methodToken);
+		Append(buffer, interpretation);
+	}
+}
+
+void LibIPC::FixedEvents::WriteMethodEnter(
+	std::vector<char>& buffer,
+	const UINT64 threadId,
+	const UINT64 moduleId,
+	const UINT32 methodToken,
+	const USHORT interpretation)
+{
+	WriteHeader(buffer, RecordedEventType::MethodEnter, threadId, moduleId, methodToken, interpretation);
+}
+
+void LibIPC::FixedEvents::WriteMethodExit(
+	std::vector<char>& buffer,
+	const UINT64 threadId,
+	const UINT64 moduleId,
+	const UINT32 methodToken,
+	const USHORT interpretation)
+{
+	WriteHeader(buffer, RecordedEventType::MethodExit, threadId, moduleId, methodToken, interpretation);
+}
+
+void LibIPC::FixedEvents::WriteMethodEnterWithArguments(
+	std::vector<char>& buffer,
+	const UINT64 threadId,
+	const UINT64 moduleId,
+	const UINT32 methodToken,
+	const USHORT interpretation,
+	const ByteSpanView argumentValues,
+	const ByteSpanView argumentInfos,
+	const std::optional<ByteSpanView> stackFrames)
+{
+	WriteHeader(buffer, RecordedEventType::MethodEnterWithArguments, threadId, moduleId, methodToken, interpretation);
+	Append(buffer, BlobLength(argumentValues));
+	Append(buffer, BlobLength(argumentInfos));
+	Append(buffer, stackFrames.has_value() ? BlobLength(*stackFrames) : AbsentBlob);
+	AppendBlob(buffer, argumentValues);
+	AppendBlob(buffer, argumentInfos);
+	if (stackFrames.has_value())
+		AppendBlob(buffer, *stackFrames);
+}
+
+void LibIPC::FixedEvents::WriteMethodExitWithArguments(
+	std::vector<char>& buffer,
+	const UINT64 threadId,
+	const UINT64 moduleId,
+	const UINT32 methodToken,
+	const USHORT interpretation,
+	const ByteSpanView returnValue,
+	const ByteSpanView byRefArgumentValues,
+	const ByteSpanView byRefArgumentInfos)
+{
+	WriteHeader(buffer, RecordedEventType::MethodExitWithArguments, threadId, moduleId, methodToken, interpretation);
+	Append(buffer, BlobLength(returnValue));
+	Append(buffer, BlobLength(byRefArgumentValues));
+	Append(buffer, BlobLength(byRefArgumentInfos));
+	AppendBlob(buffer, returnValue);
+	AppendBlob(buffer, byRefArgumentValues);
+	AppendBlob(buffer, byRefArgumentInfos);
+}

--- a/src/SharpDetect.Profiler/LibIPC/FixedEvents.h
+++ b/src/SharpDetect.Profiler/LibIPC/FixedEvents.h
@@ -1,0 +1,57 @@
+// Copyright 2026 Andrej Čižmárik and Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstddef>
+#include <optional>
+#include <vector>
+
+#include "cor.h"
+#include "Messages.h"
+
+namespace LibIPC
+{
+	namespace FixedEvents
+	{
+		// [u64 threadId][u64 moduleId][u32 methodToken][u16 interpretation]
+		// The process id and command id are not on wire
+		constexpr std::size_t HeaderSize = 22;
+		constexpr BYTE MsgPackFormat = 0;
+		constexpr UINT32 AbsentBlob = 0xFFFFFFFFu;
+
+		void WriteMethodEnter(
+			std::vector<char>& buffer,
+			UINT64 threadId,
+			UINT64 moduleId,
+			UINT32 methodToken,
+			USHORT interpretation);
+
+		void WriteMethodExit(
+			std::vector<char>& buffer,
+			UINT64 threadId,
+			UINT64 moduleId,
+			UINT32 methodToken,
+			USHORT interpretation);
+
+		void WriteMethodEnterWithArguments(
+			std::vector<char>& buffer,
+			UINT64 threadId,
+			UINT64 moduleId,
+			UINT32 methodToken,
+			USHORT interpretation,
+			ByteSpanView argumentValues,
+			ByteSpanView argumentInfos,
+			std::optional<ByteSpanView> stackFrames);
+
+		void WriteMethodExitWithArguments(
+			std::vector<char>& buffer,
+			UINT64 threadId,
+			UINT64 moduleId,
+			UINT32 methodToken,
+			USHORT interpretation,
+			ByteSpanView returnValue,
+			ByteSpanView byRefArgumentValues,
+			ByteSpanView byRefArgumentInfos);
+	}
+}

--- a/src/SharpDetect.Profiler/LibIPC/IpqProducer.cpp
+++ b/src/SharpDetect.Profiler/LibIPC/IpqProducer.cpp
@@ -81,7 +81,7 @@ void LibIPC::IpqProducer::SendMessage(char* data, const std::size_t size)
 	constexpr auto maxRetryDuration = std::chrono::seconds(5);
 
 	const auto byteStream = reinterpret_cast<BYTE*>(data);
-	const auto deadline = std::chrono::steady_clock::now() + maxRetryDuration;
+	auto deadline = std::chrono::steady_clock::time_point { };
 	for (auto spinCount = 0; ; ++spinCount)
 	{
 		const INT result = _library.Enqueue(_handle, byteStream, static_cast<INT>(size));
@@ -98,8 +98,14 @@ void LibIPC::IpqProducer::SendMessage(char* data, const std::size_t size)
 			return;
 		}
 
+		// The retry budget only starts once the ring is actually full, so the common path never reads the clock
+		const auto now = std::chrono::steady_clock::now();
+		if (deadline == std::chrono::steady_clock::time_point { })
+		{
+			deadline = now + maxRetryDuration;
+		}
 		// A full ring past deadline means we assume the consumer is gone/detached and will never drain it
-		if (std::chrono::steady_clock::now() >= deadline)
+		else if (now >= deadline)
 		{
 			LOG_F(
 				ERROR,

--- a/src/SharpDetect.Profiler/LibIPC/IpqProducer.cpp
+++ b/src/SharpDetect.Profiler/LibIPC/IpqProducer.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <chrono>
+#include <limits>
 #include <stdexcept>
 #include <thread>
 
@@ -23,6 +24,8 @@ LibIPC::IpqProducer::IpqProducer(
 		LOG_F(FATAL, "Communication library could not create producer");
 		throw std::runtime_error("Could not obtain write access to IPC event queue.");
 	}
+
+	_batch.reserve(FlushThresholdBytes + BatchSlackBytes);
 }
 
 LibIPC::IpqProducer::~IpqProducer()
@@ -33,15 +36,55 @@ LibIPC::IpqProducer::~IpqProducer()
 
 void LibIPC::IpqProducer::Send(std::vector<char>& buffer)
 {
+	constexpr auto maxRecordSize = static_cast<std::size_t>(std::numeric_limits<std::int32_t>::max());
+	const auto size = buffer.size();
+	if (size > maxRecordSize)
+	{
+		LOG_F(ERROR, "Dropping IPC message (%zu bytes): record exceeds the maximum size.", size);
+		return;
+	}
+
+	const auto sizeField = static_cast<std::int32_t>(size);
+	const auto sizeFieldBytes = reinterpret_cast<const char*>(&sizeField);
+	_batch.insert(_batch.end(), sizeFieldBytes, sizeFieldBytes + RecordHeaderSize);
+	_batch.insert(_batch.end(), buffer.begin(), buffer.end());
+
+	// An oversized record ends up in a batch of its own
+	if (_batch.size() >= FlushThresholdBytes)
+		Flush();
+}
+
+void LibIPC::IpqProducer::Flush()
+{
+	if (_batch.empty())
+		return;
+
+	SendMessage(_batch.data(), _batch.size());
+
+	// An oversized record grows the batch far past the threshold
+	if (_batch.capacity() > FlushThresholdBytes + BatchSlackBytes)
+	{
+		std::vector<char> replacement;
+		replacement.reserve(FlushThresholdBytes + BatchSlackBytes);
+		_batch.swap(replacement);
+	}
+	else
+	{
+		_batch.clear();
+	}
+}
+
+void LibIPC::IpqProducer::SendMessage(char* data, const std::size_t size)
+{
 	constexpr INT enqueueOk = 0;
 	constexpr INT enqueueNotEnoughFreeMemory = 3;
 	constexpr auto maxRetryDuration = std::chrono::seconds(5);
 
-	const auto byteStream = reinterpret_cast<BYTE*>(buffer.data());
+	const auto byteStream = reinterpret_cast<BYTE*>(data);
 	const auto deadline = std::chrono::steady_clock::now() + maxRetryDuration;
 	for (auto spinCount = 0; ; ++spinCount)
 	{
-		const INT result = _library.Enqueue(_handle, byteStream, static_cast<INT>(buffer.size()));
+		const INT result = _library.Enqueue(_handle, byteStream, static_cast<INT>(size));
 		if (result == enqueueOk)
 			return;
 
@@ -50,7 +93,7 @@ void LibIPC::IpqProducer::Send(std::vector<char>& buffer)
 			LOG_F(
 				ERROR,
 				"Dropping IPC message (%zu bytes) after non-recoverable enqueue error: %d.",
-				buffer.size(),
+				size,
 				result);
 			return;
 		}
@@ -61,7 +104,7 @@ void LibIPC::IpqProducer::Send(std::vector<char>& buffer)
 			LOG_F(
 				ERROR,
 				"Dropping IPC message (%zu bytes): consumer did not drain the queue within %lld seconds.",
-				buffer.size(),
+				size,
 				static_cast<long long>(maxRetryDuration.count()));
 			return;
 		}

--- a/src/SharpDetect.Profiler/LibIPC/IpqProducer.h
+++ b/src/SharpDetect.Profiler/LibIPC/IpqProducer.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <cstddef>
+#include <cstdint>
 #include <string>
 #include <vector>
 
@@ -15,6 +17,10 @@ namespace LibIPC
 	class IpqProducer : public IEventSink
 	{
 	public:
+		static constexpr std::size_t RecordHeaderSize = sizeof(std::int32_t);
+		static constexpr std::size_t FlushThresholdBytes = 64 * 1024;
+		static constexpr std::size_t BatchSlackBytes = 4 * 1024;
+
 		IpqProducer(
 			const IpqLibrary& library,
 			const std::string& name,
@@ -28,9 +34,12 @@ namespace LibIPC
 		IpqProducer& operator=(IpqProducer&&) = delete;
 
 		void Send(std::vector<char>& buffer) override;
+		void Flush() override;
 
 	private:
+		void SendMessage(char* data, std::size_t size);
 		const IpqLibrary& _library;
 		PVOID _handle;
+		std::vector<char> _batch;
 	};
 }

--- a/src/SharpDetect.Profiler/SharpDetect.Concurrency.Profiler/CorProfiler.cpp
+++ b/src/SharpDetect.Profiler/SharpDetect.Concurrency.Profiler/CorProfiler.cpp
@@ -27,7 +27,24 @@
 #include "CorProfiler.h"
 
 Profiler::CorProfiler* ProfilerInstance;
-thread_local std::stack<std::vector<UINT_PTR>> ArgsCallStack;
+
+namespace
+{
+    // Per-thread scratch state of the ELT callbacks. Keeping it in a single thread_local object
+    // costs one TLS lookup per callback instead of one per buffer
+    struct EltThreadScratch
+    {
+        std::stack<std::vector<UINT_PTR>> argsCallStack;
+        std::vector<BYTE> rawArgumentInfos;
+        std::vector<UINT_PTR> indirects;
+        std::vector<BYTE> argumentValues;
+        std::vector<BYTE> argumentOffsets;
+        std::vector<BYTE> stackFramesBlob;
+        std::vector<BYTE> returnValue;
+    };
+
+    thread_local EltThreadScratch EltScratch;
+}
 
 Profiler::CorProfiler::CorProfiler(const Configuration &configuration) :
     _configuration(configuration),
@@ -661,11 +678,12 @@ HRESULT Profiler::CorProfiler::EnterMethod(const FunctionIDOrClientID functionOr
 
     // Retrieve information about arguments
     const auto& descriptor = *decision->descriptor;
+    auto& scratch = EltScratch;
 
     // Retrieve arguments data
     constexpr ULONG argumentInfosBufferSize = 1024;
     COR_PRF_FRAME_INFO frameInfo { };
-    thread_local std::vector<BYTE> rawArgumentInfos;
+    auto& rawArgumentInfos = scratch.rawArgumentInfos;
     if (rawArgumentInfos.size() < argumentInfosBufferSize)
         rawArgumentInfos.resize(argumentInfosBufferSize);
 
@@ -693,12 +711,12 @@ HRESULT Profiler::CorProfiler::EnterMethod(const FunctionIDOrClientID functionOr
         return E_FAIL;
     }
 
-    thread_local std::vector<UINT_PTR> indirects;
+    auto& indirects = scratch.indirects;
     indirects.clear();
 
     const auto& argumentInfos = *reinterpret_cast<COR_PRF_FUNCTION_ARGUMENT_INFO *>(rawArgumentInfos.data());
-    thread_local std::vector<BYTE> argumentValues;
-    thread_local std::vector<BYTE> argumentOffsets;
+    auto& argumentValues = scratch.argumentValues;
+    auto& argumentOffsets = scratch.argumentOffsets;
     argumentValues.clear();
     argumentOffsets.clear();
 
@@ -724,10 +742,10 @@ HRESULT Profiler::CorProfiler::EnterMethod(const FunctionIDOrClientID functionOr
     }
 
     if (descriptor.rewritingDescriptor.returnValue.has_value() || !indirects.empty())
-        ArgsCallStack.push(indirects);
+        scratch.argsCallStack.push(indirects);
 
     // Capture stack trace if required
-    thread_local std::vector<BYTE> stackFramesBlob;
+    auto& stackFramesBlob = scratch.stackFramesBlob;
     bool hasStackFrames = false;
     if (decision->captureStackTraceOnEnter)
     {
@@ -783,6 +801,7 @@ HRESULT Profiler::CorProfiler::LeaveMethod(const FunctionIDOrClientID functionOr
     const auto& descriptor = *decision->descriptor;
     auto const hasIndirects = decision->hasIndirects;
     auto const hasReturnValue = decision->hasReturnValue;
+    auto& scratch = EltScratch;
 
     // Retrieve return value data
     COR_PRF_FRAME_INFO frameInfo;
@@ -793,7 +812,7 @@ HRESULT Profiler::CorProfiler::LeaveMethod(const FunctionIDOrClientID functionOr
         LOG_F(ERROR, "Could not retrieve return value info for method %d. Error: 0x%x", methodDef, hr);
         return E_FAIL;
     }
-    thread_local std::vector<BYTE> returnValue;
+    auto& returnValue = scratch.returnValue;
     returnValue.assign(returnValueInfo.length, 0);
     if (hasReturnValue)
     {
@@ -809,13 +828,13 @@ HRESULT Profiler::CorProfiler::LeaveMethod(const FunctionIDOrClientID functionOr
     }
 
     // Retrieve by-ref arguments data
-    thread_local std::vector<BYTE> argumentValues;
-    thread_local std::vector<BYTE> argumentOffsets;
+    auto& argumentValues = scratch.argumentValues;
+    auto& argumentOffsets = scratch.argumentOffsets;
     argumentValues.clear();
     argumentOffsets.clear();
     if (hasIndirects)
     {
-        auto& indirects = ArgsCallStack.top();
+        auto& indirects = scratch.argsCallStack.top();
         if (!indirects.empty())
         {
             auto const argumentValuesLength = std::accumulate(
@@ -841,11 +860,11 @@ HRESULT Profiler::CorProfiler::LeaveMethod(const FunctionIDOrClientID functionOr
             if (FAILED(hr))
             {
                 LOG_F(ERROR, "Could not parse by-ref arguments data for method %d. Error: 0x%x.", methodDef, hr);
-                ArgsCallStack.pop();
+                scratch.argsCallStack.pop();
                 return E_FAIL;
             }
         }
-        ArgsCallStack.pop();
+        scratch.argsCallStack.pop();
     }
 
     // Notify about method leave with arguments
@@ -893,8 +912,9 @@ HRESULT STDMETHODCALLTYPE Profiler::CorProfiler::ExceptionUnwindFunctionEnter(co
     if (descriptorPointer)
     {
         const auto& descriptor = *descriptorPointer.get();
-        if ((descriptor.rewritingDescriptor.returnValue.has_value() || HasIndirects(descriptor)) && !ArgsCallStack.empty())
-            ArgsCallStack.pop();
+        auto& argsCallStack = EltScratch.argsCallStack;
+        if ((descriptor.rewritingDescriptor.returnValue.has_value() || HasIndirects(descriptor)) && !argsCallStack.empty())
+            argsCallStack.pop();
     }
 
     auto const interpretation = hasCustomMethodExitEvent ? customMethodExitEvent : customMethodExitWithArgumentsEvent;

--- a/src/SharpDetect.Profiler/SharpDetect.Concurrency.Profiler/CorProfiler.cpp
+++ b/src/SharpDetect.Profiler/SharpDetect.Concurrency.Profiler/CorProfiler.cpp
@@ -663,25 +663,38 @@ HRESULT Profiler::CorProfiler::EnterMethod(const FunctionIDOrClientID functionOr
     const auto& descriptor = *decision->descriptor;
 
     // Retrieve arguments data
+    constexpr ULONG argumentInfosBufferSize = 1024;
     COR_PRF_FRAME_INFO frameInfo { };
-    ULONG argumentsLength = 0;
-    HRESULT hr = _corProfilerInfo->GetFunctionEnter3Info(decision->functionId, eltInfo, &frameInfo, &argumentsLength, nullptr);
-    if (hr != HRESULT_FROM_WIN32(ERROR_INSUFFICIENT_BUFFER))
+    thread_local std::vector<BYTE> rawArgumentInfos;
+    if (rawArgumentInfos.size() < argumentInfosBufferSize)
+        rawArgumentInfos.resize(argumentInfosBufferSize);
+
+    auto argumentsLength = static_cast<ULONG>(rawArgumentInfos.size());
+    HRESULT hr = _corProfilerInfo->GetFunctionEnter3Info(
+        decision->functionId,
+        eltInfo,
+        &frameInfo,
+        &argumentsLength,
+        reinterpret_cast<COR_PRF_FUNCTION_ARGUMENT_INFO *>(rawArgumentInfos.data()));
+    if (hr == HRESULT_FROM_WIN32(ERROR_INSUFFICIENT_BUFFER))
     {
-        LOG_F(ERROR, "Could not retrieve arguments info for method %d. Error: 0x%x", methodDef, hr);
-        return E_FAIL;
+        rawArgumentInfos.resize(argumentsLength);
+        hr = _corProfilerInfo->GetFunctionEnter3Info(
+            decision->functionId,
+            eltInfo,
+            &frameInfo,
+            &argumentsLength,
+            reinterpret_cast<COR_PRF_FUNCTION_ARGUMENT_INFO *>(rawArgumentInfos.data()));
     }
 
-    thread_local std::vector<UINT_PTR> indirects;
-    indirects.clear();
-    thread_local std::vector<BYTE> rawArgumentInfos;
-    rawArgumentInfos.resize(argumentsLength);
-    hr = _corProfilerInfo->GetFunctionEnter3Info(decision->functionId, eltInfo, &frameInfo, &argumentsLength, reinterpret_cast<COR_PRF_FUNCTION_ARGUMENT_INFO *>(rawArgumentInfos.data()));
     if (FAILED(hr))
     {
         LOG_F(ERROR, "Could not retrieve arguments data for method %d. Error: 0x%x.", methodDef, hr);
         return E_FAIL;
     }
+
+    thread_local std::vector<UINT_PTR> indirects;
+    indirects.clear();
 
     const auto& argumentInfos = *reinterpret_cast<COR_PRF_FUNCTION_ARGUMENT_INFO *>(rawArgumentInfos.data());
     thread_local std::vector<BYTE> argumentValues;

--- a/src/SharpDetect.Profiler/SharpDetect.Concurrency.Profiler/CorProfiler.cpp
+++ b/src/SharpDetect.Profiler/SharpDetect.Concurrency.Profiler/CorProfiler.cpp
@@ -41,6 +41,7 @@ namespace
         std::vector<BYTE> argumentOffsets;
         std::vector<BYTE> stackFramesBlob;
         std::vector<BYTE> returnValue;
+        std::vector<char> fixedEventBuffer;
     };
 
     thread_local EltThreadScratch EltScratch;
@@ -668,11 +669,7 @@ HRESULT Profiler::CorProfiler::EnterMethod(const FunctionIDOrClientID functionOr
     if (decision->descriptor == nullptr || !decision->hasArguments)
     {
         // Notify about method enter without arguments
-        _client.Send(LibIPC::Helpers::CreateMethodEnterMsg(
-            CreateMetadataMsg(),
-            moduleId,
-            methodDef,
-            decision->enterEventId));
+        SendMethodEnter(moduleId, methodDef, decision->enterEventId);
         return S_OK;
     }
 
@@ -758,8 +755,7 @@ HRESULT Profiler::CorProfiler::EnterMethod(const FunctionIDOrClientID functionOr
     }
 
     // Notify about method enter with arguments
-    _client.Send(LibIPC::Helpers::CreateMethodEnterWithArgumentsMsg(
-        CreateMetadataMsg(),
+    SendMethodEnterWithArguments(
         moduleId,
         methodDef,
         decision->enterWithArgsEventId,
@@ -767,7 +763,7 @@ HRESULT Profiler::CorProfiler::EnterMethod(const FunctionIDOrClientID functionOr
         LibIPC::ByteSpanView { argumentOffsets.data(), argumentOffsets.size() },
         hasStackFrames
             ? std::make_optional(LibIPC::ByteSpanView { stackFramesBlob.data(), stackFramesBlob.size() })
-            : std::nullopt));
+            : std::nullopt);
     return S_OK;
 }
 
@@ -789,11 +785,7 @@ HRESULT Profiler::CorProfiler::LeaveMethod(const FunctionIDOrClientID functionOr
     if (decision->descriptor == nullptr || (!decision->hasReturnValue && !decision->hasIndirects))
     {
         // Notify about method leave without arguments
-        _client.Send(LibIPC::Helpers::CreateMethodExitMsg(
-            CreateMetadataMsg(),
-            moduleId,
-            methodDef,
-            decision->exitEventId));
+        SendMethodExit(moduleId, methodDef, decision->exitEventId);
         return S_OK;
     }
 
@@ -868,14 +860,13 @@ HRESULT Profiler::CorProfiler::LeaveMethod(const FunctionIDOrClientID functionOr
     }
 
     // Notify about method leave with arguments
-    _client.Send(LibIPC::Helpers::CreateMethodExitWithArgumentsMsg(
-        CreateMetadataMsg(),
+    SendMethodExitWithArguments(
         moduleId,
         methodDef,
         decision->exitWithArgsEventId,
         LibIPC::ByteSpanView { returnValue.data(), returnValue.size() },
         LibIPC::ByteSpanView { argumentValues.data(), argumentValues.size() },
-        LibIPC::ByteSpanView { argumentOffsets.data(), argumentOffsets.size() }));
+        LibIPC::ByteSpanView { argumentOffsets.data(), argumentOffsets.size() });
 
     return S_OK;
 }
@@ -981,6 +972,58 @@ UINT64 Profiler::CorProfiler::GetCurrentThreadIdCached() const
 LibIPC::MetadataMsg Profiler::CorProfiler::CreateMetadataMsg() const
 {
     return LibIPC::Helpers::CreateMetadataMsg(_pid, GetCurrentThreadIdCached());
+}
+
+void Profiler::CorProfiler::SendMethodEnter(const UINT64 moduleId, const UINT32 methodToken, const USHORT interpretation)
+{
+    LibIPC::FixedEvents::WriteMethodEnter(EltScratch.fixedEventBuffer, GetCurrentThreadIdCached(), moduleId, methodToken, interpretation);
+    _client.SendRaw(EltScratch.fixedEventBuffer.data(), EltScratch.fixedEventBuffer.size());
+}
+
+void Profiler::CorProfiler::SendMethodExit(const UINT64 moduleId, const UINT32 methodToken, const USHORT interpretation)
+{
+    LibIPC::FixedEvents::WriteMethodExit(EltScratch.fixedEventBuffer, GetCurrentThreadIdCached(), moduleId, methodToken, interpretation);
+    _client.SendRaw(EltScratch.fixedEventBuffer.data(), EltScratch.fixedEventBuffer.size());
+}
+
+void Profiler::CorProfiler::SendMethodEnterWithArguments(
+    const UINT64 moduleId,
+    const UINT32 methodToken,
+    const USHORT interpretation,
+    const LibIPC::ByteSpanView argumentValues,
+    const LibIPC::ByteSpanView argumentInfos,
+    const std::optional<LibIPC::ByteSpanView> stackFrames)
+{
+    LibIPC::FixedEvents::WriteMethodEnterWithArguments(
+        EltScratch.fixedEventBuffer,
+        GetCurrentThreadIdCached(),
+        moduleId,
+        methodToken,
+        interpretation,
+        argumentValues,
+        argumentInfos,
+        stackFrames);
+    _client.SendRaw(EltScratch.fixedEventBuffer.data(), EltScratch.fixedEventBuffer.size());
+}
+
+void Profiler::CorProfiler::SendMethodExitWithArguments(
+    const UINT64 moduleId,
+    const UINT32 methodToken,
+    const USHORT interpretation,
+    const LibIPC::ByteSpanView returnValue,
+    const LibIPC::ByteSpanView byRefArgumentValues,
+    const LibIPC::ByteSpanView byRefArgumentInfos)
+{
+    LibIPC::FixedEvents::WriteMethodExitWithArguments(
+        EltScratch.fixedEventBuffer,
+        GetCurrentThreadIdCached(),
+        moduleId,
+        methodToken,
+        interpretation,
+        returnValue,
+        byRefArgumentValues,
+        byRefArgumentInfos);
+    _client.SendRaw(EltScratch.fixedEventBuffer.data(), EltScratch.fixedEventBuffer.size());
 }
 
 LibIPC::MetadataMsg Profiler::CorProfiler::CreateMetadataMsg(const UINT64 commandId) const

--- a/src/SharpDetect.Profiler/SharpDetect.Concurrency.Profiler/CorProfiler.h
+++ b/src/SharpDetect.Profiler/SharpDetect.Concurrency.Profiler/CorProfiler.h
@@ -8,6 +8,7 @@
 #include <functional>
 #include <mutex>
 #include <unordered_map>
+#include <optional>
 #include <vector>
 
 #include "cor.h"
@@ -83,6 +84,22 @@ namespace Profiler
 		[[nodiscard]] LibIPC::MetadataMsg CreateMetadataMsg(UINT64 commandId) const;
 		[[nodiscard]] UINT64 GetCurrentThreadIdCached() const;
 		HRESULT CaptureStackTrace(UINT64 commandId, ThreadID threadId);
+		void SendMethodEnter(UINT64 moduleId, UINT32 methodToken, USHORT interpretation);
+		void SendMethodExit(UINT64 moduleId, UINT32 methodToken, USHORT interpretation);
+		void SendMethodEnterWithArguments(
+			UINT64 moduleId,
+			UINT32 methodToken,
+			USHORT interpretation,
+			LibIPC::ByteSpanView argumentValues,
+			LibIPC::ByteSpanView argumentInfos,
+			std::optional<LibIPC::ByteSpanView> stackFrames);
+		void SendMethodExitWithArguments(
+			UINT64 moduleId,
+			UINT32 methodToken,
+			USHORT interpretation,
+			LibIPC::ByteSpanView returnValue,
+			LibIPC::ByteSpanView byRefArgumentValues,
+			LibIPC::ByteSpanView byRefArgumentInfos);
 		HRESULT PatchMethodBody(const LibProfiler::ModuleDef& moduleDef, mdTypeDef mdTypeDef, mdMethodDef mdMethodDef);
 		[[nodiscard]] GenericCaptureState ClassifyGenericValueCapture(FunctionID functionId, COR_PRF_FRAME_INFO frameInfo, const MethodDescriptor& descriptor);
 		[[nodiscard]] COR_PRF_FRAME_INFO GetFrameInfo(const EltDecision& decision, COR_PRF_ELT_INFO eltInfo, EltCallbackKind callback) const;

--- a/src/SharpDetect.Serialization/Formatters/CompositeFormatResolver.cs
+++ b/src/SharpDetect.Serialization/Formatters/CompositeFormatResolver.cs
@@ -1,0 +1,33 @@
+// Copyright 2026 Andrej Čižmárik and Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+using MessagePack;
+using MessagePack.Formatters;
+using MessagePack.Resolvers;
+
+namespace SharpDetect.Serialization.Formatters;
+
+internal sealed class CompositeFormatResolver : IFormatterResolver
+{
+    public static readonly IFormatterResolver Instance = new CompositeFormatResolver();
+
+    private CompositeFormatResolver()
+    {
+    }
+
+    public IMessagePackFormatter<T>? GetFormatter<T>()
+    {
+        return Cache<T>.Formatter;
+    }
+
+    private static class Cache<T>
+    {
+        public static readonly IMessagePackFormatter<T>? Formatter;
+
+        static Cache()
+        {
+            Formatter = CustomFormatResolver.Instance.GetFormatter<T>()
+                ?? StandardResolver.Instance.GetFormatter<T>();
+        }
+    }
+}

--- a/src/SharpDetect.Serialization/Formatters/RecordedEventFormatter.cs
+++ b/src/SharpDetect.Serialization/Formatters/RecordedEventFormatter.cs
@@ -1,0 +1,139 @@
+// Copyright 2026 Andrej Čižmárik and Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Buffers;
+using MessagePack;
+using MessagePack.Formatters;
+using SharpDetect.Core.Events;
+using SharpDetect.Core.Events.Profiler;
+
+namespace SharpDetect.Serialization.Formatters;
+
+internal sealed class RecordedEventFormatter(IFormatterResolver resolver)
+{
+    private const int EnvelopeMemberCount = 2;
+    private const int MetadataMemberCount = 3;
+    private const int UnionMemberCount = 2;
+    private const int MethodCallMemberCount = 3;
+    private const int MethodCallWithArgumentsMemberCount = 6;
+
+    private readonly IMessagePackFormatter<RecordedEvent> _envelopeFormatter = resolver.GetFormatterWithVerify<RecordedEvent>();
+
+    public RecordedEvent Deserialize(ref MessagePackReader reader, MessagePackSerializerOptions options)
+    {
+        var rewound = reader;
+        if (TryDeserializeMethodEvent(ref reader, out var recordedEvent))
+            return recordedEvent;
+
+        reader = rewound;
+        return _envelopeFormatter.Deserialize(ref reader, options);
+    }
+
+    private static bool TryDeserializeMethodEvent(ref MessagePackReader reader, out RecordedEvent recordedEvent)
+    {
+        recordedEvent = null!;
+
+        if (reader.NextMessagePackType != MessagePackType.Array || reader.ReadArrayHeader() != EnvelopeMemberCount)
+            return false;
+
+        if (reader.NextMessagePackType != MessagePackType.Array || reader.ReadArrayHeader() != MetadataMemberCount)
+            return false;
+
+        var pid = reader.ReadUInt32();
+        var tid = new ThreadId(new UIntPtr(reader.ReadUInt64()));
+        var commandId = reader.TryReadNil() ? null : (ulong?)reader.ReadUInt64();
+        var metadata = new RecordedEventMetadata(pid, tid, commandId);
+
+        if (reader.NextMessagePackType != MessagePackType.Array || reader.ReadArrayHeader() != UnionMemberCount)
+            return false;
+
+        var eventType = (RecordedEventType)reader.ReadInt32();
+        if (reader.NextMessagePackType != MessagePackType.Array)
+            return false;
+
+        var memberCount = reader.ReadArrayHeader();
+        switch (eventType)
+        {
+            case RecordedEventType.MethodEnterWithArguments when memberCount == MethodCallWithArgumentsMemberCount:
+            {
+                var moduleId = ReadModuleId(ref reader);
+                var methodToken = ReadMethodToken(ref reader);
+                var interpretation = reader.ReadUInt16();
+                var argumentValues = ReadPayload(ref reader);
+                var argumentInfos = ReadPayload(ref reader);
+                var stackFrames = ReadPayload(ref reader);
+                recordedEvent = new RecordedEvent(metadata, new MethodEnterWithArgumentsRecordedEvent(
+                    moduleId, methodToken, interpretation, argumentValues!, argumentInfos!, stackFrames));
+                return true;
+            }
+
+            case RecordedEventType.MethodExitWithArguments when memberCount == MethodCallWithArgumentsMemberCount:
+            {
+                var moduleId = ReadModuleId(ref reader);
+                var methodToken = ReadMethodToken(ref reader);
+                var interpretation = reader.ReadUInt16();
+                var returnValue = ReadPayload(ref reader);
+                var byRefArgumentValues = ReadPayload(ref reader);
+                var byRefArgumentInfos = ReadPayload(ref reader);
+                recordedEvent = new RecordedEvent(metadata, new MethodExitWithArgumentsRecordedEvent(
+                    moduleId, methodToken, interpretation, returnValue!, byRefArgumentValues!, byRefArgumentInfos!));
+                return true;
+            }
+
+            case RecordedEventType.MethodEnter when memberCount == MethodCallMemberCount:
+            {
+                var moduleId = ReadModuleId(ref reader);
+                var methodToken = ReadMethodToken(ref reader);
+                var interpretation = reader.ReadUInt16();
+                recordedEvent = new RecordedEvent(metadata,
+                    new MethodEnterRecordedEvent(moduleId, methodToken, interpretation));
+                return true;
+            }
+
+            case RecordedEventType.MethodExit when memberCount == MethodCallMemberCount:
+            {
+                var moduleId = ReadModuleId(ref reader);
+                var methodToken = ReadMethodToken(ref reader);
+                var interpretation = reader.ReadUInt16();
+                recordedEvent = new RecordedEvent(metadata,
+                    new MethodExitRecordedEvent(moduleId, methodToken, interpretation));
+                return true;
+            }
+
+            case RecordedEventType.MethodUnwound when memberCount == MethodCallMemberCount:
+            {
+                var moduleId = ReadModuleId(ref reader);
+                var methodToken = ReadMethodToken(ref reader);
+                var interpretation = reader.ReadUInt16();
+                recordedEvent = new RecordedEvent(metadata,
+                    new MethodUnwoundRecordedEvent(moduleId, methodToken, interpretation));
+                return true;
+            }
+
+            default:
+                return false;
+        }
+    }
+
+    private static ModuleId ReadModuleId(ref MessagePackReader reader)
+    {
+        return new ModuleId(new UIntPtr(reader.ReadUInt64()));
+    }
+
+    private static MdMethodDef ReadMethodToken(ref MessagePackReader reader)
+    {
+        return new MdMethodDef(reader.ReadInt32());
+    }
+
+    private static byte[]? ReadPayload(ref MessagePackReader reader)
+    {
+        var payload = reader.ReadBytes();
+        if (payload is null)
+            return null;
+
+        var sequence = payload.Value;
+        return sequence.IsSingleSegment
+            ? sequence.FirstSpan.ToArray()
+            : sequence.ToArray();
+    }
+}

--- a/src/SharpDetect.Serialization/Services/ProfilerCommandSerializerService.cs
+++ b/src/SharpDetect.Serialization/Services/ProfilerCommandSerializerService.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using MessagePack;
-using MessagePack.Resolvers;
 using SharpDetect.Core.Commands;
 using SharpDetect.Core.Serialization;
 using SharpDetect.Serialization.Formatters;
@@ -15,13 +14,8 @@ internal sealed class ProfilerCommandSerializerService : IProfilerCommandSeriali
 
     public ProfilerCommandSerializerService()
     {
-        var resolver = CompositeResolver.Create(
-            CustomFormatResolver.Instance,
-            StandardResolver.Instance
-        );
-        
         _serializerOptions = MessagePackSerializerOptions.Standard
-            .WithResolver(resolver);
+            .WithResolver(CompositeFormatResolver.Instance);
     }
 
     public byte[] Serialize(ProfilerCommand command)

--- a/src/SharpDetect.Serialization/Services/RecordedEventParserService.cs
+++ b/src/SharpDetect.Serialization/Services/RecordedEventParserService.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using MessagePack;
-using MessagePack.Resolvers;
 using SharpDetect.Core.Events;
 using SharpDetect.Core.Serialization;
 using SharpDetect.Serialization.Formatters;
@@ -12,20 +11,18 @@ namespace SharpDetect.Serialization.Services;
 internal sealed class RecordedEventParserService : IRecordedEventParser
 {
     private readonly MessagePackSerializerOptions _serializerOptions;
+    private readonly RecordedEventFormatter _formatter;
 
     public RecordedEventParserService()
     {
-        var resolver = CompositeResolver.Create(
-            CustomFormatResolver.Instance,
-            StandardResolver.Instance
-        );
-        
         _serializerOptions = MessagePackSerializerOptions.Standard
-            .WithResolver(resolver);
+            .WithResolver(CompositeFormatResolver.Instance);
+        _formatter = new RecordedEventFormatter(_serializerOptions.Resolver);
     }
 
     public RecordedEvent Parse(ReadOnlyMemory<byte> input)
     {
-        return MessagePackSerializer.Deserialize<RecordedEvent>(input, _serializerOptions);
+        var reader = new MessagePackReader(input);
+        return _formatter.Deserialize(ref reader, _serializerOptions);
     }
 }

--- a/src/SharpDetect.Worker/Services/AnalysisWorker.cs
+++ b/src/SharpDetect.Worker/Services/AnalysisWorker.cs
@@ -1,7 +1,6 @@
 // Copyright 2026 Andrej Čižmárik and Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
@@ -18,10 +17,12 @@ namespace SharpDetect.Worker.Services;
 
 public sealed class AnalysisWorker : IAnalysisWorker
 {
-    private const int EventBufferCapacity = 1000;
+    private const int EventBatchSize = 256;
+    private const int MaxPendingEventBatches = 16;
     private static readonly TimeSpan IdlePollDelay = TimeSpan.FromMilliseconds(10);
-    private const int MaxBatchPerReceiver = 256;
+    private const int MaxPollsPerReceiver = 64;
     private const int MaxConsecutiveEmptyPolls = 50;
+    private const int MaxConsecutiveFailedRecords = 1000;
 
     private readonly RunCommandArgs _arguments;
     private readonly IPlugin _plugin;
@@ -173,8 +174,8 @@ public sealed class AnalysisWorker : IAnalysisWorker
     private void ExecuteAnalysis(Task targetProcessTask, uint rootPid, StrongBox<long> targetDoneTimestamp, CancellationToken cancellationToken)
     {
         using var receiveCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-        using var events = new BlockingCollection<RecordedEvent>(EventBufferCapacity);
-        var producer = new Thread(() => ProduceEvents(events, targetProcessTask, rootPid, targetDoneTimestamp, receiveCts.Token))
+        using var events = new EventBatchPipe(EventBatchSize, MaxPendingEventBatches);
+        var producer = new Thread(() => ProduceEvents(events, targetProcessTask, targetDoneTimestamp, receiveCts.Token))
         {
             IsBackground = true,
             Name = "SharpDetect.EventReceiver"
@@ -201,40 +202,54 @@ public sealed class AnalysisWorker : IAnalysisWorker
         }
     }
 
-    private void ProduceEvents(BlockingCollection<RecordedEvent> events, Task targetProcessTask, uint rootPid, StrongBox<long> targetDoneTimestamp, CancellationToken cancellationToken)
+    private void ProduceEvents(
+        EventBatchPipe events,
+        Task targetProcessTask,
+        StrongBox<long> targetDoneTimestamp,
+        CancellationToken cancellationToken)
     {
         try
         {
-            foreach (var currentEvent in ReceiveEvents(targetProcessTask, rootPid, targetDoneTimestamp, cancellationToken))
-            {
-                AnalysisWorkerMetrics.EventReceived(currentEvent.EventArgs);
-                events.Add(currentEvent, cancellationToken);
-            }
+            ReceiveEvents(events, targetProcessTask, targetDoneTimestamp, cancellationToken);
         }
         catch (OperationCanceledException)
         {
             // Expected when the consumer finishes (or analysis is cancelled) while we wait for buffer capacity.
         }
+        catch (Exception ex)
+        {
+            _logger.LogCritical(ex, "Event receiver stopped; the analysis is incomplete");
+        }
         finally
         {
-            events.CompleteAdding();
+            events.Complete(cancellationToken);
         }
     }
 
-    private void ProcessEvents(BlockingCollection<RecordedEvent> events, uint rootPid, CancellationToken cancellationToken)
+    private void ProcessEvents(EventBatchPipe events, uint rootPid, CancellationToken cancellationToken)
     {
         try
         {
-            foreach (var currentEvent in events.GetConsumingEnumerable(cancellationToken))
+            while (events.TryTakeBatch(out var batch, cancellationToken))
             {
-                if (currentEvent.EventArgs is ProfilerDestroyRecordedEvent && currentEvent.Metadata.Pid == rootPid)
-                    return;
-
-                AnalysisWorkerMetrics.EventProcessed();
-                if (_pluginHost.ProcessEvent(currentEvent) == RecordedEventState.Failed)
+                var processed = 0;
+                try
                 {
-                    LogFailureAndTerminateAnalysis();
-                    return;
+                    var buffer = batch.Buffer;
+                    for (; processed < batch.Count; processed++)
+                    {
+                        var currentEvent = buffer[processed];
+                        if (currentEvent.EventArgs is ProfilerDestroyRecordedEvent && currentEvent.Metadata.Pid == rootPid)
+                            return;
+
+                        if (_pluginHost.ProcessEvent(currentEvent) == RecordedEventState.Failed)
+                            LogFailureAndTerminateAnalysis();
+                    }
+                }
+                finally
+                {
+                    AnalysisWorkerMetrics.EventsProcessed(processed);
+                    events.Recycle(batch);
                 }
             }
         }
@@ -244,19 +259,41 @@ public sealed class AnalysisWorker : IAnalysisWorker
         }
     }
 
-    private IEnumerable<RecordedEvent> ReceiveEvents(Task targetProcessTask, uint rootPid, StrongBox<long> targetDoneTimestamp, CancellationToken cancellationToken)
+    private void ReceiveEvents(
+        EventBatchPipe events,
+        Task targetProcessTask,
+        StrongBox<long> targetDoneTimestamp,
+        CancellationToken cancellationToken)
     {
         var receivers = new Dictionary<uint, IProfilerEventReceiver>();
         var drainStartTimestamp = 0L;
         var lastDrainedEventTimestamp = 0L;
+        var consecutiveFailedRecords = 0;
 
-        void TrackDrainedEvent()
+
+        bool DrainReceiver(IProfilerEventReceiver receiver)
         {
-            if (drainStartTimestamp == 0)
-                return;
+            var receivedAny = false;
+            for (var poll = 0; poll < MaxPollsPerReceiver; poll++)
+            {
+                var destination = events.GetWriteSpan();
+                var count = receiver.TryReceiveNotifications(destination, out var failedRecords);
+                consecutiveFailedRecords = count > 0 ? 0 : consecutiveFailedRecords + failedRecords;
+                if (count == 0)
+                    break;
 
-            lastDrainedEventTimestamp = Stopwatch.GetTimestamp();
-            AnalysisWorkerMetrics.EventDrained();
+                AnalysisWorkerMetrics.EventsReceived(destination[..count]);
+                if (drainStartTimestamp != 0)
+                {
+                    lastDrainedEventTimestamp = Stopwatch.GetTimestamp();
+                    AnalysisWorkerMetrics.EventsDrained(count);
+                }
+
+                events.Advance(count, cancellationToken);
+                receivedAny = true;
+            }
+
+            return receivedAny;
         }
 
         try
@@ -277,34 +314,11 @@ public sealed class AnalysisWorker : IAnalysisWorker
                 }
 
                 var receivedAny = false;
-                foreach (var (pid, receiver) in receivers)
-                {
-                    if (pid == rootPid)
-                        continue;
+                foreach (var receiver in receivers.Values)
+                    receivedAny |= DrainReceiver(receiver);
 
-                    for (var i = 0; i < MaxBatchPerReceiver && receiver.TryReceiveNotification(out var childEvent); i++)
-                    {
-                        receivedAny = true;
-                        TrackDrainedEvent();
-                        yield return childEvent;
-                    }
-                }
-
-                if (receivers.TryGetValue(rootPid, out var rootReceiver))
-                {
-                    for (var i = 0; i < MaxBatchPerReceiver && rootReceiver.TryReceiveNotification(out var rootEvent); i++)
-                    {
-                        receivedAny = true;
-                        TrackDrainedEvent();
-                        yield return rootEvent;
-
-                        if (rootEvent.EventArgs is ProfilerDestroyRecordedEvent && rootEvent.Metadata.Pid == rootPid)
-                        {
-                            Interlocked.CompareExchange(ref targetDoneTimestamp.Value, Stopwatch.GetTimestamp(), 0L);
-                            yield break;
-                        }
-                    }
-                }
+                if (consecutiveFailedRecords >= MaxConsecutiveFailedRecords)
+                    LogUnreadableEventStreamAndTerminateAnalysis(consecutiveFailedRecords);
 
                 if (receivedAny)
                 {
@@ -312,8 +326,9 @@ public sealed class AnalysisWorker : IAnalysisWorker
                     continue;
                 }
 
+                events.Flush(cancellationToken);
                 if (targetProcessTask.IsCompleted && ++consecutiveEmptyPolls >= MaxConsecutiveEmptyPolls)
-                    yield break;
+                    return;
 
                 Thread.Sleep(IdlePollDelay);
             }
@@ -406,6 +421,13 @@ public sealed class AnalysisWorker : IAnalysisWorker
     private void LogFailureAndTerminateAnalysis()
     {
         _logger.LogCritical("Cannot continue with analysis due to corrupted shadow runtime state.");
+        throw new AnalysisFailedException();
+    }
+
+    [DoesNotReturn]
+    private void LogUnreadableEventStreamAndTerminateAnalysis(int failedRecords)
+    {
+        _logger.LogCritical("Discarded {FailedRecords} consecutive unparsable events.", failedRecords);
         throw new AnalysisFailedException();
     }
 }

--- a/src/SharpDetect.Worker/Services/AnalysisWorker.cs
+++ b/src/SharpDetect.Worker/Services/AnalysisWorker.cs
@@ -76,12 +76,15 @@ public sealed class AnalysisWorker : IAnalysisWorker
                 TaskContinuationOptions.ExecuteSynchronously,
                 TaskScheduler.Default);
 
-            ExecuteAnalysis(targetApplicationProcess.Task, rootPid, targetDoneTimestamp, cancellationToken);
+            var processTailEnd = ExecuteAnalysis(targetApplicationProcess.Task, rootPid, targetDoneTimestamp, cancellationToken);
             _logger.LogInformation("Terminating analysis of process with PID: {Pid}.", rootPid);
 
             var commandResult = await targetApplicationProcess;
+            var targetExit = await targetExitTimestamp;
             AnalysisWorkerMetrics.TargetWallCompleted(
-                Stopwatch.GetElapsedTime(targetStartTimestamp, await targetExitTimestamp));
+                Stopwatch.GetElapsedTime(targetStartTimestamp, targetExit));
+            var processTail = Stopwatch.GetElapsedTime(targetExit, processTailEnd);
+            AnalysisWorkerMetrics.ProcessTailCompleted(processTail > TimeSpan.Zero ? processTail : TimeSpan.Zero);
             if (commandResult.ExitCode != 0)
             {
                 var level = _arguments.Target.Kind == TargetKind.TestAssembly ? LogLevel.Information : LogLevel.Warning;
@@ -171,7 +174,7 @@ public sealed class AnalysisWorker : IAnalysisWorker
         return envVars;
     }
 
-    private void ExecuteAnalysis(Task targetProcessTask, uint rootPid, StrongBox<long> targetDoneTimestamp, CancellationToken cancellationToken)
+    private long ExecuteAnalysis(Task targetProcessTask, uint rootPid, StrongBox<long> targetDoneTimestamp, CancellationToken cancellationToken)
     {
         using var receiveCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         using var events = new EventBatchPipe(EventBatchSize, MaxPendingEventBatches);
@@ -182,24 +185,22 @@ public sealed class AnalysisWorker : IAnalysisWorker
         };
         producer.Start();
 
+        var processTailEnd = 0L;
         try
         {
             ProcessEvents(events, rootPid, cancellationToken);
         }
         finally
         {
-            var processTailEnd = Stopwatch.GetTimestamp();
+            processTailEnd = Stopwatch.GetTimestamp();
             receiveCts.Cancel();
             producer.Join();
-
-            var exitTimestamp = Volatile.Read(ref targetDoneTimestamp.Value);
-            AnalysisWorkerMetrics.ProcessTailCompleted(exitTimestamp != 0
-                ? Stopwatch.GetElapsedTime(exitTimestamp, processTailEnd)
-                : TimeSpan.Zero);
 
             if (_pluginHost is IDisposable disposable)
                 disposable.Dispose();
         }
+
+        return processTailEnd;
     }
 
     private void ProduceEvents(

--- a/src/SharpDetect.Worker/Services/AnalysisWorkerMetrics.cs
+++ b/src/SharpDetect.Worker/Services/AnalysisWorkerMetrics.cs
@@ -66,21 +66,25 @@ public static class AnalysisWorkerMetrics
 
     public static long CurrentTargetPid => Volatile.Read(ref _targetPid);
 
-    internal static void EventReceived(IRecordedEventArgs eventArgs)
+    internal static void EventsReceived(ReadOnlySpan<RecordedEvent> recordedEvents)
     {
-        _receivedEvents++;
+        _receivedEvents += recordedEvents.Length;
         if (!ReceivedByTypeCounter.Enabled)
             return;
 
-        if (ReceivedEventsByType.Value.TryGetValue(eventArgs.GetType(), out var count))
-            count.Value++;
+        var byType = ReceivedEventsByType.Value;
+        foreach (var recordedEvent in recordedEvents)
+        {
+            if (byType.TryGetValue(recordedEvent.EventArgs.GetType(), out var count))
+                count.Value++;
+        }
     }
 
-    internal static void EventProcessed()
-        => _processedEvents++;
+    internal static void EventsProcessed(int count)
+        => _processedEvents += count;
 
-    internal static void EventDrained()
-        => _drainedEvents++;
+    internal static void EventsDrained(int count)
+        => _drainedEvents += count;
 
     internal static void DrainCompleted(TimeSpan duration)
         => _drainDurationSeconds += duration.TotalSeconds;

--- a/src/SharpDetect.Worker/Services/EventBatch.cs
+++ b/src/SharpDetect.Worker/Services/EventBatch.cs
@@ -1,0 +1,8 @@
+// Copyright 2026 Andrej Čižmárik and Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+using SharpDetect.Core.Events;
+
+namespace SharpDetect.Worker.Services;
+
+internal readonly record struct EventBatch(RecordedEvent[] Buffer, int Count);

--- a/src/SharpDetect.Worker/Services/EventBatchPipe.cs
+++ b/src/SharpDetect.Worker/Services/EventBatchPipe.cs
@@ -1,0 +1,90 @@
+// Copyright 2026 Andrej Čižmárik and Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Collections.Concurrent;
+using SharpDetect.Core.Events;
+
+namespace SharpDetect.Worker.Services;
+
+/// <summary>
+/// Single-producer/single-consumer handoff between the event receiver thread and the event processing thread
+/// </summary>
+internal sealed class EventBatchPipe : IDisposable
+{
+    private readonly int _batchSize;
+    private readonly BlockingCollection<EventBatch> _batches;
+    private readonly ConcurrentQueue<RecordedEvent[]> _spareBuffers;
+    private RecordedEvent[]? _writeBuffer;
+    private int _writeCount;
+
+    public EventBatchPipe(int batchSize, int maxPendingBatches)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThan(batchSize, 1);
+        ArgumentOutOfRangeException.ThrowIfLessThan(maxPendingBatches, 1);
+
+        _batchSize = batchSize;
+        _batches = new BlockingCollection<EventBatch>(maxPendingBatches);
+        _spareBuffers = new ConcurrentQueue<RecordedEvent[]>();
+    }
+    
+    public Span<RecordedEvent> GetWriteSpan()
+    {
+        var buffer = _writeBuffer ??= RentBuffer();
+        return buffer.AsSpan(_writeCount);
+    }
+    
+    public void Advance(int count, CancellationToken cancellationToken)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(count);
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(count, _batchSize - _writeCount);
+
+        _writeCount += count;
+        if (_writeCount == _batchSize)
+            PublishCurrentBatch(cancellationToken);
+    }
+    
+    public void Flush(CancellationToken cancellationToken)
+    {
+        if (_writeCount > 0)
+            PublishCurrentBatch(cancellationToken);
+    }
+    
+    public void Complete(CancellationToken cancellationToken)
+    {
+        try
+        {
+            Flush(cancellationToken);
+        }
+        catch (OperationCanceledException)
+        {
+            // The consumer has already stopped draining
+        }
+        finally
+        {
+            _batches.CompleteAdding();
+        }
+    }
+    
+    public bool TryTakeBatch(out EventBatch batch, CancellationToken cancellationToken)
+        => _batches.TryTake(out batch, Timeout.Infinite, cancellationToken);
+    
+    public void Recycle(EventBatch batch)
+    {
+        Array.Clear(batch.Buffer);
+        _spareBuffers.Enqueue(batch.Buffer);
+    }
+    
+    public void Dispose()
+        => _batches.Dispose();
+
+    private void PublishCurrentBatch(CancellationToken cancellationToken)
+    {
+        var batch = new EventBatch(_writeBuffer!, _writeCount);
+        _writeBuffer = null;
+        _writeCount = 0;
+        _batches.Add(batch, cancellationToken);
+    }
+
+    private RecordedEvent[] RentBuffer()
+        => _spareBuffers.TryDequeue(out var buffer) ? buffer : new RecordedEvent[_batchSize];
+}

--- a/src/Tests/SharpDetect.Core.Tests/Communication/EventBatchProtocolTests.cs
+++ b/src/Tests/SharpDetect.Core.Tests/Communication/EventBatchProtocolTests.cs
@@ -1,0 +1,93 @@
+// Copyright 2026 Andrej Čižmárik and Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Buffers.Binary;
+using SharpDetect.Core.Communication;
+using Xunit;
+
+namespace SharpDetect.Core.Tests.Communication;
+
+public class EventBatchProtocolTests
+{
+    [Fact]
+    public void TryReadRecord_ReadsRecordsInOrder()
+    {
+        var batch = BuildBatch([1, 2, 3], [4, 5], []);
+
+        var offset = 0;
+        Assert.Equal(EventBatchRecordStatus.Record, EventBatchProtocol.TryReadRecord(batch, ref offset, out var first));
+        Assert.Equal(EventBatchRecordStatus.Record, EventBatchProtocol.TryReadRecord(batch, ref offset, out var second));
+        Assert.Equal(EventBatchRecordStatus.Record, EventBatchProtocol.TryReadRecord(batch, ref offset, out var third));
+        Assert.Equal(EventBatchRecordStatus.EndOfBatch, EventBatchProtocol.TryReadRecord(batch, ref offset, out _));
+
+        Assert.Equal<byte>([1, 2, 3], first.ToArray());
+        Assert.Equal<byte>([4, 5], second.ToArray());
+        Assert.Empty(third.ToArray());
+        Assert.Equal(batch.Length, offset);
+    }
+
+    [Fact]
+    public void TryReadRecord_ReportsEndOfEmptyBatch()
+    {
+        var offset = 0;
+        Assert.Equal(
+            EventBatchRecordStatus.EndOfBatch,
+            EventBatchProtocol.TryReadRecord(ReadOnlyMemory<byte>.Empty, ref offset, out _));
+    }
+
+    [Fact]
+    public void TryReadRecord_ReportsTruncatedHeaderAsCorrupted()
+    {
+        var offset = 0;
+        Assert.Equal(
+            EventBatchRecordStatus.Corrupted,
+            EventBatchProtocol.TryReadRecord(new byte[] { 1, 2, 3 }, ref offset, out _));
+    }
+
+    [Fact]
+    public void TryReadRecord_ReportsSizeOverrunningTheBatchAsCorrupted()
+    {
+        var batch = new byte[EventBatchProtocol.RecordHeaderSize + 2];
+        BinaryPrimitives.WriteInt32LittleEndian(batch, 64);
+
+        var offset = 0;
+        Assert.Equal(EventBatchRecordStatus.Corrupted, EventBatchProtocol.TryReadRecord(batch, ref offset, out _));
+        Assert.Equal(0, offset);
+    }
+
+    [Fact]
+    public void TryReadRecord_ReportsNegativeSizeAsCorrupted()
+    {
+        var batch = new byte[EventBatchProtocol.RecordHeaderSize + 4];
+        BinaryPrimitives.WriteInt32LittleEndian(batch, -1);
+
+        var offset = 0;
+        Assert.Equal(EventBatchRecordStatus.Corrupted, EventBatchProtocol.TryReadRecord(batch, ref offset, out _));
+    }
+
+    [Fact]
+    public void TryReadRecord_ReportsOffsetPastTheBatchAsCorrupted()
+    {
+        var batch = BuildBatch([1]);
+
+        var offset = batch.Length + 1;
+        Assert.Equal(EventBatchRecordStatus.Corrupted, EventBatchProtocol.TryReadRecord(batch, ref offset, out _));
+    }
+
+    internal static byte[] BuildBatch(params byte[][] records)
+    {
+        var size = records.Sum(record => EventBatchProtocol.RecordHeaderSize + record.Length);
+        var batch = new byte[size];
+
+        var offset = 0;
+        foreach (var record in records)
+        {
+            BinaryPrimitives.WriteInt32LittleEndian(batch.AsSpan(offset), record.Length);
+            offset += EventBatchProtocol.RecordHeaderSize;
+            record.CopyTo(batch.AsSpan(offset));
+            offset += record.Length;
+        }
+
+        return batch;
+    }
+}

--- a/src/Tests/SharpDetect.Core.Tests/Communication/EventBatchReaderTests.cs
+++ b/src/Tests/SharpDetect.Core.Tests/Communication/EventBatchReaderTests.cs
@@ -1,0 +1,161 @@
+// Copyright 2026 Andrej Čižmárik and Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Buffers.Binary;
+using SharpDetect.Core.Communication;
+using SharpDetect.Core.Events;
+using SharpDetect.Core.Events.Profiler;
+using SharpDetect.Core.Serialization;
+using Xunit;
+
+namespace SharpDetect.Core.Tests.Communication;
+
+public class EventBatchReaderTests
+{
+    private sealed class StubParser : IRecordedEventParser
+    {
+        public const uint UnparsableMarker = uint.MaxValue;
+
+        public RecordedEvent Parse(ReadOnlyMemory<byte> input)
+        {
+            var pid = BinaryPrimitives.ReadUInt32LittleEndian(input.Span);
+            return pid != UnparsableMarker
+                ? new RecordedEvent(new RecordedEventMetadata(pid, new ThreadId(0)), new ProfilerDestroyRecordedEvent())
+                : throw new InvalidOperationException("Unparsable record.");
+        }
+    }
+
+    private static byte[] Record(uint value)
+    {
+        var record = new byte[sizeof(uint)];
+        BinaryPrimitives.WriteUInt32LittleEndian(record, value);
+        return record;
+    }
+
+    private static uint[] PidsOf(ReadOnlySpan<RecordedEvent> events, int count)
+    {
+        var pids = new uint[count];
+        for (var index = 0; index < count; index++)
+            pids[index] = events[index].Metadata.Pid;
+
+        return pids;
+    }
+
+    [Fact]
+    public void ReadInto_ReadsWholeBatchWhenDestinationIsLargeEnough()
+    {
+        var reader = new EventBatchReader(new StubParser());
+        reader.SetBatch(EventBatchProtocolTests.BuildBatch(Record(1), Record(2), Record(3)));
+
+        var destination = new RecordedEvent[8];
+        var result = reader.ReadInto(destination);
+
+        Assert.Equal(3, result.Count);
+        Assert.Equal(0, result.FailedRecords);
+        Assert.False(result.Corrupted);
+        Assert.False(reader.HasPendingRecords);
+        Assert.Equal<uint>([1, 2, 3], PidsOf(destination, result.Count));
+    }
+
+    [Fact]
+    public void ReadInto_KeepsLeftoversForTheNextCall()
+    {
+        var reader = new EventBatchReader(new StubParser());
+        reader.SetBatch(EventBatchProtocolTests.BuildBatch(Record(1), Record(2), Record(3), Record(4)));
+
+        var destination = new RecordedEvent[2];
+
+        var first = reader.ReadInto(destination);
+        Assert.Equal(2, first.Count);
+        Assert.True(reader.HasPendingRecords);
+        Assert.Equal<uint>([1, 2], PidsOf(destination, first.Count));
+
+        var second = reader.ReadInto(destination);
+        Assert.Equal(2, second.Count);
+        Assert.Equal<uint>([3, 4], PidsOf(destination, second.Count));
+
+        Assert.True(reader.HasPendingRecords);
+        var third = reader.ReadInto(destination);
+        Assert.Equal(0, third.Count);
+        Assert.False(reader.HasPendingRecords);
+    }
+
+    [Fact]
+    public void ReadInto_SkipsUnparsableRecordsAndKeepsGoing()
+    {
+        var reader = new EventBatchReader(new StubParser());
+        reader.SetBatch(EventBatchProtocolTests.BuildBatch(
+            Record(1),
+            Record(StubParser.UnparsableMarker),
+            Record(2)));
+
+        var destination = new RecordedEvent[8];
+        var result = reader.ReadInto(destination);
+
+        Assert.Equal(2, result.Count);
+        Assert.Equal(1, result.FailedRecords);
+        Assert.IsType<InvalidOperationException>(result.LastFailure);
+        Assert.False(result.Corrupted);
+        Assert.False(reader.HasPendingRecords);
+        Assert.Equal<uint>([1, 2], PidsOf(destination, result.Count));
+    }
+
+    [Fact]
+    public void ReadInto_ReportsAnUnparsableBatchWithoutLosingItsPosition()
+    {
+        var reader = new EventBatchReader(new StubParser());
+        reader.SetBatch(EventBatchProtocolTests.BuildBatch(
+            Record(StubParser.UnparsableMarker),
+            Record(StubParser.UnparsableMarker)));
+
+        var destination = new RecordedEvent[8];
+        var result = reader.ReadInto(destination);
+
+        Assert.Equal(0, result.Count);
+        Assert.Equal(2, result.FailedRecords);
+        Assert.False(reader.HasPendingRecords);
+    }
+
+    [Fact]
+    public void ReadInto_AbandonsTheBatchOnBrokenFraming()
+    {
+        var reader = new EventBatchReader(new StubParser());
+        var batch = EventBatchProtocolTests.BuildBatch(Record(1), Record(2));
+        BinaryPrimitives.WriteInt32LittleEndian(batch.AsSpan(EventBatchProtocol.RecordHeaderSize + sizeof(uint)), 1024);
+        reader.SetBatch(batch);
+
+        var destination = new RecordedEvent[8];
+        var result = reader.ReadInto(destination);
+
+        Assert.Equal(1, result.Count);
+        Assert.True(result.Corrupted);
+        Assert.False(reader.HasPendingRecords);
+        Assert.Equal<uint>([1], PidsOf(destination, result.Count));
+    }
+
+    [Fact]
+    public void ReadInto_ReturnsNothingWhenNoBatchIsSet()
+    {
+        var reader = new EventBatchReader(new StubParser());
+
+        var result = reader.ReadInto(new RecordedEvent[8]);
+
+        Assert.Equal(0, result.Count);
+        Assert.False(reader.HasPendingRecords);
+    }
+
+    [Fact]
+    public void Reset_AbandonsThePendingBatch()
+    {
+        var reader = new EventBatchReader(new StubParser());
+        reader.SetBatch(EventBatchProtocolTests.BuildBatch(Record(1), Record(2)));
+
+        Assert.Equal(1, reader.ReadInto(new RecordedEvent[1]).Count);
+        Assert.True(reader.HasPendingRecords);
+
+        reader.Reset();
+
+        Assert.False(reader.HasPendingRecords);
+        Assert.Equal(0, reader.ReadInto(new RecordedEvent[8]).Count);
+    }
+}

--- a/src/Tests/SharpDetect.Core.Tests/Communication/EventBatchReaderTests.cs
+++ b/src/Tests/SharpDetect.Core.Tests/Communication/EventBatchReaderTests.cs
@@ -12,6 +12,9 @@ namespace SharpDetect.Core.Tests.Communication;
 
 public class EventBatchReaderTests
 {
+    private const uint ReceiverPid = 4242;
+    private const int MsgPackRecordSize = sizeof(byte) + sizeof(uint);
+
     private sealed class StubParser : IRecordedEventParser
     {
         public const uint UnparsableMarker = uint.MaxValue;
@@ -27,8 +30,17 @@ public class EventBatchReaderTests
 
     private static byte[] Record(uint value)
     {
-        var record = new byte[sizeof(uint)];
-        BinaryPrimitives.WriteUInt32LittleEndian(record, value);
+        var record = new byte[MsgPackRecordSize];
+        record[0] = FixedEventFormat.MsgPackFormat;
+        BinaryPrimitives.WriteUInt32LittleEndian(record.AsSpan(sizeof(byte)), value);
+        return record;
+    }
+
+    private static byte[] FixedMethodEnterRecord(ulong threadId)
+    {
+        var record = new byte[sizeof(byte) + FixedEventFormat.HeaderSize];
+        record[0] = (byte)RecordedEventType.MethodEnter;
+        BinaryPrimitives.WriteUInt64LittleEndian(record.AsSpan(sizeof(byte)), threadId);
         return record;
     }
 
@@ -44,7 +56,7 @@ public class EventBatchReaderTests
     [Fact]
     public void ReadInto_ReadsWholeBatchWhenDestinationIsLargeEnough()
     {
-        var reader = new EventBatchReader(new StubParser());
+        var reader = new EventBatchReader(new StubParser(), ReceiverPid);
         reader.SetBatch(EventBatchProtocolTests.BuildBatch(Record(1), Record(2), Record(3)));
 
         var destination = new RecordedEvent[8];
@@ -60,7 +72,7 @@ public class EventBatchReaderTests
     [Fact]
     public void ReadInto_KeepsLeftoversForTheNextCall()
     {
-        var reader = new EventBatchReader(new StubParser());
+        var reader = new EventBatchReader(new StubParser(), ReceiverPid);
         reader.SetBatch(EventBatchProtocolTests.BuildBatch(Record(1), Record(2), Record(3), Record(4)));
 
         var destination = new RecordedEvent[2];
@@ -83,7 +95,7 @@ public class EventBatchReaderTests
     [Fact]
     public void ReadInto_SkipsUnparsableRecordsAndKeepsGoing()
     {
-        var reader = new EventBatchReader(new StubParser());
+        var reader = new EventBatchReader(new StubParser(), ReceiverPid);
         reader.SetBatch(EventBatchProtocolTests.BuildBatch(
             Record(1),
             Record(StubParser.UnparsableMarker),
@@ -103,7 +115,7 @@ public class EventBatchReaderTests
     [Fact]
     public void ReadInto_ReportsAnUnparsableBatchWithoutLosingItsPosition()
     {
-        var reader = new EventBatchReader(new StubParser());
+        var reader = new EventBatchReader(new StubParser(), ReceiverPid);
         reader.SetBatch(EventBatchProtocolTests.BuildBatch(
             Record(StubParser.UnparsableMarker),
             Record(StubParser.UnparsableMarker)));
@@ -119,9 +131,10 @@ public class EventBatchReaderTests
     [Fact]
     public void ReadInto_AbandonsTheBatchOnBrokenFraming()
     {
-        var reader = new EventBatchReader(new StubParser());
+        var reader = new EventBatchReader(new StubParser(), ReceiverPid);
         var batch = EventBatchProtocolTests.BuildBatch(Record(1), Record(2));
-        BinaryPrimitives.WriteInt32LittleEndian(batch.AsSpan(EventBatchProtocol.RecordHeaderSize + sizeof(uint)), 1024);
+        BinaryPrimitives.WriteInt32LittleEndian(
+            batch.AsSpan(EventBatchProtocol.RecordHeaderSize + MsgPackRecordSize), 1024);
         reader.SetBatch(batch);
 
         var destination = new RecordedEvent[8];
@@ -134,9 +147,50 @@ public class EventBatchReaderTests
     }
 
     [Fact]
+    public void ReadInto_DecodesFixedLayoutRecordsAndSuppliesTheReceiverPid()
+    {
+        var reader = new EventBatchReader(new StubParser(), ReceiverPid);
+        reader.SetBatch(EventBatchProtocolTests.BuildBatch(
+            FixedMethodEnterRecord(0x1122334455667788),
+            Record(1),
+            FixedMethodEnterRecord(7)));
+
+        var destination = new RecordedEvent[8];
+        var result = reader.ReadInto(destination);
+
+        Assert.Equal(3, result.Count);
+        Assert.Equal(0, result.FailedRecords);
+        Assert.False(result.Corrupted);
+
+        Assert.Equal<uint>([ReceiverPid, 1, ReceiverPid], PidsOf(destination, result.Count));
+        Assert.IsType<MethodEnterRecordedEvent>(destination[0].EventArgs);
+        Assert.Equal(new ThreadId(unchecked((nuint)0x1122334455667788)), destination[0].Metadata.Tid);
+        Assert.IsType<ProfilerDestroyRecordedEvent>(destination[1].EventArgs);
+        Assert.Equal(new ThreadId(7), destination[2].Metadata.Tid);
+    }
+
+    [Fact]
+    public void ReadInto_SkipsMalformedFixedLayoutRecordsAndKeepsGoing()
+    {
+        var reader = new EventBatchReader(new StubParser(), ReceiverPid);
+        var truncated = FixedMethodEnterRecord(1)[..^1];
+        reader.SetBatch(EventBatchProtocolTests.BuildBatch(truncated, Record(2)));
+
+        var destination = new RecordedEvent[8];
+        var result = reader.ReadInto(destination);
+
+        Assert.Equal(1, result.Count);
+        Assert.Equal(1, result.FailedRecords);
+        Assert.IsType<InvalidDataException>(result.LastFailure);
+        Assert.False(result.Corrupted);
+        Assert.False(reader.HasPendingRecords);
+        Assert.Equal<uint>([2], PidsOf(destination, result.Count));
+    }
+
+    [Fact]
     public void ReadInto_ReturnsNothingWhenNoBatchIsSet()
     {
-        var reader = new EventBatchReader(new StubParser());
+        var reader = new EventBatchReader(new StubParser(), ReceiverPid);
 
         var result = reader.ReadInto(new RecordedEvent[8]);
 
@@ -147,7 +201,7 @@ public class EventBatchReaderTests
     [Fact]
     public void Reset_AbandonsThePendingBatch()
     {
-        var reader = new EventBatchReader(new StubParser());
+        var reader = new EventBatchReader(new StubParser(), ReceiverPid);
         reader.SetBatch(EventBatchProtocolTests.BuildBatch(Record(1), Record(2)));
 
         Assert.Equal(1, reader.ReadInto(new RecordedEvent[1]).Count);

--- a/src/Tools/SharpDetect.Benchmarks/Measurements/RunValidation.cs
+++ b/src/Tools/SharpDetect.Benchmarks/Measurements/RunValidation.cs
@@ -46,8 +46,8 @@ internal static class RunValidation
             violations.Add("target wall time was not measured (0)");
         if (run.Metrics.TargetWallSeconds > run.WallSeconds + WallToleranceSeconds)
             violations.Add($"target wall ({run.Metrics.TargetWallSeconds:F4} s) exceeds the whole analysis wall ({run.WallSeconds:F4} s)");
-        if (run.Metrics.ProcessTailSeconds <= 0)
-            violations.Add("process tail was not measured (0)");
+        if (run.Metrics.ProcessTailSeconds < 0)
+            violations.Add($"process tail is negative ({run.Metrics.ProcessTailSeconds:F4} s)");
         if (run.TargetResources.CpuSeconds <= 0)
             violations.Add($"instrumented target CPU is {run.TargetResources.CpuSeconds:F4} s");
         if (run.ReportedIssues != 0)


### PR DESCRIPTION
This PR reduces per-event overhead across the profiler, IPC and worker. There are the following key changes:

- **Batching**: profiler can send events in batches instead of paying the inter-process communication price per event.
- **Fixed layout**: the vast majority of events (>95%) are method enter/exit hooks that spent a lot of time resolving formatters. Instead of this - the layout is now hardcoded both in native and managed code.

Based on perf workload, on my machine I observed the following improvements:
- Average events throughput increased from 1.83M/s -> 4.4M/s