### PR TITLE
DataRace: Publish lazy values from the factory path

### DIFF
--- a/src/Extensibility/SharpDetect.Plugins.DataRace.FastTrack/FastTrackDetector.cs
+++ b/src/Extensibility/SharpDetect.Plugins.DataRace.FastTrack/FastTrackDetector.cs
@@ -28,11 +28,20 @@ internal sealed class FastTrackDetector
     private readonly Dictionary<FieldId, VectorClock> _staticVolatileClocks = [];
     private readonly Dictionary<ProcessTrackedObjectId, Dictionary<FieldId, VectorClock>> _instanceVolatileClocks = [];
     private readonly Dictionary<PublicationSlot, VectorClock> _publicationClocks = [];
+    private readonly Dictionary<PublicationSlot, PendingObservation> _publicationObservers = [];
+    private readonly LinkedList<PublicationSlot> _pendingObservationOrder = new();
     private readonly Dictionary<ProcessTrackedObjectId, HashSet<PublicationSlot>> _publicationSlotsByParticipant = [];
     private readonly Dictionary<ProcessTrackedObjectId, ObjectEscapeState> _escapeStates = [];
+    internal const int MaxPendingPublicationObservations = 1024;
     private readonly record struct ObjectEscapeState(ProcessThreadId Instantiator, bool Escaped);
     private readonly record struct PublicationSlot(ProcessTrackedObjectId Container, ProcessTrackedObjectId Value);
-    
+
+    private sealed class PendingObservation
+    {
+        public readonly HashSet<ProcessThreadId> Observers = [];
+        public LinkedListNode<PublicationSlot>? OrderNode;
+    }
+
     public FastTrackDetector(
         FastTrackPluginConfiguration configuration,
         IMetadataContext metadataContext,
@@ -51,6 +60,7 @@ internal sealed class FastTrackDetector
     public int GetTrackedThreadCount() => _threadClocks.Count;
     public int GetTrackedPublicationCount() => _publicationClocks.Count;
     internal int GetIndexedPublicationParticipantCount() => _publicationSlotsByParticipant.Count;
+    internal int GetPublicationObserverEntryCount() => _publicationObservers.Count;
 
     public void RecordThreadCreated(ProcessThreadId threadId)
     {
@@ -90,7 +100,7 @@ internal sealed class FastTrackDetector
 
     private void RemoveCollectedPublicationSlots(uint processId, ReadOnlySpan<TrackedObjectId> removedObjectIds)
     {
-        if (_publicationClocks.Count == 0)
+        if (_publicationClocks.Count == 0 && _publicationObservers.Count == 0)
             return;
 
         foreach (var objectId in removedObjectIds)
@@ -102,6 +112,7 @@ internal sealed class FastTrackDetector
             foreach (var slot in slots)
             {
                 _publicationClocks.Remove(slot);
+                RemovePendingObservation(slot);
                 UnindexPublicationSlot(slot.Container == participant ? slot.Value : slot.Container, participant, slot);
             }
         }
@@ -123,11 +134,16 @@ internal sealed class FastTrackDetector
         ProcessTrackedObjectId collectedParticipant,
         PublicationSlot slot)
     {
-        if (participant == collectedParticipant ||
-            !_publicationSlotsByParticipant.TryGetValue(participant, out var slots))
-        {
+        if (participant == collectedParticipant)
             return;
-        }
+
+        UnindexPublicationSlot(participant, slot);
+    }
+
+    private void UnindexPublicationSlot(ProcessTrackedObjectId participant, PublicationSlot slot)
+    {
+        if (!_publicationSlotsByParticipant.TryGetValue(participant, out var slots))
+            return;
 
         slots.Remove(slot);
         if (slots.Count == 0)
@@ -337,12 +353,14 @@ internal sealed class FastTrackDetector
         }
         else
         {
-            _publicationClocks[slot] = threadVc.Clone();
+            publicationVc = threadVc.Clone();
+            _publicationClocks[slot] = publicationVc;
             IndexPublicationSlot(containerId, slot);
             if (containerId != valueId)
                 IndexPublicationSlot(valueId, slot);
         }
 
+        ReleasePendingObservers(slot, publicationVc, threadId);
         threadVc.Increment(threadId);
     }
 
