### PR TITLE
Performance: Emit fewer instrumentation events

### DIFF
--- a/src/Extensibility/SharpDetect.Plugins.Descriptors/Methods/ConcurrentDictionaryMethodDescriptors.cs
+++ b/src/Extensibility/SharpDetect.Plugins.Descriptors/Methods/ConcurrentDictionaryMethodDescriptors.cs
@@ -52,7 +52,8 @@ public static class ConcurrentDictionaryMethodDescriptors
                 Arguments: [ValueArg],
                 ReturnValue: null,
                 MethodEnterInterpretation: (ushort)RecordedEventType.ValuePublicationStore,
-                MethodExitInterpretation: null));
+                MethodExitInterpretation: null,
+                EmitExitEvent: false));
 
         SetItem = new MethodDescriptor(
             MethodName: "set_Item",
@@ -69,7 +70,8 @@ public static class ConcurrentDictionaryMethodDescriptors
                 Arguments: [ValueArg],
                 ReturnValue: null,
                 MethodEnterInterpretation: (ushort)RecordedEventType.ValuePublicationStore,
-                MethodExitInterpretation: null));
+                MethodExitInterpretation: null,
+                EmitExitEvent: false));
 
         GetItem = new MethodDescriptor(
             MethodName: "get_Item",
@@ -175,7 +177,8 @@ public static class ConcurrentDictionaryMethodDescriptors
                 Arguments: [ValueArg],
                 ReturnValue: null,
                 MethodEnterInterpretation: (ushort)RecordedEventType.ValuePublicationStore,
-                MethodExitInterpretation: null));
+                MethodExitInterpretation: null,
+                EmitExitEvent: false));
 
         AddOrUpdateValue = new MethodDescriptor(
             MethodName: "AddOrUpdate",

--- a/src/Extensibility/SharpDetect.Plugins.Descriptors/Methods/SemaphoreSlimMethodDescriptors.cs
+++ b/src/Extensibility/SharpDetect.Plugins.Descriptors/Methods/SemaphoreSlimMethodDescriptors.cs
@@ -56,7 +56,8 @@ public static class SemaphoreSlimMethodDescriptors
                 Arguments: [ObjectRefArg, InitialCountArg, MaximumCountArg],
                 ReturnValue: null,
                 MethodEnterInterpretation: (ushort)RecordedEventType.SemaphoreCreate,
-                MethodExitInterpretation: null));
+                MethodExitInterpretation: null,
+                EmitExitEvent: false));
 
         WaitV8 = new MethodDescriptor(
             MethodName: "Wait",

--- a/src/Extensibility/SharpDetect.Plugins.Descriptors/Methods/TaskMethodDescriptors.cs
+++ b/src/Extensibility/SharpDetect.Plugins.Descriptors/Methods/TaskMethodDescriptors.cs
@@ -49,7 +49,8 @@ public static class TaskMethodDescriptors
                 Arguments: [ObjectRefArg],
                 ReturnValue: null,
                 MethodEnterInterpretation: (ushort)RecordedEventType.TaskSchedule,
-                MethodExitInterpretation: null));
+                MethodExitInterpretation: null,
+                EmitExitEvent: false));
 
         TaskInnerInvoke = CreateInnerInvokeMethodDescriptorForType(TaskTypeName);
 

--- a/src/Extensibility/SharpDetect.Plugins.Descriptors/Methods/ThreadMethodDescriptors.cs
+++ b/src/Extensibility/SharpDetect.Plugins.Descriptors/Methods/ThreadMethodDescriptors.cs
@@ -50,7 +50,8 @@ public static class ThreadMethodDescriptors
                 Arguments: [ new(0, new((byte)nint.Size, CapturedValue.CaptureAsReference)) ],
                 ReturnValue: null,
                 MethodEnterInterpretation: (ushort)RecordedEventType.ThreadStartCallback,
