### PR TITLE
Extensibility: Model happens-before across TaskCompletionSource completion

### DIFF
--- a/src/Extensibility/SharpDetect.Plugins.DataRace.FastTrack/FastTrackPlugin.cs
+++ b/src/Extensibility/SharpDetect.Plugins.DataRace.FastTrack/FastTrackPlugin.cs
@@ -114,6 +114,7 @@ public partial class FastTrackPlugin : PerThreadOrderingPluginBase, IPlugin
         TaskStarted += OnTaskStarted;
         TaskCompleted += OnTaskCompleted;
         TaskJoinFinished += OnTaskJoinFinished;
+        TaskPromiseCompleted += OnTaskPromiseCompleted;
         SemaphoreCreated += OnSemaphoreCreated;
         SemaphoreAcquireReturned += OnSemaphoreAcquireReturned;
         SemaphoreReleased += OnSemaphoreReleased;
@@ -269,6 +270,11 @@ public partial class FastTrackPlugin : PerThreadOrderingPluginBase, IPlugin
     {
         if (args.IsSuccess)
             _detector.RecordTaskJoinFinished(args.ProcessThreadId, args.TaskObjectId);
+    }
+
+    private void OnTaskPromiseCompleted(TaskPromiseCompleteArgs args)
+    {
+        _detector.RecordTaskCompleted(args.ProcessThreadId, args.TaskObjectId);
     }
 
     private void OnSemaphoreCreated(SemaphoreCreatedArgs args)

--- a/src/Extensibility/SharpDetect.Plugins.Descriptors/Methods/TaskMethodDescriptors.cs
+++ b/src/Extensibility/SharpDetect.Plugins.Descriptors/Methods/TaskMethodDescriptors.cs
@@ -31,6 +31,11 @@ public static class TaskMethodDescriptors
     private static readonly MethodDescriptor TaskWait;
     private static readonly MethodDescriptor TaskResult;
     private static readonly MethodDescriptor TaskAwaiterValidateEnd;
+    private static readonly MethodDescriptor TaskTResultTrySetResult;
+    private static readonly MethodDescriptor TaskTrySetResult;
+    private static readonly MethodDescriptor TaskTrySetException;
+    private static readonly MethodDescriptor TaskTrySetCanceled;
+    private static readonly MethodDescriptor TaskTrySetCanceledWithException;
 
     static TaskMethodDescriptors()
     {
@@ -122,6 +127,54 @@ public static class TaskMethodDescriptors
                 ReturnValue: null,
                 MethodEnterInterpretation: (ushort)RecordedEventType.TaskJoinStart,
                 MethodExitInterpretation: (ushort)RecordedEventType.TaskJoinFinish));
+
+        TaskTResultTrySetResult = CreatePromiseCompletionMethodDescriptor(
+            TaskTResultTypeName,
+            "TrySetResult",
+            ArgumentTypeDescriptor.CreateGenericTypeParam(0));
+
+        TaskTrySetResult = CreatePromiseCompletionMethodDescriptor(
+            TaskTypeName,
+            "TrySetResult");
+
+        TaskTrySetException = CreatePromiseCompletionMethodDescriptor(
+            TaskTypeName,
+            "TrySetException",
+            ArgumentTypeDescriptor.CreateSimple(CorElementType.ELEMENT_TYPE_OBJECT));
+
+        TaskTrySetCanceled = CreatePromiseCompletionMethodDescriptor(
+            TaskTypeName,
+            "TrySetCanceled",
+            ArgumentTypeDescriptor.CreateValueType(CancellationTokenTypeName));
+
+        TaskTrySetCanceledWithException = CreatePromiseCompletionMethodDescriptor(
+            TaskTypeName,
+            "TrySetCanceled",
+            ArgumentTypeDescriptor.CreateValueType(CancellationTokenTypeName),
+            ArgumentTypeDescriptor.CreateSimple(CorElementType.ELEMENT_TYPE_OBJECT));
+    }
+
+    private static MethodDescriptor CreatePromiseCompletionMethodDescriptor(
+        string typeName,
+        string methodName,
+        params ArgumentTypeDescriptor[] parameters)
+    {
+        return new MethodDescriptor(
+            MethodName: methodName,
+            DeclaringTypeFullName: typeName,
+            VersionDescriptor: null,
+            SignatureDescriptor: new MethodSignatureDescriptor(
+                CallingConvention: CorCallingConvention.IMAGE_CEE_CS_CALLCONV_HASTHIS,
+                ParametersCount: (byte)parameters.Length,
+                ReturnType: ArgumentTypeDescriptor.CreateSimple(CorElementType.ELEMENT_TYPE_BOOLEAN),
+                ArgumentTypeElements: parameters),
+            RewritingDescriptor: new MethodRewritingDescriptor(
+                InjectHooks: true,
+                InjectManagedWrapper: false,
+                Arguments: [ObjectRefArg],
+                ReturnValue: new CapturedValueDescriptor(sizeof(bool), CapturedValue.CaptureAsValue),
+                MethodEnterInterpretation: (ushort)RecordedEventType.TaskPromiseComplete,
+                MethodExitInterpretation: (ushort)RecordedEventType.TaskPromiseCompleteResult));
     }
 
     private static MethodDescriptor CreateInnerInvokeMethodDescriptorForType(string typeName)