@@ -351,11 +369,83 @@ internal sealed class FastTrackDetector
         ProcessTrackedObjectId containerId,
         ProcessTrackedObjectId valueId)
     {
-        if (!_publicationClocks.TryGetValue(new PublicationSlot(containerId, valueId), out var publicationVc))
+        var slot = new PublicationSlot(containerId, valueId);
+        if (!_publicationClocks.TryGetValue(slot, out var publicationVc))
+        {
+            RecordPendingObserver(slot, containerId, valueId, threadId);
             return;
+        }
 
         var threadVc = GetOrCreateThreadClock(threadId);
         threadVc.Join(publicationVc);
+    }
+
+    private void RecordPendingObserver(
+        PublicationSlot slot,
+        ProcessTrackedObjectId containerId,
+        ProcessTrackedObjectId valueId,
+        ProcessThreadId threadId)
+    {
+        if (!_publicationObservers.TryGetValue(slot, out var pending))
+        {
+            pending = new PendingObservation { OrderNode = _pendingObservationOrder.AddLast(slot) };
+            _publicationObservers[slot] = pending;
+
+            IndexPublicationSlot(containerId, slot);
+            if (containerId != valueId)
+                IndexPublicationSlot(valueId, slot);
+
+            EvictOldestPendingObservations();
+        }
+
+        pending.Observers.Add(threadId);
+    }
+
+    private void ReleasePendingObservers(
+        PublicationSlot slot,
+        VectorClock publicationVc,
+        ProcessThreadId publisherThreadId)
+    {
+        if (RemovePendingObservation(slot) is not { } pending)
+            return;
+
+        foreach (var observerThreadId in pending.Observers)
+        {
+            if (observerThreadId != publisherThreadId)
+                GetOrCreateThreadClock(observerThreadId).Join(publicationVc);
+        }
+    }
+
+    private PendingObservation? RemovePendingObservation(PublicationSlot slot)
+    {
+        if (!_publicationObservers.Remove(slot, out var pending))
+            return null;
+
+        if (pending.OrderNode is { } node)
+        {
+            _pendingObservationOrder.Remove(node);
+            pending.OrderNode = null;
+        }
+
+        return pending;
+    }
+
+    private void EvictOldestPendingObservations()
+    {
+        while (_publicationObservers.Count > MaxPendingPublicationObservations &&
+               _pendingObservationOrder.First is { } oldest)
+        {
+            var slot = oldest.Value;
+            if (RemovePendingObservation(slot) is null)
+            {
+                _pendingObservationOrder.Remove(oldest);
+                continue;
+            }
+
+            UnindexPublicationSlot(slot.Container, slot);
+            if (slot.Container != slot.Value)
+                UnindexPublicationSlot(slot.Value, slot);
+        }
     }
 
     public DataRaceInfo? RecordRead(

--- a/src/Extensibility/SharpDetect.Plugins.Descriptors/Methods/LazyMethodDescriptors.cs
+++ b/src/Extensibility/SharpDetect.Plugins.Descriptors/Methods/LazyMethodDescriptors.cs
@@ -13,12 +13,40 @@ public static class LazyMethodDescriptors
     private static readonly CapturedArgumentDescriptor ContainerArg =
         new(0, new((byte)nint.Size, CapturedValue.CaptureAsReference));
 
+    private static readonly CapturedArgumentDescriptor ValueArg =
+        new(1, new((byte)nint.Size, CapturedValue.CaptureAsReference));
+
     private static readonly MethodDescriptor GetValue;
+    private static readonly MethodDescriptor CreateValue;
+    private static readonly MethodDescriptor ValueConstructor;
 
     static LazyMethodDescriptors()
     {
-        GetValue = new MethodDescriptor(
-            MethodName: "get_Value",
+        CreateValue = CreateDescriptor("CreateValue", RecordedEventType.ValuePublicationMaybeStoreLoad);
+        GetValue = CreateDescriptor("get_Value", RecordedEventType.ValuePublicationLoad);
+        ValueConstructor = new MethodDescriptor(
+            MethodName: ".ctor",
+            DeclaringTypeFullName: LazyTypeName,
+            VersionDescriptor: null,
+            SignatureDescriptor: new MethodSignatureDescriptor(
+                CallingConvention: CorCallingConvention.IMAGE_CEE_CS_CALLCONV_HASTHIS,
+                ParametersCount: 1,
+                ReturnType: ArgumentTypeDescriptor.CreateSimple(CorElementType.ELEMENT_TYPE_VOID),
+                ArgumentTypeElements: [ArgumentTypeDescriptor.CreateGenericTypeParam(0)]),
+            RewritingDescriptor: new MethodRewritingDescriptor(
+                InjectHooks: true,
+                InjectManagedWrapper: false,
+                Arguments: [ContainerArg, ValueArg],
+                ReturnValue: null,
+                MethodEnterInterpretation: (ushort)RecordedEventType.ValuePublicationStore,
+                MethodExitInterpretation: null,
+                EmitExitEvent: false));
+    }
+
+    private static MethodDescriptor CreateDescriptor(string methodName, RecordedEventType exitInterpretation)
+    {
+        return new MethodDescriptor(
+            MethodName: methodName,
             DeclaringTypeFullName: LazyTypeName,
             VersionDescriptor: null,
             SignatureDescriptor: new MethodSignatureDescriptor(
@@ -32,11 +60,13 @@ public static class LazyMethodDescriptors
                 Arguments: [ContainerArg],
                 ReturnValue: new CapturedValueDescriptor((byte)nint.Size, CapturedValue.CaptureAsReference),
                 MethodEnterInterpretation: (ushort)RecordedEventType.ValuePublicationContainerEnter,
-                MethodExitInterpretation: (ushort)RecordedEventType.ValuePublicationMaybeStoreLoad));
+                MethodExitInterpretation: (ushort)exitInterpretation));
     }
 
     public static IEnumerable<MethodDescriptor> GetAllMethods()
     {
+        yield return ValueConstructor;
+        yield return CreateValue;
         yield return GetValue;
     }
 }