-                MethodExitInterpretation: null));
+                MethodExitInterpretation: null,
+                EmitExitEvent: false));
         
         ThreadStartCore = new MethodDescriptor(
             MethodName: "StartCore",
@@ -67,7 +68,8 @@ public static class ThreadMethodDescriptors
                 Arguments: [ new(0, new((byte)nint.Size, CapturedValue.CaptureAsReference)) ],
                 ReturnValue: null,
                 MethodEnterInterpretation: (ushort)RecordedEventType.ThreadStartCore,
-                MethodExitInterpretation: null));
+                MethodExitInterpretation: null,
+                EmitExitEvent: false));
     }
 
     public static IEnumerable<MethodDescriptor> GetAllMethods()

--- a/src/Extensibility/SharpDetect.Plugins.Descriptors/Methods/WaitHandleMethodDescriptors.cs
+++ b/src/Extensibility/SharpDetect.Plugins.Descriptors/Methods/WaitHandleMethodDescriptors.cs
@@ -127,7 +127,8 @@ public static class WaitHandleMethodDescriptors
                 Arguments: [ObjectRefArg],
                 ReturnValue: null,
                 MethodEnterInterpretation: (ushort)RecordedEventType.MutexCreate,
-                MethodExitInterpretation: null));
+                MethodExitInterpretation: null,
+                EmitExitEvent: false));
 
         MutexCtor = new MethodDescriptor(
             MethodName: ".ctor",
@@ -147,7 +148,8 @@ public static class WaitHandleMethodDescriptors
                 Arguments: [ObjectRefArg],
                 ReturnValue: null,
                 MethodEnterInterpretation: (ushort)RecordedEventType.MutexCreate,
-                MethodExitInterpretation: null));
+                MethodExitInterpretation: null,
+                EmitExitEvent: false));
 
         MutexRelease = new MethodDescriptor(
             MethodName: "ReleaseMutex",
@@ -185,7 +187,8 @@ public static class WaitHandleMethodDescriptors
                 Arguments: [ObjectRefArg, InitialCountArg, MaximumCountArg],
                 ReturnValue: null,
                 MethodEnterInterpretation: (ushort)RecordedEventType.SemaphoreCreate,
-                MethodExitInterpretation: null));
+                MethodExitInterpretation: null,
+                EmitExitEvent: false));
 
         SemaphoreReleaseCore = new MethodDescriptor(
             MethodName: "ReleaseCore",
@@ -223,7 +226,8 @@ public static class WaitHandleMethodDescriptors
                 Arguments: [ObjectRefArg, InitialStateArg],
                 ReturnValue: null,
                 MethodEnterInterpretation: (ushort)RecordedEventType.EventWaitHandleCreate,
-                MethodExitInterpretation: null));
+                MethodExitInterpretation: null,
+                EmitExitEvent: false));
 
         AutoResetEventCtor = new MethodDescriptor(
             MethodName: ".ctor",
@@ -243,7 +247,8 @@ public static class WaitHandleMethodDescriptors
                 Arguments: [ObjectRefArg, InitialStateArg],
                 ReturnValue: null,
                 MethodEnterInterpretation: (ushort)RecordedEventType.AutoResetEventCreate,
-                MethodExitInterpretation: null));
+                MethodExitInterpretation: null,
+                EmitExitEvent: false));
 
         ManualResetEventCtor = new MethodDescriptor(
             MethodName: ".ctor",
@@ -263,7 +268,8 @@ public static class WaitHandleMethodDescriptors
                 Arguments: [ObjectRefArg, InitialStateArg],
                 ReturnValue: null,
                 MethodEnterInterpretation: (ushort)RecordedEventType.ManualResetEventCreate,
-                MethodExitInterpretation: null));
+                MethodExitInterpretation: null,
+                EmitExitEvent: false));
 
         EventWaitHandleSet = new MethodDescriptor(
             MethodName: "Set",
@@ -358,7 +364,8 @@ public static class WaitHandleMethodDescriptors
                 Arguments: [ObjectRefArg],
                 ReturnValue: null,
                 MethodEnterInterpretation: (ushort)RecordedEventType.AbandonedMutexExceptionCreate,
-                MethodExitInterpretation: null));
+                MethodExitInterpretation: null,
+                EmitExitEvent: false));
 
         AbandonedMutexExceptionCtorWithHandle = new MethodDescriptor(
             MethodName: ".ctor",
@@ -379,7 +386,8 @@ public static class WaitHandleMethodDescriptors
                 Arguments: [ObjectRefArg, AbandonedMutexHandleArg],
                 ReturnValue: null,
                 MethodEnterInterpretation: (ushort)RecordedEventType.AbandonedMutexExceptionCreate,
-                MethodExitInterpretation: null));
+                MethodExitInterpretation: null,
+                EmitExitEvent: false));
     }
 
     public static IEnumerable<MethodDescriptor> GetAllMethods()