@@ -155,6 +208,11 @@ public static class TaskMethodDescriptors
         yield return ContinuationTaskFromResultTaskInnerInvoke;
         yield return ContinuationResultTaskFromResultTaskInnerInvoke;
         yield return TaskAwaiterValidateEnd;
+        yield return TaskTResultTrySetResult;
+        yield return TaskTrySetResult;
+        yield return TaskTrySetException;
+        yield return TaskTrySetCanceled;
+        yield return TaskTrySetCanceledWithException;
 
         // Common public API
         yield return TaskWait;

--- a/src/Extensibility/SharpDetect.Plugins.PerThreadOrdering/PerThreadOrderingPluginBase.Tasks.cs
+++ b/src/Extensibility/SharpDetect.Plugins.PerThreadOrdering/PerThreadOrderingPluginBase.Tasks.cs
@@ -14,6 +14,7 @@ public abstract partial class PerThreadOrderingPluginBase
     public event Action<TaskStartArgs>? TaskStarted;
     public event Action<TaskCompleteArgs>? TaskCompleted;
     public event Action<TaskJoinFinishArgs>? TaskJoinFinished;
+    public event Action<TaskPromiseCompleteArgs>? TaskPromiseCompleted;
 
     private void RegisterTaskBindings()
     {
@@ -23,6 +24,8 @@ public abstract partial class PerThreadOrderingPluginBase
         Bind<MethodEnterWithArgumentsRecordedEvent>(RecordedEventType.TaskJoinStart, OnTaskJoinStart);
         Bind<MethodExitRecordedEvent>(RecordedEventType.TaskJoinFinish, OnTaskJoinFinish);
         Bind<MethodExitWithArgumentsRecordedEvent>(RecordedEventType.TaskJoinFinish, OnTaskJoinFinishWithArguments);
+        Bind<MethodEnterWithArgumentsRecordedEvent>(RecordedEventType.TaskPromiseComplete, OnTaskPromiseComplete);
+        Bind<MethodExitWithArgumentsRecordedEvent>(RecordedEventType.TaskPromiseCompleteResult, OnTaskPromiseCompleteResult);
     }
 
     private void OnTaskSchedule(RecordedEventMetadata metadata, MethodEnterWithArgumentsRecordedEvent args)
@@ -84,6 +87,20 @@ public abstract partial class PerThreadOrderingPluginBase
         }
     }
 
+    private void OnTaskPromiseComplete(RecordedEventMetadata metadata, MethodEnterWithArgumentsRecordedEvent args)
+        => PushArgumentsOnCallStack(metadata, args);
+
+    private void OnTaskPromiseCompleteResult(RecordedEventMetadata metadata, MethodExitWithArgumentsRecordedEvent args)
+    {
+        var id = new ProcessThreadId(metadata.Pid, metadata.Tid);
+        using var frameLease = _callStackTracker.PopFrame(id, args.ModuleId, args.MethodToken);
+        if (!MemoryMarshal.Read<bool>(args.ReturnValue))
+            return;
+
+        var taskObjectId = new ProcessTrackedObjectId(id.ProcessId, frameLease.Frame.Arguments![0].Value.AsTrackedObject);
+        ProcessTaskPromiseComplete(id, taskObjectId);
+    }
+
     protected virtual void ProcessTaskSchedule(ProcessThreadId id, ProcessTrackedObjectId taskObjectId)
     {
         TaskScheduled?.Invoke(new TaskScheduleArgs(id, taskObjectId));
@@ -102,5 +119,13 @@ public abstract partial class PerThreadOrderingPluginBase
     protected virtual void ProcessTaskJoinFinish(ProcessThreadId id, ProcessTrackedObjectId taskObjectId, bool isSuccess)
     {
         TaskJoinFinished?.Invoke(new TaskJoinFinishArgs(id, taskObjectId, isSuccess));
+    }
+
+    protected virtual void ProcessTaskPromiseComplete(ProcessThreadId id, ProcessTrackedObjectId taskObjectId)
+    {
+        if (taskObjectId.ObjectId.Value == 0)
+            return;
+
+        TaskPromiseCompleted?.Invoke(new TaskPromiseCompleteArgs(id, taskObjectId));
     }
 }