--- a/src/Tests/SharpDetect.E2ETests.Subject/Entrypoint.cs
+++ b/src/Tests/SharpDetect.E2ETests.Subject/Entrypoint.cs
@@ -195,6 +195,9 @@ namespace SharpDetect.E2ETests.Subject
                 case nameof(Test_LazyMethods_GetValue):
                     Test_LazyMethods_GetValue();
                     break;
+                case nameof(Test_LazyMethods_ValueConstructor):
+                    Test_LazyMethods_ValueConstructor();
+                    break;
                 case nameof(Test_ConcurrentDictionaryMethods_Store):
                     Test_ConcurrentDictionaryMethods_Store();
                     break;

--- a/src/Tests/SharpDetect.E2ETests.Subject/SimpleTests.cs
+++ b/src/Tests/SharpDetect.E2ETests.Subject/SimpleTests.cs
@@ -1640,6 +1640,12 @@ namespace SharpDetect.E2ETests.Subject
             _ = lazy.Value;
         }
 
+        public static void Test_LazyMethods_ValueConstructor()
+        {
+            var lazy = new Lazy<object>(new object());
+            _ = lazy.Value;
+        }
+
         private const int PublicationSpinLimit = 2000;
 
         public static void Test_NoDataRace_ConcurrentDictionaryLockFreeReaderObservesPublication()

--- a/src/Tests/SharpDetect.E2ETests/MethodInterpretationTests.cs
+++ b/src/Tests/SharpDetect.E2ETests/MethodInterpretationTests.cs
@@ -453,21 +453,65 @@ public class MethodInterpretationTests(ITestOutputHelper testOutput)
         var events = new TestEventsEnumerable(plugin);
         var assert = EventuallyMethodEnter(args.Target.Args!, plugin)
             .Then(EventuallyEventType(RecordedEventType.ValuePublicationMaybeStoreLoad))
-            .Then(EventuallyEventType(RecordedEventType.ValuePublicationMaybeStoreLoad))
+            .Then(EventuallyEventType(RecordedEventType.ValuePublicationLoad))
+            .Then(EventuallyEventType(RecordedEventType.ValuePublicationLoad))
             .Then(EventuallyMethodExit(args.Target.Args!, plugin));
 
         // Act && Assert
         await analysisWorker.ExecuteAsync(CancellationToken.None);
         Assert.True(AssertStatus.Satisfied == assert.Evaluate(events), assert.GetDiagnosticInfo());