--- a/src/SharpDetect.Profiler/LibIL/Instrumentation.cpp
+++ b/src/SharpDetect.Profiler/LibIL/Instrumentation.cpp
@@ -26,6 +26,22 @@ static bool ShouldSkipInstrumentation(
 	return false;
 }
 
+static bool ShouldSkipFieldAccessInstrumentation(
+	IN const LibProfiler::ModuleDef& moduleDef,
+	IN const ILInstr& instruction,
+	IN const mdToken fieldToken)
+{
+	BOOL isVolatile;
+	if (FAILED(LibProfiler::IsVolatile(instruction, &isVolatile)) || isVolatile)
+		return false;
+
+	BOOL isExcluded;
+	if (FAILED(LibProfiler::IsFieldExcludedFromRaceAnalysis(moduleDef, fieldToken, &isExcluded)))
+		return false;
+
+	return isExcluded;
+}
+
 static bool ShouldCaptureFieldStack(
 	IN const LibProfiler::ModuleDef& moduleDef,
 	IN mdToken fieldToken,
@@ -105,12 +121,16 @@ HRESULT LibProfiler::PatchMethodBody(
 
 		if (enableFieldsAccessInstrumentation)
 		{
+			auto const fieldToken = static_cast<mdToken>(currentInstruction->m_Arg32);
 			if (ShouldSkipInstrumentation(moduleDef, skipInstrumentationForAssemblies))
 				continue;
 
 			// Static field access
 			if (currentInstruction->m_opcode == CEE_LDSFLD || currentInstruction->m_opcode == CEE_STSFLD)
 			{
+				if (ShouldSkipFieldAccessInstrumentation(moduleDef, *currentInstruction, fieldToken))
+					continue;
+
 				auto const mark = instrumentationMark.fetch_add(1);
 				ILInstr* nextInstruction = nullptr;
 
@@ -134,6 +154,9 @@ HRESULT LibProfiler::PatchMethodBody(
 			// Instance field access
 			if (currentInstruction->m_opcode == CEE_LDFLD || currentInstruction->m_opcode == CEE_STFLD)
 			{
+				if (ShouldSkipFieldAccessInstrumentation(moduleDef, *currentInstruction, fieldToken))
+					continue;
+
 				// Import local variable signature if not done yet
 				if (!importedLocals)
 				{

--- a/src/SharpDetect.Profiler/LibIL/MetadataAnalysis.cpp
+++ b/src/SharpDetect.Profiler/LibIL/MetadataAnalysis.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "MetadataAnalysis.h"
+#include "WString.h"
 
 HRESULT LibProfiler::IsVolatile(
 	IN const ILInstr& instruction,
@@ -9,4 +10,32 @@ HRESULT LibProfiler::IsVolatile(
 {
 	*isVolatile = instruction.m_pPrev != nullptr && instruction.m_pPrev->m_opcode == CEE_VOLATILE;
 	return S_OK;
+}
+
+HRESULT LibProfiler::IsFieldExcludedFromRaceAnalysis(
+	IN const ModuleDef& moduleDef,
+	IN const mdToken fieldToken,
+	OUT BOOL* isExcluded)
+{
+	*isExcluded = FALSE;
+
+	// A member reference cannot be resolved to its definition without crossing module boundaries
+	if (TypeFromToken(fieldToken) != mdtFieldDef)
+		return S_OK;
+
+	DWORD attributes;
+	HRESULT hr = moduleDef.GetFieldAttributes(fieldToken, &attributes);
+	if (FAILED(hr))
+		return hr;
+
+	if (IsFdInitOnly(attributes) || IsFdLiteral(attributes))
+	{
+		*isExcluded = TRUE;
+		return S_OK;
+	}
+	
+	if (!IsFdStatic(attributes))
+		return S_OK;
+
+	return moduleDef.HasCustomAttribute(fieldToken, WSTR("System.ThreadStaticAttribute"), isExcluded);
 }

--- a/src/SharpDetect.Profiler/LibIL/MetadataAnalysis.h
+++ b/src/SharpDetect.Profiler/LibIL/MetadataAnalysis.h
@@ -5,10 +5,16 @@
 
 #include "cor.h"
 #include "ILRewriter.h"
+#include "ModuleDef.h"
 
 namespace LibProfiler
 {
 	HRESULT IsVolatile(
 		IN const ILInstr& instruction,
 		OUT BOOL* isVolatile);
+
+	HRESULT IsFieldExcludedFromRaceAnalysis(
+		IN const ModuleDef& moduleDef,
+		IN mdToken fieldToken,
+		OUT BOOL* isExcluded);
 }

--- a/src/SharpDetect.Profiler/LibMetadata/ModuleDef.cpp
+++ b/src/SharpDetect.Profiler/LibMetadata/ModuleDef.cpp
@@ -407,6 +407,42 @@ HRESULT LibProfiler::ModuleDef::GetFieldProps(
 	return S_OK;
 }
 
+HRESULT LibProfiler::ModuleDef::GetFieldAttributes(
+	IN const mdFieldDef fieldDef,
+	OUT DWORD* attributes) const
+{
+	auto& metadataImport = GetMetadataImport();
+	return metadataImport.GetFieldProps(
+		fieldDef,
+		nullptr,
+		nullptr,
+		0,
+		nullptr,
+		attributes,
+		nullptr,
+		nullptr,
+		nullptr,
+		nullptr,
+		nullptr);
+}
+
+HRESULT LibProfiler::ModuleDef::HasCustomAttribute(
+	IN const mdToken token,
+	IN const WCHAR* attributeFullName,
+	OUT BOOL* hasAttribute) const
+{
+	auto& metadataImport = GetMetadataImport();
+	const void* attributeData = nullptr;
+	ULONG attributeDataLength = 0;
+
+	HRESULT hr = metadataImport.GetCustomAttributeByName(token, attributeFullName, &attributeData, &attributeDataLength);
+	if (FAILED(hr))
+		return hr;
+
+	*hasAttribute = (hr == S_OK);
+	return S_OK;
+}
+
 HRESULT LibProfiler::ModuleDef::GetFieldRefProps(
 	IN const mdToken fieldMemberRef,
 	OUT mdToken* parent,

--- a/src/SharpDetect.Profiler/LibMetadata/ModuleDef.h
+++ b/src/SharpDetect.Profiler/LibMetadata/ModuleDef.h
@@ -135,6 +135,15 @@ namespace LibProfiler
 			OUT PCCOR_SIGNATURE* fieldSignature,
 			OUT ULONG* fieldSignatureLength) const;
 
+		HRESULT GetFieldAttributes(
+			IN mdFieldDef fieldDef,
+			OUT DWORD* attributes) const;
+
+		HRESULT HasCustomAttribute(
+			IN mdToken token,
+			IN const WCHAR* attributeFullName,
+			OUT BOOL* hasAttribute) const;
+
 		HRESULT GetFieldRefProps(
 			IN mdToken fieldMemberRef,
 			OUT mdToken* parent,


### PR DESCRIPTION
This PR adds the following changes:

- **Drop unused method exit hooks**: profiler still needed to inject ELT hooks and send data that was discarded.
- **Skip instrumentation for some fields that cannot race**: readonly fields and thread static fields.

Note that on PerfWorkload, the amount of emitted events is ~ 11% lower.