--- a/src/Extensibility/SharpDetect.Plugins.PerThreadOrdering/PerThreadOrderingPluginBase.cs
+++ b/src/Extensibility/SharpDetect.Plugins.PerThreadOrdering/PerThreadOrderingPluginBase.cs
@@ -170,6 +170,12 @@ public abstract partial class PerThreadOrderingPluginBase : PluginBase
                 ProcessTaskJoinFinish(id, taskObjectId, isSuccess: false);
                 break;
             }
+
+            case RecordedEventType.TaskPromiseCompleteResult:
+            {
+                // Without the return value there is no way to tell a winning completer from a losing one
+                break;
+            }
         }
     }
 

--- a/src/SharpDetect.Core/Events/RecordedEventType.cs
+++ b/src/SharpDetect.Core/Events/RecordedEventType.cs
@@ -117,6 +117,8 @@ public enum RecordedEventType : ushort
     TaskComplete = 202,
     TaskJoinStart = 203,
     TaskJoinFinish = 204,
+    TaskPromiseComplete = 205,
+    TaskPromiseCompleteResult = 206,
 
     /* Value publication */
     ValuePublicationStore = 220,

--- a/src/SharpDetect.Core/Plugins/PluginEventArgs.cs
+++ b/src/SharpDetect.Core/Plugins/PluginEventArgs.cs
@@ -26,6 +26,7 @@ public readonly record struct TaskScheduleArgs(ProcessThreadId ProcessThreadId, 
 public readonly record struct TaskStartArgs(ProcessThreadId ProcessThreadId, ProcessTrackedObjectId TaskObjectId);
 public readonly record struct TaskCompleteArgs(ProcessThreadId ProcessThreadId, ProcessTrackedObjectId TaskObjectId);
 public readonly record struct TaskJoinFinishArgs(ProcessThreadId ProcessThreadId, ProcessTrackedObjectId TaskObjectId, bool IsSuccess);
+public readonly record struct TaskPromiseCompleteArgs(ProcessThreadId ProcessThreadId, ProcessTrackedObjectId TaskObjectId);
 public readonly record struct SemaphoreAcquireAttemptArgs(ProcessThreadId ProcessThreadId, ModuleId ModuleId, MdMethodDef MethodToken, ProcessTrackedObjectId SemaphoreId);
 public readonly record struct SemaphoreAcquireResultArgs(ProcessThreadId ProcessThreadId, ModuleId ModuleId, MdMethodDef MethodToken, ProcessTrackedObjectId SemaphoreId, bool IsSuccess);
 public readonly record struct SemaphoreReleaseArgs(ProcessThreadId ProcessThreadId, ModuleId ModuleId, MdMethodDef MethodToken, ProcessTrackedObjectId SemaphoreId, int ReleaseCount);

--- a/src/Tests/SharpDetect.E2ETests.Subject/Entrypoint.cs
+++ b/src/Tests/SharpDetect.E2ETests.Subject/Entrypoint.cs
@@ -207,6 +207,18 @@ namespace SharpDetect.E2ETests.Subject
                 case nameof(Test_ConcurrentDictionaryMethods_AddOrUpdate):
                     Test_ConcurrentDictionaryMethods_AddOrUpdate();
                     break;
+                case nameof(Test_TaskCompletionSource_TrySetResult):
+                    Test_TaskCompletionSource_TrySetResult();
+                    break;
+                case nameof(Test_TaskCompletionSource_TrySetResultNonGeneric):
+                    Test_TaskCompletionSource_TrySetResultNonGeneric();
+                    break;
+                case nameof(Test_TaskCompletionSource_TrySetException):
+                    Test_TaskCompletionSource_TrySetException();
+                    break;
+                case nameof(Test_TaskCompletionSource_TrySetCanceled):
+                    Test_TaskCompletionSource_TrySetCanceled();
+                    break;
             }
 
             // Field events
