### PR TITLE
DataRace: Exempt writes to objects queued for finalization

### DIFF
--- a/src/Extensibility/SharpDetect.Plugins.DataRace.FastTrack/FastTrackDetector.cs
+++ b/src/Extensibility/SharpDetect.Plugins.DataRace.FastTrack/FastTrackDetector.cs
@@ -24,6 +24,7 @@ internal sealed class FastTrackDetector
     private readonly Dictionary<ProcessTrackedObjectId, Queue<VectorClock>> _semaphoreClocks = [];
     private readonly Dictionary<ProcessTrackedObjectId, VectorClock> _eventClocks = [];
     private readonly Dictionary<ProcessTrackedObjectId, VectorClock> _taskClocks = [];
+    private readonly HashSet<ProcessTrackedObjectId> _finalizationQueuedObjects = [];
     private readonly Dictionary<ProcessTrackedObjectId, VectorClock> _forkClocks = [];
     private readonly Dictionary<FieldId, VectorClock> _staticVolatileClocks = [];
     private readonly Dictionary<ProcessTrackedObjectId, Dictionary<FieldId, VectorClock>> _instanceVolatileClocks = [];
@@ -90,6 +91,7 @@ internal sealed class FastTrackDetector
             _semaphoreClocks.Remove(processObjectId);
             _eventClocks.Remove(processObjectId);
             _taskClocks.Remove(processObjectId);
+            _finalizationQueuedObjects.Remove(processObjectId);
             _forkClocks.Remove(processObjectId);
             _escapeStates.Remove(processObjectId);
             _instanceVolatileClocks.Remove(processObjectId);
@@ -171,6 +173,15 @@ internal sealed class FastTrackDetector
         joinerVc.Join(joinedVc);
         joinerVc.Increment(joinerThreadId);
     }