-        var publications = events
-            .Where(e => e.Type == RecordedEventType.ValuePublicationMaybeStoreLoad)
+        var stores = ValuePublications(events, RecordedEventType.ValuePublicationMaybeStoreLoad);
+        Assert.Single(stores);
+        var lazyContainer = stores[0].Container;
+        var loads = ValuePublications(events, RecordedEventType.ValuePublicationLoad)
+            .Where(load => load.Container == lazyContainer)
+            .ToList();
+        Assert.True(loads.Count >= 2);
+        var publications = stores.Concat(loads).ToList();
+        var publishedValues = publications.Select(publication => publication.Value).Distinct().ToList();
+        Assert.True(publishedValues.Count == 1);
+        AssertPublishedThroughASingleContainer(publications);
+    }
+
+    [Theory]
+    [MemberData(nameof(SdkVersions.All), MemberType = typeof(SdkVersions))]
+    public async Task MethodInterpretation_Lazy_ValueConstructor(string sdk)
+    {
+        // Arrange
+        using var services = E2ETestBuilder
+            .ForSubject("Test_LazyMethods_ValueConstructor")
+            .WithPlugin<TestPerThreadOrderingPlugin>()
+            .Build(sdk, testOutput);
+        var args = services.GetRequiredService<RunCommandArgs>();
+        var plugin = services.GetRequiredService<TestPerThreadOrderingPlugin>();
+        var analysisWorker = services.GetRequiredService<IAnalysisWorker>();
+        var events = new TestEventsEnumerable(plugin);
+        var assert = EventuallyMethodEnter(args.Target.Args!, plugin)
+            .Then(EventuallyEventType(RecordedEventType.ValuePublicationStore))
+            .Then(EventuallyEventType(RecordedEventType.ValuePublicationLoad))
+            .Then(EventuallyMethodExit(args.Target.Args!, plugin));
+
+        // Act & Assert
+        await analysisWorker.ExecuteAsync(CancellationToken.None);
+        Assert.True(AssertStatus.Satisfied == assert.Evaluate(events), assert.GetDiagnosticInfo());
+        var stores = ValuePublications(events, RecordedEventType.ValuePublicationStore);
+        Assert.Single(stores);
+        var loads = ValuePublications(events, RecordedEventType.ValuePublicationLoad)
+            .Where(load => load.Container == stores[0].Container)
+            .ToList();
+        Assert.NotEmpty(loads);
+        Assert.Empty(ValuePublications(events, RecordedEventType.ValuePublicationMaybeStoreLoad));
+        Assert.All(loads, load => Assert.Equal(stores[0].Value, load.Value));
+    }
+
+    private static List<ValuePublicationArgs> ValuePublications(
+        TestEventsEnumerable events,
+        RecordedEventType type)
+    {
+        return events
+            .Where(e => e.Type == type)
             .Select(e => e.Get<(RecordedEventMetadata Metadata, ValuePublicationArgs Args)>().Args)
             .ToList();
-        var publishedValues = publications.Select(args => args.Value).ToList();
-        Assert.True(
-            publishedValues.GroupBy(value => value).Any(group => group.Count() >= 2),
-            $"Expected a value published by both accesses, observed {publishedValues.Count} publication(s).");
-        AssertPublishedThroughASingleContainer(publications);
     }
 
     [Theory]