@@ -703,6 +715,12 @@ namespace SharpDetect.E2ETests.Subject
                     break;
                 case nameof(Test_NoDataRace_Task_SequentialTasks_WriteRead):
                     Test_NoDataRace_Task_SequentialTasks_WriteRead();
+                    break;
+                case nameof(Test_NoDataRace_TaskCompletionSource_WriteThenSetResult_ReadAfterAwait):
+                    Test_NoDataRace_TaskCompletionSource_WriteThenSetResult_ReadAfterAwait();
+                    break;
+                case nameof(Test_DataRace_TaskCompletionSource_PostCompletionWrite):
+                    Test_DataRace_TaskCompletionSource_PostCompletionWrite();
                     break;
                 case nameof(Test_NoDataRace_GenericType_Static_DifferentInstantiations_WriteWrite_NoRace):
                     Test_NoDataRace_GenericType_Static_DifferentInstantiations_WriteWrite_NoRace();

--- a/src/Tests/SharpDetect.E2ETests.Subject/Helpers/Concurrency.cs
+++ b/src/Tests/SharpDetect.E2ETests.Subject/Helpers/Concurrency.cs
@@ -13,6 +13,7 @@ namespace SharpDetect.E2ETests.Subject.Helpers.DataRaces
         public static int Test_DataRace_ValueType_StaticProperty { get; set; }
         public static volatile int Test_Volatile_ValueType_Static;
         public static volatile int Test_Volatile_ValueType_Static_Back;
+        public static int Test_TaskCompletionSource_ValueType_Static;
         public static int Test_Atomic_ValueType_Static;
         public static string? Test_Atomic_ReferenceType_Static;
         [ThreadStatic]

--- a/src/Tests/SharpDetect.E2ETests.Subject/SimpleTests.cs
+++ b/src/Tests/SharpDetect.E2ETests.Subject/SimpleTests.cs
@@ -1703,6 +1703,102 @@ namespace SharpDetect.E2ETests.Subject
             Task.Run(() => { _ = DataRace.Test_DataRace_ValueType_Static; }).Wait();
         }
 