+
+    public void RecordFinalizationQueuedObjects(uint processId, ReadOnlySpan<TrackedObjectId> queuedObjectIds)
+    {
+        foreach (var objectId in queuedObjectIds)
+            _finalizationQueuedObjects.Add(new ProcessTrackedObjectId(processId, objectId));
+    }
+
+    private bool IsFinalizationQueued(ProcessTrackedObjectId? objectId)
+        => objectId is { } id && _finalizationQueuedObjects.Contains(id);
 
     public void RecordTaskScheduled(ProcessThreadId parentThreadId, ProcessTrackedObjectId taskId)
     {
@@ -489,7 +500,8 @@ internal sealed class FastTrackDetector
 
         _ = UpdateObjectPublicationState(threadId, objectId);
 
-        if (!shadow.WriteEpoch.IsNone &&
+        if (!IsFinalizationQueued(objectId) &&
+            !shadow.WriteEpoch.IsNone &&
             !shadow.WriteEpoch.HappensBefore(threadVc) &&
             shadow.LastWriteKind == WriteKind.Regular)
         {
@@ -537,8 +549,8 @@ internal sealed class FastTrackDetector
         var currentEpoch = threadVc.GetEpoch(threadId);
         var writeKind = ClassifyWrite(threadId, fieldDef!, objectId, stack);
 
-        var isInstantiationWrite = writeKind == WriteKind.Instantiation;
-        if (!isInstantiationWrite &&
+        var isExemptWrite = writeKind != WriteKind.Regular;
+        if (!isExemptWrite &&
             !shadow.WriteEpoch.IsNone &&
             shadow.WriteEpoch.ThreadId != threadId &&
             !shadow.WriteEpoch.HappensBefore(threadVc))
@@ -562,7 +574,7 @@ internal sealed class FastTrackDetector
             return null;
         }
 
-        var readWriteRace = isInstantiationWrite ? null : CheckReadWriteRace(threadId, shadow, threadVc);
+        var readWriteRace = isExemptWrite ? null : CheckReadWriteRace(threadId, shadow, threadVc);
         if (readWriteRace != null)
         {
             var hasLastAccess = _accessTracker.TryGetLastAccess(fieldId, objectId, out var lastAccess);
@@ -599,6 +611,9 @@ internal sealed class FastTrackDetector
         var processId = threadId.ProcessId;
         var declaringType = fieldDef.DeclaringType;
         var isInstantiatorExclusive = UpdateObjectPublicationState(threadId, objectId);
+
+        if (IsFinalizationQueued(objectId))
+            return WriteKind.Finalization;
 
         if (objectId == null)
         {

--- a/src/Extensibility/SharpDetect.Plugins.DataRace.FastTrack/FastTrackPlugin.cs
+++ b/src/Extensibility/SharpDetect.Plugins.DataRace.FastTrack/FastTrackPlugin.cs
@@ -390,6 +390,12 @@ public partial class FastTrackPlugin : PerThreadOrderingPluginBase, IPlugin
         base.Visit(metadata, args);
     }
 
+    protected override void Visit(RecordedEventMetadata metadata, FinalizationQueuedTrackedObjectsRecordedEvent args)
+    {
+        _detector.RecordFinalizationQueuedObjects(metadata.Pid, args.FinalizationQueuedTrackedObjectIds);
+        base.Visit(metadata, args);
+    }
+
     private void RecordDataRace(DataRaceInfo raceInfo)
     {
         _detectedRaces.Add(raceInfo);

--- a/src/Extensibility/SharpDetect.Plugins.DataRace.FastTrack/WriteKind.cs
+++ b/src/Extensibility/SharpDetect.Plugins.DataRace.FastTrack/WriteKind.cs
@@ -6,5 +6,6 @@ namespace SharpDetect.Plugins.DataRace.FastTrack;
 internal enum WriteKind
 {
     Regular,
-    Instantiation
+    Instantiation,
+    Finalization
 }

--- a/src/SharpDetect.Core/Events/IRecordedEventArgs.cs
+++ b/src/SharpDetect.Core/Events/IRecordedEventArgs.cs
@@ -15,6 +15,7 @@ namespace SharpDetect.Core.Events;
 [Union((int)RecordedEventType.JITCompilation, typeof(JitCompilationRecordedEvent))]
 [Union((int)RecordedEventType.GarbageCollectionStart, typeof(GarbageCollectionStartRecordedEvent))]
 [Union((int)RecordedEventType.GarbageCollectedTrackedObjects, typeof(GarbageCollectedTrackedObjectsRecordedEvent))]
+[Union((int)RecordedEventType.FinalizationQueuedTrackedObjects, typeof(FinalizationQueuedTrackedObjectsRecordedEvent))]
 [Union((int)RecordedEventType.GarbageCollectionFinish, typeof(GarbageCollectionFinishRecordedEvent))]
 [Union((int)RecordedEventType.ThreadCreate, typeof(ThreadCreateRecordedEvent))]
 [Union((int)RecordedEventType.ThreadRename, typeof(ThreadRenameRecordedEvent))]

--- a/src/SharpDetect.Core/Events/RecordedEventActionVisitorBase.cs
+++ b/src/SharpDetect.Core/Events/RecordedEventActionVisitorBase.cs
@@ -22,6 +22,7 @@ public abstract class RecordedEventActionVisitorBase
             case ThreadDestroyRecordedEvent threadDestroyArgs: Visit(metadata, threadDestroyArgs); break;
             case GarbageCollectionStartRecordedEvent gcStartedArgs: Visit(metadata, gcStartedArgs); break;
             case GarbageCollectedTrackedObjectsRecordedEvent gcTrackedObjectsArgs: Visit(metadata, gcTrackedObjectsArgs); break;
+            case FinalizationQueuedTrackedObjectsRecordedEvent finalizationQueuedArgs: Visit(metadata, finalizationQueuedArgs); break;
             case GarbageCollectionFinishRecordedEvent gcFinishedArgs: Visit(metadata, gcFinishedArgs); break;
             case MethodEnterRecordedEvent methodEnterArgs: Visit(metadata, methodEnterArgs); break;
             case MethodExitRecordedEvent methodExitArgs: Visit(metadata, methodExitArgs); break;
@@ -81,6 +82,9 @@ public abstract class RecordedEventActionVisitorBase
         => DefaultVisit(metadata, args);
 
     protected virtual void Visit(RecordedEventMetadata metadata, GarbageCollectedTrackedObjectsRecordedEvent args)
+        => DefaultVisit(metadata, args);
+
+    protected virtual void Visit(RecordedEventMetadata metadata, FinalizationQueuedTrackedObjectsRecordedEvent args)
         => DefaultVisit(metadata, args);
 
     protected virtual void Visit(RecordedEventMetadata metadata, GarbageCollectionFinishRecordedEvent args)

--- a/src/SharpDetect.Core/Events/RecordedEventType.cs
+++ b/src/SharpDetect.Core/Events/RecordedEventType.cs
@@ -32,7 +32,7 @@ public enum RecordedEventType : ushort
     GarbageCollectionStart = 20,
     GarbageCollectionFinish = 21,
     GarbageCollectedTrackedObjects = 22,
-    //Reserved = 23,
+    FinalizationQueuedTrackedObjects = 23,
 
     /* Metadata modifications */
     AssemblyReferenceInjection = 24,

--- a/src/SharpDetect.Core/Events/RecordedEvents.cs
+++ b/src/SharpDetect.Core/Events/RecordedEvents.cs
@@ -67,6 +67,10 @@ public sealed record GarbageCollectedTrackedObjectsRecordedEvent(
     [property: Key(0)] TrackedObjectId[] RemovedTrackedObjectIds) : IRecordedEventArgs;
 
 [MessagePackObject]
+public sealed record FinalizationQueuedTrackedObjectsRecordedEvent(
+    [property: Key(0)] TrackedObjectId[] FinalizationQueuedTrackedObjectIds) : IRecordedEventArgs;
+
+[MessagePackObject]
 public sealed record GarbageCollectionFinishRecordedEvent(
     [property: Key(0)] ulong OldTrackedObjectsCount,
     [property: Key(1)] ulong NewTrackedObjectsCount) : IRecordedEventArgs;

--- a/src/SharpDetect.Profiler/LibIPC/Messages.cpp
+++ b/src/SharpDetect.Profiler/LibIPC/Messages.cpp
@@ -76,6 +76,12 @@ GarbageCollectedTrackedObjectsMsg Helpers::CreateGarbageCollectedTrackedObjectsM
     return { std::move(metadataMsg), GarbageCollectedTrackedObjectsMsgArgsInstance(discriminator, GarbageCollectedTrackedObjectsMsgArgs(std::move(removedTrackedObjects)))};
 }
 
+FinalizationQueuedTrackedObjectsMsg Helpers::CreateFinalizationQueuedTrackedObjectsMsg(MetadataMsg&& metadataMsg, std::vector<UINT64>&& finalizationQueuedTrackedObjects)
+{
+    constexpr auto discriminator = static_cast<INT32>(RecordedEventType::FinalizationQueuedTrackedObjects);
+    return { std::move(metadataMsg), FinalizationQueuedTrackedObjectsMsgArgsInstance(discriminator, FinalizationQueuedTrackedObjectsMsgArgs(std::move(finalizationQueuedTrackedObjects)))};
+}
+
 GarbageCollectionFinishMsg Helpers::CreateGarbageCollectionFinishMsg(MetadataMsg&& metadataMsg, UINT64 oldTrackedObjectsCount, UINT64 newTrackedObjectsCount)
 {
     constexpr auto discriminator = static_cast<INT32>(RecordedEventType::GarbageCollectionFinish);

--- a/src/SharpDetect.Profiler/LibIPC/Messages.h
+++ b/src/SharpDetect.Profiler/LibIPC/Messages.h
@@ -48,7 +48,7 @@ namespace LibIPC
 		GarbageCollectionStart = 20,
 		GarbageCollectionFinish = 21,
 		GarbageCollectedTrackedObjects = 22,
-		//Reserved = 23,
+		FinalizationQueuedTrackedObjects = 23,
 
 		/* Metadata modifications */
 		AssemblyReferenceInjection = 24,
@@ -149,6 +149,10 @@ namespace LibIPC
 	using GarbageCollectedTrackedObjectsMsgArgs = msgpack::type::tuple<std::vector<UINT64>>;
 	using GarbageCollectedTrackedObjectsMsgArgsInstance = msgpack::type::tuple<INT32, GarbageCollectedTrackedObjectsMsgArgs>;
 	using GarbageCollectedTrackedObjectsMsg = msgpack::type::tuple<MetadataMsg, GarbageCollectedTrackedObjectsMsgArgsInstance>;
+
+	using FinalizationQueuedTrackedObjectsMsgArgs = msgpack::type::tuple<std::vector<UINT64>>;
+	using FinalizationQueuedTrackedObjectsMsgArgsInstance = msgpack::type::tuple<INT32, FinalizationQueuedTrackedObjectsMsgArgs>;
+	using FinalizationQueuedTrackedObjectsMsg = msgpack::type::tuple<MetadataMsg, FinalizationQueuedTrackedObjectsMsgArgsInstance>;
 
 	using GarbageCollectionFinishMsgArgs = msgpack::type::tuple<UINT64, UINT64>;
 	using GarbageCollectionFinishMsgArgsInstance = msgpack::type::tuple<INT32, GarbageCollectionFinishMsgArgs>;
@@ -256,6 +260,7 @@ namespace LibIPC
 		
 		GarbageCollectionStartMsg CreateGarbageCollectionStartMsg(MetadataMsg&& metadataMsg);
 		GarbageCollectedTrackedObjectsMsg CreateGarbageCollectedTrackedObjectsMsg(MetadataMsg&& metadataMsg, std::vector<UINT64>&& removedTrackedObjects);
+		FinalizationQueuedTrackedObjectsMsg CreateFinalizationQueuedTrackedObjectsMsg(MetadataMsg&& metadataMsg, std::vector<UINT64>&& finalizationQueuedTrackedObjects);
 		GarbageCollectionFinishMsg CreateGarbageCollectionFinishMsg(MetadataMsg&& metadataMsg, UINT64 oldTrackedObjectsCount, UINT64 newTrackedObjectsCount);
 		
 		ThreadCreateMsg CreateThreadCreateMsg(MetadataMsg&& metadataMsg, UINT64 threadId);

--- a/src/SharpDetect.Profiler/LibProfilerCore/ObjectsTracker.cpp
+++ b/src/SharpDetect.Profiler/LibProfilerCore/ObjectsTracker.cpp
@@ -100,6 +100,15 @@ namespace LibProfiler
         return newTrackedObjectId;
     }
 
+    std::optional<TrackedObjectId> ObjectsTracker::TryGetTrackedObject(ObjectID objectId) {
+        std::lock_guard<std::mutex> guard(_allocationMutex);
+        auto const it = _allocations.find(objectId);
+        if (it == _allocations.cend())
+            return std::nullopt;
+
+        return it->second;
+    }
+
     UINT ObjectsTracker::GetTrackedObjectsCount() {
         std::lock_guard<std::mutex> guard(_allocationMutex);
         return _allocations.size();

--- a/src/SharpDetect.Profiler/LibProfilerCore/ObjectsTracker.h
+++ b/src/SharpDetect.Profiler/LibProfilerCore/ObjectsTracker.h
@@ -28,6 +28,7 @@ namespace LibProfiler
 		void ProcessSurvivingReferences(std::span<ObjectID> starts, std::span<SIZE_T> lengths);
 		void ProcessMovingReferences(std::span<ObjectID> oldStarts, std::span<ObjectID> newStarts, std::span<SIZE_T> lengths);
 		[[nodiscard]] TrackedObjectId GetTrackedObject(ObjectID objectId);
+		[[nodiscard]] std::optional<TrackedObjectId> TryGetTrackedObject(ObjectID objectId);
 		[[nodiscard]] UINT GetTrackedObjectsCount();
 
 	private:

--- a/src/SharpDetect.Profiler/SharpDetect.Concurrency.Profiler/CorProfiler.cpp
+++ b/src/SharpDetect.Profiler/SharpDetect.Concurrency.Profiler/CorProfiler.cpp
@@ -280,8 +280,32 @@ HRESULT STDMETHODCALLTYPE Profiler::CorProfiler::GarbageCollectionStarted(
     return S_OK;
 }
 
+HRESULT STDMETHODCALLTYPE Profiler::CorProfiler::FinalizeableObjectQueued(const DWORD finalizerFlags, const ObjectID objectID)
+{
+    if (const auto trackedObjectId = _objectsTracker.TryGetTrackedObject(objectID))
+    {
+        auto guard = std::lock_guard(_finalizationQueuedMutex);
+        _finalizationQueuedTrackedObjects.push_back(*trackedObjectId);
+    }
+
+    return S_OK;
+}
+
 HRESULT STDMETHODCALLTYPE Profiler::CorProfiler::GarbageCollectionFinished()
 {
+    std::vector<UINT64> finalizationQueuedTrackedObjects;
+    {
+        auto guard = std::lock_guard(_finalizationQueuedMutex);
+        finalizationQueuedTrackedObjects.swap(_finalizationQueuedTrackedObjects);
+    }
+
+    if (!finalizationQueuedTrackedObjects.empty())
+    {
+        _client.SendPriority(LibIPC::Helpers::CreateFinalizationQueuedTrackedObjectsMsg(
+            CreateMetadataMsg(),
+            std::move(finalizationQueuedTrackedObjects)));
+    }
+
     const auto oldSize = _objectsTracker.GetTrackedObjectsCount();
     const auto gcContext = _objectsTracker.ProcessGarbageCollectionFinished();
     auto& nextTrackedObjectIds = gcContext.GetNextTrackedObjects();

--- a/src/SharpDetect.Profiler/SharpDetect.Concurrency.Profiler/CorProfiler.h
+++ b/src/SharpDetect.Profiler/SharpDetect.Concurrency.Profiler/CorProfiler.h
@@ -65,6 +65,7 @@ namespace Profiler
 
 		HRESULT STDMETHODCALLTYPE GarbageCollectionStarted(int cGenerations, BOOL generationCollected[], COR_PRF_GC_REASON reason) override;
 		HRESULT STDMETHODCALLTYPE GarbageCollectionFinished() override;
+		HRESULT STDMETHODCALLTYPE FinalizeableObjectQueued(DWORD finalizerFlags, ObjectID objectID) override;
 		HRESULT STDMETHODCALLTYPE JITCompilationStarted(FunctionID functionId, BOOL fIsSafeToBlock) override;
 		HRESULT STDMETHODCALLTYPE ModuleLoadFinished(ModuleID moduleId, HRESULT hrStatus) override;
 		HRESULT STDMETHODCALLTYPE MovedReferences2(ULONG cMovedObjectIDRanges, ObjectID oldObjectIDRangeStart[], ObjectID newObjectIDRangeStart[], SIZE_T cObjectIDRangeLength[]) override;
@@ -118,6 +119,8 @@ namespace Profiler
 
 		MetadataStore _metadataStore;
 		LibProfiler::ObjectsTracker _objectsTracker;
+		std::vector<UINT64> _finalizationQueuedTrackedObjects;
+		std::mutex _finalizationQueuedMutex;
 		MethodDescriptorRegistry _methodDescriptorRegistry;
 		std::vector<FieldAccessIntrinsicDescriptor> _fieldAccessIntrinsics;
 		RewriteRegistry _rewriteRegistry;

--- a/src/Tests/SharpDetect.E2ETests.Subject/Entrypoint.cs
+++ b/src/Tests/SharpDetect.E2ETests.Subject/Entrypoint.cs
@@ -581,6 +581,12 @@ namespace SharpDetect.E2ETests.Subject
                 case nameof(Test_DataRace_ValueType_Instance_WriteWriteRace):
                     Test_DataRace_ValueType_Instance_WriteWriteRace();
                     break;
+                case nameof(Test_NoDataRace_Finalizer_ClearsHandleWrittenInConstructor):
+                    Test_NoDataRace_Finalizer_ClearsHandleWrittenInConstructor();
+                    break;
+                case nameof(Test_DataRace_FinalizableObject_ConcurrentWrites):
+                    Test_DataRace_FinalizableObject_ConcurrentWrites();
+                    break;
                 case nameof(Test_DataRace_ReferenceType_Instance_SingleWriterWriteReadRace):
                     Test_DataRace_ReferenceType_Instance_SingleWriterWriteReadRace();
                     break;

--- a/src/Tests/SharpDetect.E2ETests.Subject/Helpers/Concurrency.cs
+++ b/src/Tests/SharpDetect.E2ETests.Subject/Helpers/Concurrency.cs
@@ -100,6 +100,21 @@ namespace SharpDetect.E2ETests.Subject.Helpers.DataRaces
         }
     }
 
+    public class NativeHandleOwner
+    {
+        public nint Handle;
+
+        public NativeHandleOwner(nint handle)
+        {
+            Handle = handle;
+        }
+
+        ~NativeHandleOwner()
+        {
+            Handle = 0;
+        }
+    }
+
     public class AsyncExecution
     {
         private const int SuspendMilliseconds = 50;

--- a/src/Tests/SharpDetect.E2ETests.Subject/SimpleTests.cs
+++ b/src/Tests/SharpDetect.E2ETests.Subject/SimpleTests.cs
@@ -1293,6 +1293,33 @@ namespace SharpDetect.E2ETests.Subject
                 () => instance.Test_DataRace_ValueType_InstanceField = 456);
         }
 
+        public static void Test_NoDataRace_Finalizer_ClearsHandleWrittenInConstructor()
+        {
+            AllocateAndDropHandleOwners();
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            GC.Collect();
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static void AllocateAndDropHandleOwners()
+        {
+            Task.Run(() =>
+            {
+                for (var i = 1; i <= 16; i++)
+                    _ = new NativeHandleOwner(i);
+            }).Wait();
+        }
+
+        public static void Test_DataRace_FinalizableObject_ConcurrentWrites()
+        {
+            var instance = new NativeHandleOwner(1);
+            RunConcurrently(
+                () => instance.Handle = 123,
+                () => instance.Handle = 456);
+            GC.KeepAlive(instance);
+        }
+
         public static void Test_DataRace_ReferenceType_Instance_SingleWriterWriteReadRace()
         {
             var instance = new DataRace();

--- a/src/Tests/SharpDetect.E2ETests/DataRacePluginTests.cs
+++ b/src/Tests/SharpDetect.E2ETests/DataRacePluginTests.cs
@@ -66,6 +66,16 @@ public class DataRacePluginTests(ITestOutputHelper testOutput)
 
     [Theory]
     [MemberData(nameof(SdkVersions.AllWithFastTrackOnly), MemberType = typeof(SdkVersions))]
+    public Task NoDataRace_Finalizer_ClearsHandleWrittenInConstructor(string sdk, string plugin)
+        => AssertDoesNotDetectDataRace("Test_NoDataRace_Finalizer_ClearsHandleWrittenInConstructor", sdk, plugin);
+
+    [Theory]
+    [MemberData(nameof(SdkVersions.AllWithFastTrackOnly), MemberType = typeof(SdkVersions))]
+    public Task CanDetectDataRace_FinalizableObject_ConcurrentWrites(string sdk, string plugin)
+        => AssertDetectsDataRace("Test_DataRace_FinalizableObject_ConcurrentWrites", sdk, plugin);
+
+    [Theory]
+    [MemberData(nameof(SdkVersions.AllWithFastTrackOnly), MemberType = typeof(SdkVersions))]
     public Task CanDetectDataRace_ReferenceType_Instance_SingleWriterWriteReadRace(string sdk, string plugin)
         => AssertDetectsDataRace("Test_DataRace_ReferenceType_Instance_SingleWriterWriteReadRace", sdk, plugin);
 

--- a/src/Tests/SharpDetect.Plugins.DataRace.FastTrack.Tests/Fakes/DetectorHarness.cs
+++ b/src/Tests/SharpDetect.Plugins.DataRace.FastTrack.Tests/Fakes/DetectorHarness.cs
@@ -73,6 +73,12 @@ internal sealed class DetectorHarness
     public void VolatileRead(ProcessThreadId thread, MdToken field, ProcessTrackedObjectId? instance)
         => Detector.RecordVolatileRead(thread, TestMetadata.ModuleId, field, instance);
 
+    public void QueueForFinalization(params ProcessTrackedObjectId[] objects)
+    {
+        var ids = objects.Select(o => o.ObjectId).ToArray();
+        Detector.RecordFinalizationQueuedObjects(TestMetadata.ProcessId, ids);
+    }
+
     public void CollectObjects(params ProcessTrackedObjectId[] objects)
     {
         var ids = objects.Select(o => o.ObjectId).ToArray();

--- a/src/Tests/SharpDetect.Plugins.DataRace.FastTrack.Tests/FinalizationOrderingTests.cs
+++ b/src/Tests/SharpDetect.Plugins.DataRace.FastTrack.Tests/FinalizationOrderingTests.cs
@@ -1,0 +1,134 @@
+// Copyright 2026 Andrej Čižmárik and Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+using SharpDetect.Plugins.DataRace.FastTrack.Tests.Fakes;
+using Xunit;
+
+namespace SharpDetect.Plugins.DataRace.FastTrack.Tests;
+
+public class FinalizationOrderingTests
+{
+    private readonly DetectorHarness _harness = new();
+
+    [Fact]
+    public void FinalizerWrite_AfterConstructorWriteOnAnotherThread_IsNotReported()
+    {
+        // Arrange
+        var owner = _harness.NewThread();
+        var finalizer = _harness.NewThread();
+        var instance = _harness.NewObject();
+        var field = _harness.NewInstanceField("Handle");
+
+        // Act
+        _harness.Write(owner, field, instance);
+        _harness.QueueForFinalization(instance);
+
+        // Assert
+        Assert.False(_harness.WriteIsRace(finalizer, field, instance));
+    }
+
+    [Fact]
+    public void FinalizerRead_AfterWriteOnAnotherThread_IsNotReported()
+    {
+        // Arrange
+        var owner = _harness.NewThread();
+        var finalizer = _harness.NewThread();
+        var instance = _harness.NewObject();
+        var field = _harness.NewInstanceField("Handle");
+
+        // Act
+        _harness.Write(owner, field, instance);
+        _harness.QueueForFinalization(instance);
+
+        // Assert
+        Assert.False(_harness.ReadIsRace(finalizer, field, instance));
+    }
+
+    [Fact]
+    public void FinalizerWrite_DoesNotLeaveAnEpochThatSuppressesLaterReaders()
+    {
+        // Arrange
+        var owner = _harness.NewThread();
+        var finalizer = _harness.NewThread();
+        var reader = _harness.NewThread();
+        var instance = _harness.NewObject();
+        var field = _harness.NewInstanceField("Handle");
+
+        // Act
+        _harness.Write(owner, field, instance);
+        _harness.QueueForFinalization(instance);
+        _harness.Write(finalizer, field, instance);
+
+        // Assert
+        Assert.False(_harness.ReadIsRace(reader, field, instance));
+    }
+
+    [Fact]
+    public void WriteBeforeTheObjectIsQueued_IsReported()
+    {
+        // Arrange
+        var owner = _harness.NewThread();
+        var other = _harness.NewThread();
+        var instance = _harness.NewObject();
+        var field = _harness.NewInstanceField("Handle");
+
+        // Act
+        _harness.Write(owner, field, instance);
+
+        // Assert
+        Assert.True(_harness.WriteIsRace(other, field, instance));
+    }
+
+    [Fact]
+    public void QueueingOneObject_DoesNotExemptAnother()
+    {
+        // Arrange
+        var owner = _harness.NewThread();
+        var finalizer = _harness.NewThread();
+        var queued = _harness.NewObject();
+        var live = _harness.NewObject();
+        var field = _harness.NewInstanceField("Handle");
+
+        // Act
+        _harness.Write(owner, field, live);
+        _harness.QueueForFinalization(queued);
+
+        // Assert
+        Assert.True(_harness.WriteIsRace(finalizer, field, live));
+    }
+
+    [Fact]
+    public void QueueingAnObject_DoesNotExemptStaticFields()
+    {
+        // Arrange
+        var owner = _harness.NewThread();
+        var finalizer = _harness.NewThread();
+        var instance = _harness.NewObject();
+        var field = _harness.NewStaticField("Shared");
+
+        // Act
+        _harness.Write(owner, field, instance: null);
+        _harness.QueueForFinalization(instance);
+
+        // Assert
+        Assert.True(_harness.WriteIsRace(finalizer, field, instance: null));
+    }
+
+    [Fact]
+    public void CollectedObject_DropsItsFinalizationExemption()
+    {
+        // Arrange
+        var owner = _harness.NewThread();
+        var finalizer = _harness.NewThread();
+        var instance = DetectorHarness.ObjectWithId(700);
+        var field = _harness.NewInstanceField("Handle");
+
+        // Act
+        _harness.QueueForFinalization(instance);
+        _harness.CollectObjects(instance);
+        _harness.Write(owner, field, DetectorHarness.ObjectWithId(700));
+
+        // Assert
+        Assert.True(_harness.WriteIsRace(finalizer, field, DetectorHarness.ObjectWithId(700)));
+    }
+}


### PR DESCRIPTION
This PR fixes a problem with analysis of memory accesses during finalization.

* Finalization always runs once all managed references are gone
* There is no happens-before edge between last object accessor and finalizer

With this change all objects that are already being finalized are exempt from data race analysis.