--- a/src/Tests/SharpDetect.Plugins.DataRace.FastTrack.Tests/ValuePublicationReportingOrderTests.cs
+++ b/src/Tests/SharpDetect.Plugins.DataRace.FastTrack.Tests/ValuePublicationReportingOrderTests.cs
@@ -1,0 +1,169 @@
+// Copyright 2026 Andrej Čižmárik and Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+using SharpDetect.Plugins.DataRace.FastTrack.Tests.Fakes;
+using Xunit;
+
+namespace SharpDetect.Plugins.DataRace.FastTrack.Tests;
+
+public class ValuePublicationReportingOrderTests
+{
+    private readonly DetectorHarness _harness = new();
+
+    [Fact]
+    public void ObserverSeenBeforeThePublisher_IsStillOrderedAfterThePublication()
+    {
+        // Arrange
+        var publisher = _harness.NewThread();
+        var observer = _harness.NewThread();
+        var container = _harness.NewObject();
+        var value = _harness.NewObject();
+        var field = _harness.NewInstanceField("State");
+
+        // Act
+        _harness.Write(publisher, field, value);
+        _harness.Detector.RecordValueObserved(observer, container, value);
+        _harness.Detector.RecordValuePublished(publisher, container, value, onlyIfAbsent: true);
+
+        // Assert
+        Assert.False(_harness.ReadIsRace(observer, field, value));
+    }
+
+    [Fact]
+    public void ObserverSeenAfterThePublisher_IsOrderedAfterThePublication()
+    {
+        // Arrange
+        var publisher = _harness.NewThread();
+        var observer = _harness.NewThread();
+        var container = _harness.NewObject();
+        var value = _harness.NewObject();
+        var field = _harness.NewInstanceField("State");
+
+        // Act
+        _harness.Write(publisher, field, value);
+        _harness.Detector.RecordValuePublished(publisher, container, value, onlyIfAbsent: true);
+        _harness.Detector.RecordValueObserved(observer, container, value);
+
+        // Assert
+        Assert.False(_harness.ReadIsRace(observer, field, value));
+    }
+
+    [Fact]
+    public void ObserverSeenBeforeThePublisher_IsNotOrderedAgainstPostPublicationWork()
+    {
+        // Arrange
+        var publisher = _harness.NewThread();
+        var observer = _harness.NewThread();
+        var container = _harness.NewObject();
+        var value = _harness.NewObject();
+        var field = _harness.NewInstanceField("State");
+
+        // Act
+        _harness.Detector.RecordValueObserved(observer, container, value);
+        _harness.Detector.RecordValuePublished(publisher, container, value, onlyIfAbsent: true);
+        _harness.Write(publisher, field, value);
+
+        // Assert
+        Assert.True(_harness.ReadIsRace(observer, field, value));
+    }
+
+    [Fact]
+    public void ObserverOfADifferentContainer_IsNotOrderedByALaterPublication()
+    {
+        // Arrange
+        var publisher = _harness.NewThread();
+        var observer = _harness.NewThread();
+        var container = _harness.NewObject();
+        var unrelatedContainer = _harness.NewObject();
+        var value = _harness.NewObject();
+        var field = _harness.NewInstanceField("State");
+
+        // Act
+        _harness.Write(publisher, field, value);
+        _harness.Detector.RecordValueObserved(observer, unrelatedContainer, value);
+        _harness.Detector.RecordValuePublished(publisher, container, value, onlyIfAbsent: true);
+
+        // Assert
+        Assert.True(_harness.ReadIsRace(observer, field, value));
+    }
+
+    [Fact]
+    public void PendingObservers_DoNotCarryEachOthersWork()
+    {
+        // Arrange
+        var publisher = _harness.NewThread();
+        var mutator = _harness.NewThread();
+        var observer = _harness.NewThread();
+        var container = _harness.NewObject();
+        var value = _harness.NewObject();
+        var unrelated = _harness.NewObject();
+        var field = _harness.NewInstanceField("State");
+
+        // Act
+        _harness.Write(mutator, field, unrelated);
+        _harness.Detector.RecordValueObserved(mutator, container, value);
+        _harness.Detector.RecordValueObserved(observer, container, value);
+        _harness.Detector.RecordValuePublished(publisher, container, value, onlyIfAbsent: true);
+
+        // Assert
+        Assert.True(_harness.ReadIsRace(observer, field, unrelated));
+    }
+
+    [Fact]
+    public void PendingObservations_AreBounded()
+    {
+        // Arrange
+        var observer = _harness.NewThread();
+
+        // Act
+        for (var i = 0; i < FastTrackDetector.MaxPendingPublicationObservations * 2; i++)
+            _harness.Detector.RecordValueObserved(observer, _harness.NewObject(), _harness.NewObject());
+
+        // Assert
+        Assert.Equal(
+            FastTrackDetector.MaxPendingPublicationObservations,
+            _harness.Detector.GetPublicationObserverEntryCount());
+        Assert.Equal(
+            FastTrackDetector.MaxPendingPublicationObservations * 2,
+            _harness.Detector.GetIndexedPublicationParticipantCount());
+    }
+
+    [Fact]
+    public void EvictedObservation_NoLongerOrdersItsObserverAfterALaterPublication()
+    {
+        // Arrange
+        var publisher = _harness.NewThread();
+        var observer = _harness.NewThread();
+        var container = _harness.NewObject();
+        var value = _harness.NewObject();
+        var field = _harness.NewInstanceField("State");
+
+        // Act
+        _harness.Write(publisher, field, value);
+        _harness.Detector.RecordValueObserved(observer, container, value);
+        for (var i = 0; i <= FastTrackDetector.MaxPendingPublicationObservations; i++)
+            _harness.Detector.RecordValueObserved(observer, _harness.NewObject(), _harness.NewObject());
+
+        _harness.Detector.RecordValuePublished(publisher, container, value, onlyIfAbsent: true);
+
+        // Assert
+        Assert.True(_harness.ReadIsRace(observer, field, value));
+    }
+
+    [Fact]
+    public void CollectedValue_ReleasesThePendingObserversRecordedForItsSlots()
+    {
+        // Arrange
+        var observer = _harness.NewThread();
+        var container = _harness.NewObject();
+        var value = _harness.NewObject();
+
+        // Act
+        _harness.Detector.RecordValueObserved(observer, container, value);
+        _harness.CollectObjects(value);
+
+        // Assert
+        Assert.Equal(0, _harness.Detector.GetPublicationObserverEntryCount());
+        Assert.Equal(0, _harness.Detector.GetIndexedPublicationParticipantCount());
+    }
+}


### PR DESCRIPTION
This PR fixes false positives on `Lazy<T>` publication.

**Descriptors**
- Added hook for `Lazy<T>.CreateValue` - the actual publisher when factory is supplied