+        public static void Test_TaskCompletionSource_TrySetResult()
+        {
+            var source = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            source.SetResult(true);
+            source.Task.Wait();
+        }
+
+        public static void Test_TaskCompletionSource_TrySetResultNonGeneric()
+        {
+            var source = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            source.SetResult();
+            source.Task.Wait();
+        }
+
+        public static void Test_TaskCompletionSource_TrySetException()
+        {
+            var source = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            source.SetException(new InvalidOperationException());
+            AwaitFaultedTask(source.Task);
+        }
+
+        public static void Test_TaskCompletionSource_TrySetCanceled()
+        {
+            var source = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            source.SetCanceled();
+            AwaitFaultedTask(source.Task);
+        }
+
+        private static void AwaitFaultedTask(Task task)
+        {
+            try
+            {
+                task.Wait();
+            }
+            catch (AggregateException)
+            {
+            
+            }
+        }
+
+        public static void Test_NoDataRace_TaskCompletionSource_WriteThenSetResult_ReadAfterAwait()
+        {
+            WarmUpThreadPool();
+
+            var source = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var reader = ReadAfterCompletionAsync(source.Task);
+
+            Task.Run(() =>
+            {
+                DataRace.Test_TaskCompletionSource_ValueType_Static = 42;
+                source.SetResult(true);
+            }).Wait();
+
+            reader.Wait();
+        }
+
+        private static void WarmUpThreadPool()
+        {
+            const int workers = 8;
+            using var barrier = new Barrier(workers + 1);
+            var tasks = new Task[workers];
+            for (var i = 0; i < workers; i++)
+                tasks[i] = Task.Run(() => barrier.SignalAndWait());
+
+            barrier.SignalAndWait();
+            Task.WaitAll(tasks);
+        }
+
+        private static async Task ReadAfterCompletionAsync(Task gate)
+        {
+            await gate.ConfigureAwait(false);
+            _ = DataRace.Test_TaskCompletionSource_ValueType_Static;
+        }
+
+        public static void Test_DataRace_TaskCompletionSource_PostCompletionWrite()
+        {
+            WarmUpThreadPool();
+
+            var source = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            using var bothReady = new Barrier(participantCount: 2);
+            var continuation = WriteAfterCompletionAsync(source.Task, bothReady, 1);
+
+            source.SetResult(true);
+            bothReady.SignalAndWait(WaitTimeout);
+            DataRace.Test_TaskCompletionSource_ValueType_Static = 2;
+
+            continuation.Wait();
+        }
+
+        private static async Task WriteAfterCompletionAsync(Task gate, Barrier bothReady, int value)
+        {
+            await gate.ConfigureAwait(false);
+            bothReady.SignalAndWait(WaitTimeout);
+            DataRace.Test_TaskCompletionSource_ValueType_Static = value;
+        }
+
         public static void Test_SemaphoreSlimMethods_WaitRelease1()
         {
             var sem = new SemaphoreSlim(1, 1);

--- a/src/Tests/SharpDetect.E2ETests/DataRacePluginTests.cs
+++ b/src/Tests/SharpDetect.E2ETests/DataRacePluginTests.cs
@@ -309,6 +309,16 @@ public class DataRacePluginTests(ITestOutputHelper testOutput)
 
     [Theory]
     [MemberData(nameof(SdkVersions.AllWithFastTrackOnly), MemberType = typeof(SdkVersions))]
+    public Task NoDataRace_TaskCompletionSource_WriteThenSetResult_ReadAfterAwait(string sdk, string plugin)
+        => AssertDoesNotDetectDataRace("Test_NoDataRace_TaskCompletionSource_WriteThenSetResult_ReadAfterAwait", sdk, plugin);
+
+    [Theory]
+    [MemberData(nameof(SdkVersions.AllWithFastTrackOnly), MemberType = typeof(SdkVersions))]
+    public Task CanDetectDataRace_TaskCompletionSource_PostCompletionWrite(string sdk, string plugin)
+        => AssertDetectsDataRace("Test_DataRace_TaskCompletionSource_PostCompletionWrite", sdk, plugin);
+
+    [Theory]
+    [MemberData(nameof(SdkVersions.AllWithFastTrackOnly), MemberType = typeof(SdkVersions))]
     public Task NoDataRace_SemaphoreSlim_ProtectedWriteRead(string sdk, string plugin)
         => AssertDoesNotDetectDataRace("Test_NoDataRace_SemaphoreSlim_ProtectedWriteRead", sdk, plugin);
 

--- a/src/Tests/SharpDetect.E2ETests/MethodInterpretationTests.cs
+++ b/src/Tests/SharpDetect.E2ETests/MethodInterpretationTests.cs
@@ -178,6 +178,48 @@ public class MethodInterpretationTests(ITestOutputHelper testOutput)
 
     [Theory]
     [MemberData(nameof(SdkVersions.All), MemberType = typeof(SdkVersions))]
+    public Task MethodInterpretation_TaskCompletionSource_TrySetResult(string sdk)
+        => AssertPromiseCompletionIsInterpreted("Test_TaskCompletionSource_TrySetResult", sdk);
+
+    [Theory]
+    [MemberData(nameof(SdkVersions.All), MemberType = typeof(SdkVersions))]
+    public Task MethodInterpretation_TaskCompletionSource_TrySetResultNonGeneric(string sdk)
+        => AssertPromiseCompletionIsInterpreted("Test_TaskCompletionSource_TrySetResultNonGeneric", sdk);
+
+    [Theory]
+    [MemberData(nameof(SdkVersions.All), MemberType = typeof(SdkVersions))]
+    public Task MethodInterpretation_TaskCompletionSource_TrySetException(string sdk)
+        => AssertPromiseCompletionIsInterpreted("Test_TaskCompletionSource_TrySetException", sdk);
+
+    [Theory]
+    [MemberData(nameof(SdkVersions.All), MemberType = typeof(SdkVersions))]
+    public Task MethodInterpretation_TaskCompletionSource_TrySetCanceled(string sdk)
+        => AssertPromiseCompletionIsInterpreted("Test_TaskCompletionSource_TrySetCanceled", sdk);
+
+    private async Task AssertPromiseCompletionIsInterpreted(string subject, string sdk)
+    {
+        // Arrange
+        using var services = E2ETestBuilder
+            .ForSubject(subject)
+            .WithPlugin<TestPerThreadOrderingPlugin>()
+            .Build(sdk, testOutput);
+        var args = services.GetRequiredService<RunCommandArgs>();
+        var plugin = services.GetRequiredService<TestPerThreadOrderingPlugin>();
+        var analysisWorker = services.GetRequiredService<IAnalysisWorker>();
+        var events = new TestEventsEnumerable(plugin);
+        var assert = EventuallyMethodEnter(args.Target.Args!, plugin)
+            .Then(EventuallyEventType(RecordedEventType.TaskPromiseCompleteResult))
+            .Then(EventuallyMethodExit(args.Target.Args!, plugin));
+
+        // Execute
+        await analysisWorker.ExecuteAsync(CancellationToken.None);
+
+        // Assert
+        Assert.True(AssertStatus.Satisfied == assert.Evaluate(events), assert.GetDiagnosticInfo());
+    }
+
+    [Theory]
+    [MemberData(nameof(SdkVersions.All), MemberType = typeof(SdkVersions))]
     public async Task MethodInterpretation_Task_InnerInvoke1(string sdk)
     {
         // Arrange

--- a/src/Tests/SharpDetect.E2ETests/TestEventsEnumerable.cs
+++ b/src/Tests/SharpDetect.E2ETests/TestEventsEnumerable.cs
@@ -111,6 +111,8 @@ public sealed class TestEventsEnumerable : IEnumerable<IEvent<ulong, RecordedEve
             => _queue.Enqueue(new Event<ulong, RecordedEventType, (RecordedEventMetadata, TaskCompleteArgs)>(GetNextId(), RecordedEventType.TaskComplete, (new RecordedEventMetadata(args.ProcessThreadId.ProcessId, args.ProcessThreadId.ThreadId), args)));
         pluginBase.TaskJoinFinished += args
             => _queue.Enqueue(new Event<ulong, RecordedEventType, (RecordedEventMetadata, TaskJoinFinishArgs)>(GetNextId(), RecordedEventType.TaskJoinFinish, (new RecordedEventMetadata(args.ProcessThreadId.ProcessId, args.ProcessThreadId.ThreadId), args)));
+        pluginBase.TaskPromiseCompleted += args
+            => _queue.Enqueue(new Event<ulong, RecordedEventType, (RecordedEventMetadata, TaskPromiseCompleteArgs)>(GetNextId(), RecordedEventType.TaskPromiseCompleteResult, (new RecordedEventMetadata(args.ProcessThreadId.ProcessId, args.ProcessThreadId.ThreadId), args)));
         pluginBase.SemaphoreAcquireAttempted += args
             => _queue.Enqueue(new Event<ulong, RecordedEventType, (RecordedEventMetadata, SemaphoreAcquireAttemptArgs)>(GetNextId(), RecordedEventType.SemaphoreAcquire, (new RecordedEventMetadata(args.ProcessThreadId.ProcessId, args.ProcessThreadId.ThreadId), args)));
         pluginBase.SemaphoreAcquireReturned += args

--- a/src/Tests/SharpDetect.Plugins.DataRace.FastTrack.Tests/TaskOrderingTests.cs
+++ b/src/Tests/SharpDetect.Plugins.DataRace.FastTrack.Tests/TaskOrderingTests.cs
@@ -128,4 +128,42 @@ public class TaskOrderingTests
         Assert.False(_harness.ReadIsRace(waiter, parentField, instance: null));
         Assert.True(_harness.ReadIsRace(waiter, bodyField, instance: null));
     }
+
+    [Fact]
+    public void CompletingPromise_OrdersTheCompleterBeforeEveryLaterJoiner()
+    {
+        // Arrange
+        var completer = _harness.NewThread();
+        var waiter = _harness.NewThread();
+        var promise = _harness.NewObject();
+        var field = _harness.NewStaticField("Shared");
+
+        // Act
+        _harness.Write(completer, field, instance: null);
+        _harness.Detector.RecordTaskCompleted(completer, promise);
+        _harness.Detector.RecordTaskJoinFinished(waiter, promise);
+
+        // Assert
+        Assert.False(_harness.ReadIsRace(waiter, field, instance: null));
+    }
+
+    [Fact]
+    public void RepeatedCompletion_ReplacesTheFirstCompletersRelease()
+    {
+        // Arrange
+        var winner = _harness.NewThread();
+        var loser = _harness.NewThread();
+        var waiter = _harness.NewThread();
+        var promise = _harness.NewObject();
+        var field = _harness.NewStaticField("Shared");
+
+        // Act
+        _harness.Write(winner, field, instance: null);
+        _harness.Detector.RecordTaskCompleted(winner, promise);
+        _harness.Detector.RecordTaskCompleted(loser, promise);
+        _harness.Detector.RecordTaskJoinFinished(waiter, promise);
+
+        // Assert
+        Assert.True(_harness.ReadIsRace(waiter, field, instance: null));
+    }
 }


### PR DESCRIPTION
This PR resolves gap for promises (acquire half already worked, we were missing writer for task clocks on promise task)